### PR TITLE
Add pickup_time, review_time, and prs_per_week to printer output

### DIFF
--- a/git_dev_metrics/metrics/printer.py
+++ b/git_dev_metrics/metrics/printer.py
@@ -6,31 +6,53 @@ def print_metrics(metrics, org, repo, period):
     console = Console()
 
     overall_table = Table(title=f"Repo Metrics (last {period})")
-    for col in ["Repo", "Cycle Time (h)", "PR Size", "Throughput"]:
+    for col in [
+        "Repo",
+        "Cycle Time (h)",
+        "PR Size",
+        "Throughput",
+        "Pickup Time (h)",
+        "Review Time (h)",
+        "PRs/Week",
+    ]:
         overall_table.add_column(col)
 
     overall_table.add_row(
         f"{org}/{repo}",
         f"{metrics['cycle_time']:.2f}",
         f"{metrics['pr_size']:.1f}",
-        f"{metrics['throughput']:.2f}",
+        f"{metrics['pr_count']:.2f}",
+        f"{metrics['pickup_time']:.2f}",
+        f"{metrics['review_time']:.2f}",
+        f"{metrics['prs_per_week']:.2f}",
     )
 
     console.print("\n")
     console.print(overall_table)
 
     dev_table = Table(title="Developer Metrics")
-    for col in ["Dev", "Cycle Time (h)", "PR Size", "Throughput"]:
+    for col in [
+        "Dev",
+        "Cycle Time (h)",
+        "PR Size",
+        "Throughput",
+        "Pickup Time (h)",
+        "Review Time (h)",
+        "PRs/Week",
+    ]:
         dev_table.add_column(col)
 
     for dev, m in sorted(
-        metrics["dev_metrics"].items(), key=lambda x: x[1]["throughput"], reverse=True
+        metrics["dev_metrics"].items(), key=lambda x: x[1]["pr_count"], reverse=True
     ):
         dev_table.add_row(
             dev,
             f"{m['cycle_time']:.2f}",
             f"{m['pr_size']:.1f}",
-            f"{m['throughput']:.2f}",
+            f"{m['pr_count']:.2f}",
+            f"{m['pickup_time']:.2f}",
+            f"{m['review_time']:.2f}",
+            f"{m['prs_per_week']:.2f}",
         )
 
     console.print(dev_table)


### PR DESCRIPTION
## Summary
- Added Pickup Time (h), Review Time (h), and PRs/Week columns to the metrics output tables
- These metrics were calculated but not displayed in the output