### PR TITLE
fix: order commits by ASC to get first commit date

### DIFF
--- a/git_dev_metrics/github/graphql_queries.py
+++ b/git_dev_metrics/github/graphql_queries.py
@@ -75,7 +75,7 @@ REPO_METRICS_QUERY = gql.gql(
                         login
                     }
                     body
-                    commits(first: 1) {
+                    commits(first: 1, orderBy: {field: COMMITTED_DATE, direction: ASC}) {
                         nodes {
                             commit {
                                 committedDate
@@ -154,7 +154,7 @@ SEARCH_MERGED_PRS_QUERY = gql.gql(
                         login
                     }
                     body
-                    commits(first: 1) {
+                    commits(first: 1, orderBy: {field: COMMITTED_DATE, direction: ASC}) {
                         nodes {
                             commit {
                                 committedDate

--- a/git_dev_metrics/github/queries.py
+++ b/git_dev_metrics/github/queries.py
@@ -10,7 +10,7 @@ from .graphql_queries import (
     SEARCH_MERGED_PRS_QUERY,
 )
 
-PAGE_SIZE = 100
+PAGE_SIZE = 50
 
 
 def _build_merged_prs_query(org: str, repo: str, since: datetime) -> str:


### PR DESCRIPTION
## Summary
- Order commits by `COMMITTED_DATE ASC` to get the earliest commit date instead of the newest (which was the default)
- Align `PAGE_SIZE` (100) with `DEFAULT_PAGE_SIZE` (50) for consistency