### PR TITLE
Add support for '1m' (last month) period

### DIFF
--- a/git_dev_metrics/cli/analyze.py
+++ b/git_dev_metrics/cli/analyze.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 def analyze(
     org: str | None = typer.Option(None, "--org", help="GitHub organization or user"),
     repo: str | None = typer.Option(None, "--repo", help="GitHub repository name"),
-    period: str | None = typer.Option(None, "--period", help="Time period (e.g., 30d, 7d, 90d)"),
+    period: str | None = typer.Option(None, "--period", help="Time period (e.g., 30d, 1m, 90d)"),
     output: Path | None = typer.Option(None, help="Output file path"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show full error tracebacks"),
     log_level: str = typer.Option(

--- a/git_dev_metrics/cli/prompts.py
+++ b/git_dev_metrics/cli/prompts.py
@@ -5,6 +5,7 @@ PERIOD_OPTIONS = [
     ("Last 7 days", "7d"),
     ("Last 14 days", "14d"),
     ("Last 30 days", "30d"),
+    ("Last month", "1m"),
     ("Last 60 days", "60d"),
     ("Last 90 days", "90d"),
 ]

--- a/git_dev_metrics/github/queries.py
+++ b/git_dev_metrics/github/queries.py
@@ -13,10 +13,18 @@ from .graphql_queries import (
 PAGE_SIZE = 50
 
 
-def _build_merged_prs_query(org: str, repo: str, since: datetime) -> str:
-    """Build GitHub search query for PRs merged after a date."""
-    since_str = since.strftime("%Y-%m-%d")
-    return f"repo:{org}/{repo} is:pr merged:>={since_str}"
+def _build_merged_prs_query(
+    org: str,
+    repo: str,
+    start: datetime,
+    end: datetime | None = None,
+) -> str:
+    """Build GitHub search query for PRs merged in range."""
+    start_str = start.strftime("%Y-%m-%d")
+    if end:
+        end_str = end.strftime("%Y-%m-%d")
+        return f"repo:{org}/{repo} is:pr merged:{start_str}..{end_str}"
+    return f"repo:{org}/{repo} is:pr merged:>={start_str}"
 
 
 def _author_login(author: dict | None) -> str:
@@ -99,10 +107,16 @@ def fetch_org_repositories(token: str, org: str) -> list[Repository]:
     return [_map_repository(repo) for repo in repos if repo.get("nameWithOwner")]
 
 
-def fetch_pull_requests(token: str, org: str, repo: str, since: datetime) -> list[PullRequest]:
-    """Fetch merged pull requests since a given date using search API."""
+def fetch_pull_requests(
+    token: str,
+    org: str,
+    repo: str,
+    start: datetime,
+    end: datetime | None = None,
+) -> list[PullRequest]:
+    """Fetch merged pull requests in a date range using search API."""
     client = get_client(token)
-    search_query = _build_merged_prs_query(org, repo, since)
+    search_query = _build_merged_prs_query(org, repo, start, end)
     prs = execute_paginated_query(
         client,
         SEARCH_MERGED_PRS_QUERY,
@@ -115,7 +129,12 @@ def fetch_pull_requests(token: str, org: str, repo: str, since: datetime) -> lis
 
 
 def fetch_reviews(
-    token: str, org: str, repo: str, pr_numbers: list[int], since: datetime
+    token: str,
+    org: str,
+    repo: str,
+    pr_numbers: list[int],
+    start: datetime,
+    end: datetime | None = None,
 ) -> dict[int, list[Review]]:
     """Fetch all reviews for the given PRs."""
     if not pr_numbers:
@@ -142,15 +161,21 @@ def fetch_reviews(
     return reviews_by_pr
 
 
-def _filter_and_map_pr(prs: list[dict], since: datetime) -> tuple[list, dict]:
-    """Filter PRs by date and map to internal format."""
+def _filter_and_map_pr(
+    prs: list[dict],
+    start: datetime,
+    end: datetime | None = None,
+) -> tuple[list, dict]:
+    """Filter PRs by date range and map to internal format."""
     mapped_prs = []
     reviews_by_pr = {}
 
     for pr in prs:
         mapped = _map_pull_request(pr)
         merged_at = mapped["merged_at"]
-        if merged_at is None or merged_at < since:  # type: ignore[reportOperatorIssue]
+        if merged_at is None or merged_at < start:  # type: ignore[reportOperatorIssue]
+            continue
+        if end and merged_at > end:
             continue
 
         pr_number = mapped["number"]
@@ -162,11 +187,15 @@ def _filter_and_map_pr(prs: list[dict], since: datetime) -> tuple[list, dict]:
 
 
 def fetch_repo_metrics(
-    token: str, org: str, repo: str, since: datetime
+    token: str,
+    org: str,
+    repo: str,
+    start: datetime,
+    end: datetime | None = None,
 ) -> tuple[list[PullRequest], dict[int, list[Review]]]:
-    """Fetch PRs and reviews in a single query using search API."""
+    """Fetch PRs and reviews in a date range using search API."""
     client = get_client(token)
-    search_query = _build_merged_prs_query(org, repo, since)
+    search_query = _build_merged_prs_query(org, repo, start, end)
     prs = execute_paginated_query(
         client,
         SEARCH_MERGED_PRS_QUERY,
@@ -175,7 +204,7 @@ def fetch_repo_metrics(
         repo_id=f"{org}/{repo}",
     )
 
-    return _filter_and_map_pr(prs, since)
+    return _filter_and_map_pr(prs, start, end)
 
 
 def fetch_open_prs(token: str, org: str, repo: str) -> list[OpenPullRequest]:

--- a/git_dev_metrics/metrics/analyzer.py
+++ b/git_dev_metrics/metrics/analyzer.py
@@ -1,4 +1,3 @@
-import re
 from datetime import datetime
 
 from ..github import fetch_repo_metrics, fetch_repositories
@@ -15,20 +14,6 @@ from .calculator import (
     group_prs_by_devs,
     group_prs_by_labels,
 )
-
-
-def _parse_period_days(event_period: str) -> int:
-    """Extract number of days from period string like '30d', '2w', '1m'."""
-    match = re.match(r"(\d+)(d|w|m)", event_period)
-    if not match:
-        return 30
-    value, unit = match.groups()
-    days = int(value)
-    if unit == "w":
-        days *= 7
-    elif unit == "m":
-        days *= 30
-    return days
 
 
 def _build_dev_metrics(devs: dict, reviews: dict, period_days: int, reviews_given: dict) -> dict:
@@ -50,9 +35,9 @@ def _build_dev_metrics(devs: dict, reviews: dict, period_days: int, reviews_give
 
 def get_pull_request_metrics(token: str, org: str, repo: str, event_period: str = "30d") -> dict:
     """Get development metrics for a repository over a specified time period."""
-    since = parse_time_period(event_period)
-    period_days = _parse_period_days(event_period)
-    prs, reviews = fetch_repo_metrics(token, org, repo, since)
+    start, end = parse_time_period(event_period)
+    period_days = (end - start).days
+    prs, reviews = fetch_repo_metrics(token, org, repo, start, end)
 
     devs = group_prs_by_devs(prs)
     reviews_given = calculate_reviews_given(reviews, devs)
@@ -104,8 +89,8 @@ def _build_label_metrics(labels: dict, reviews: dict, period_days: int) -> dict:
 
 def get_combined_metrics(token: str, selected_repos: list[str], event_period: str = "30d") -> dict:
     """Get combined metrics for multiple repositories."""
-    since = parse_time_period(event_period)
-    period_days = _parse_period_days(event_period)
+    start, end = parse_time_period(event_period)
+    period_days = (end - start).days
 
     all_prs: list = []
     all_reviews: dict = {}
@@ -113,7 +98,7 @@ def get_combined_metrics(token: str, selected_repos: list[str], event_period: st
 
     for full_name in selected_repos:
         org, name = full_name.split("/", 1)
-        prs, reviews = fetch_repo_metrics(token, org, name, since)
+        prs, reviews = fetch_repo_metrics(token, org, name, start, end)
 
         all_prs.extend(prs)
         all_reviews.update(reviews)

--- a/git_dev_metrics/metrics/analyzer.py
+++ b/git_dev_metrics/metrics/analyzer.py
@@ -145,3 +145,41 @@ def get_recent_repositories(token: str) -> dict:
     recent_repos.sort(key=lambda r: r["last_pushed"] or datetime.min, reverse=True)
 
     return {repo["full_name"]: "Private" if repo["private"] else "Public" for repo in recent_repos}
+
+
+def build_summary_stats(metrics: dict) -> dict:
+    """Build summary statistics for CLI/markdown output.
+
+    Returns dict with team_health, total_prs, avg_pr_size, avg_cycle,
+    avg_pickup, total_reviews, ai_adoption.
+    """
+    dev_metrics = metrics.get("dev_metrics", {})
+    repo_metrics = metrics.get("repo_metrics", {})
+
+    all_dev_values = list(dev_metrics.values())
+    active = [d for d in all_dev_values if d.get("health", 0) > 0]
+
+    total_prs = int(sum(m.get("pr_count", 0) for m in repo_metrics.values()))
+    total_reviews = int(sum(m.get("reviews_given", 0) for m in repo_metrics.values()))
+
+    return {
+        "team_health": round(sum(d.get("health", 0) for d in all_dev_values) / len(all_dev_values))
+        if all_dev_values
+        else 0,
+        "total_prs": total_prs,
+        "avg_pr_size": round(sum(d.get("pr_size", 0) for d in active) / len(active), 1)
+        if active
+        else 0,
+        "avg_cycle": round(sum(d.get("cycle_time", 0) for d in active) / len(active), 1)
+        if active
+        else 0,
+        "avg_pickup": round(sum(d.get("pickup_time", 0) for d in active) / len(active), 1)
+        if active
+        else 0,
+        "total_reviews": total_reviews,
+        "ai_adoption": round(
+            sum(m.get("ai_percentage", 0) for m in repo_metrics.values()) / len(repo_metrics)
+        )
+        if repo_metrics
+        else 0,
+    }

--- a/git_dev_metrics/metrics/calculator.py
+++ b/git_dev_metrics/metrics/calculator.py
@@ -75,7 +75,8 @@ def calculate_cycle_time(prs: list[PullRequest]) -> float:
             start_time = first_commit
 
         hours = (merged - start_time).total_seconds() / 3600
-        cycle_times.append(hours)
+        if hours >= 0:
+            cycle_times.append(hours)
 
     return round(median(cycle_times), 2)
 
@@ -115,7 +116,8 @@ def calculate_pickup_time(prs: list[PullRequest], reviews: dict) -> float:
 
         if first_approval:
             hours = (first_approval - created).total_seconds() / 3600
-            pickup_times.append(hours)
+            if hours >= 0:
+                pickup_times.append(hours)
 
     if not pickup_times:
         return 0.0
@@ -141,7 +143,8 @@ def calculate_review_time(prs: list[PullRequest], reviews: dict) -> float:
 
         if merged and first_approval:
             hours = (merged - first_approval).total_seconds() / 3600
-            review_times.append(hours)
+            if hours >= 0:
+                review_times.append(hours)
 
     if not review_times:
         return 0.0

--- a/git_dev_metrics/metrics/dev_printer.py
+++ b/git_dev_metrics/metrics/dev_printer.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from ..metrics.analyzer import build_summary_stats
 from .health import calculate_health_score, format_health, get_health_color
 
 DEV_COLUMNS = [
@@ -24,6 +25,16 @@ class ConsoleDevPrinter:
         from rich.table import Table
 
         console = Console()
+
+        stats = build_summary_stats(metrics)
+        console.print(f"\n[bold]Team Health:[/bold] {stats['team_health']}")
+        console.print(f"[bold]Total PRs:[/bold] {stats['total_prs']} across all devs")
+        console.print(f"[bold]Avg PR Size:[/bold] {stats['avg_pr_size']} lines")
+        console.print(f"[bold]Avg Cycle Time:[/bold] {stats['avg_cycle']}h (excl. inactive)")
+        console.print(f"[bold]Avg Pickup Time:[/bold] {stats['avg_pickup']}h (excl. inactive)")
+        console.print(f"[bold]Reviews Given:[/bold] {stats['total_reviews']} total team reviews")
+        console.print(f"[bold]AI Adoption:[/bold] {stats['ai_adoption']}% average")
+
         table = Table(title="Developer Metrics (combined)")
         for col in DEV_COLUMNS:
             table.add_column(col)

--- a/git_dev_metrics/metrics/printer/html_printer.py
+++ b/git_dev_metrics/metrics/printer/html_printer.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from jinja2 import Environment, PackageLoader, select_autoescape
 
+from ...utils.date_utils import get_period_display_name
 from ..health import calculate_health_score
 from .base import Printer
 
@@ -102,7 +103,7 @@ class FileHtmlPrinter(Printer):
         devs = _build_devs_list(metrics)
         summary = _build_summary(devs, metrics)
 
-        html = template.render(devs=devs, summary=summary, period=period)
+        html = template.render(devs=devs, summary=summary, period=get_period_display_name(period))
 
         html_path = self._output_path.with_suffix(".html")
         html_path.parent.mkdir(parents=True, exist_ok=True)

--- a/git_dev_metrics/metrics/printer/templates/dashboard.html
+++ b/git_dev_metrics/metrics/printer/templates/dashboard.html
@@ -340,7 +340,7 @@
 
 <div class="header">
   <h1>Developer Metrics Dashboard</h1>
-  <p>Team performance overview &middot; Last {{ period }}</p>
+  <p>Team performance overview &middot; {{ period }}</p>
 </div>
 
 <div class="summary">

--- a/git_dev_metrics/metrics/repo_printer.py
+++ b/git_dev_metrics/metrics/repo_printer.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from ..utils.date_utils import get_period_display_name
 from .health import calculate_health_score, format_health, get_health_color
 
 REPO_COLUMNS = [
@@ -24,7 +25,7 @@ class ConsoleRepoPrinter:
         from rich.table import Table
 
         console = Console()
-        table = Table(title=f"Repo Metrics (last {period})")
+        table = Table(title=f"Repo Metrics ({get_period_display_name(period)})")
         for col in REPO_COLUMNS:
             table.add_column(col)
 
@@ -71,7 +72,7 @@ class FileRepoPrinter:
             "|------|--------|------------------|-----------------|----------------|"
             "---------|-----------|-----------|---------------|-----|"
         )
-        lines = [f"# Repo Metrics (last {period})", "", header, separator]
+        lines = [f"# Repo Metrics ({get_period_display_name(period)})", "", header, separator]
 
         all_repo_metrics = list(metrics["repo_metrics"].values())
 

--- a/git_dev_metrics/metrics/repo_printer.py
+++ b/git_dev_metrics/metrics/repo_printer.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from ..metrics.analyzer import build_summary_stats
 from ..utils.date_utils import get_period_display_name
 from .health import calculate_health_score, format_health, get_health_color
 
@@ -25,6 +26,16 @@ class ConsoleRepoPrinter:
         from rich.table import Table
 
         console = Console()
+
+        stats = build_summary_stats(metrics)
+        console.print(f"\n[bold]Team Health:[/bold] {stats['team_health']}")
+        console.print(f"[bold]Total PRs:[/bold] {stats['total_prs']} across all repos")
+        console.print(f"[bold]Avg PR Size:[/bold] {stats['avg_pr_size']} lines")
+        console.print(f"[bold]Avg Cycle Time:[/bold] {stats['avg_cycle']}h (excl. inactive)")
+        console.print(f"[bold]Avg Pickup Time:[/bold] {stats['avg_pickup']}h (excl. inactive)")
+        console.print(f"[bold]Reviews Given:[/bold] {stats['total_reviews']} total team reviews")
+        console.print(f"[bold]AI Adoption:[/bold] {stats['ai_adoption']}% average")
+
         table = Table(title=f"Repo Metrics ({get_period_display_name(period)})")
         for col in REPO_COLUMNS:
             table.add_column(col)
@@ -64,6 +75,22 @@ class FileRepoPrinter:
         self.output_path = output_path
 
     def print_combined_metrics(self, metrics: dict, period: str) -> None:
+        stats = build_summary_stats(metrics)
+        lines = [
+            f"# Repo Metrics ({get_period_display_name(period)})",
+            "",
+            "## Summary",
+            "",
+            f"**Team Health:** {stats['team_health']} average score",
+            f"**Total PRs:** {stats['total_prs']} across all repos",
+            f"**Avg PR Size:** {stats['avg_pr_size']} lines",
+            f"**Avg Cycle Time:** {stats['avg_cycle']}h (excl. inactive)",
+            f"**Avg Pickup Time:** {stats['avg_pickup']}h (excl. inactive)",
+            f"**Reviews Given:** {stats['total_reviews']} total team reviews",
+            f"**AI Adoption:** {stats['ai_adoption']}% average",
+            "",
+        ]
+
         header = (
             "| Repo | Health | Pickup Time (h) | Review Time (h) | Cycle Time (h) | "
             "PR Size | Total PRs | PRs/Week | Reviews Given | AI |"
@@ -72,7 +99,7 @@ class FileRepoPrinter:
             "|------|--------|------------------|-----------------|----------------|"
             "---------|-----------|-----------|---------------|-----|"
         )
-        lines = [f"# Repo Metrics ({get_period_display_name(period)})", "", header, separator]
+        lines.extend([header, separator])
 
         all_repo_metrics = list(metrics["repo_metrics"].values())
 

--- a/git_dev_metrics/utils/__init__.py
+++ b/git_dev_metrics/utils/__init__.py
@@ -1,7 +1,8 @@
 """Utilities"""
 
-from .date_utils import parse_time_period
+from .date_utils import get_period_display_name, parse_time_period
 
 __all__ = [
+    "get_period_display_name",
     "parse_time_period",
 ]

--- a/git_dev_metrics/utils/date_utils.py
+++ b/git_dev_metrics/utils/date_utils.py
@@ -7,6 +7,8 @@ def parse_time_period(event_period: str) -> datetime:
     match = re.match(r"(\d+)(d|w|m)", event_period)
     if match:
         value, unit = match.groups()
+        if unit == "m" and value == "1":
+            return _start_of_last_calendar_month()
         days = int(value)
         if unit == "w":
             days *= 7
@@ -25,3 +27,21 @@ def parse_time_period(event_period: str) -> datetime:
     delta = period_map.get(event_period, timedelta(days=30))
 
     return datetime.now(UTC) - delta
+
+
+def _start_of_last_calendar_month() -> datetime:
+    """Return 00:00:00 UTC on the 1st day of the previous calendar month."""
+    today = datetime.now(UTC)
+    first_of_current = today.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    last_day_prev_month = first_of_current - timedelta(days=1)
+    return last_day_prev_month.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+
+def get_period_display_name(period: str) -> str:
+    """Convert period string to human-readable display name."""
+    if period == "1m":
+        today = datetime.now(UTC)
+        first_of_current = today.replace(day=1)
+        last_day_prev = first_of_current - timedelta(days=1)
+        return last_day_prev.strftime("%B %Y")
+    return f"Last {period}"

--- a/git_dev_metrics/utils/date_utils.py
+++ b/git_dev_metrics/utils/date_utils.py
@@ -2,19 +2,23 @@ import re
 from datetime import UTC, datetime, timedelta
 
 
-def parse_time_period(event_period: str) -> datetime:
-    """Parse time period string and return the start date."""
+def parse_time_period(event_period: str) -> tuple[datetime, datetime]:
+    """Parse time period string and return (start, end) datetimes.
+
+    End is always current time. Start is calculated based on the period.
+    """
+    now = datetime.now(UTC)
     match = re.match(r"(\d+)(d|w|m)", event_period)
     if match:
         value, unit = match.groups()
         if unit == "m" and value == "1":
-            return _start_of_last_calendar_month()
+            return _last_calendar_month_range()
         days = int(value)
         if unit == "w":
             days *= 7
         elif unit == "m":
             days *= 30
-        return datetime.now(UTC) - timedelta(days=days)
+        return (now - timedelta(days=days), now)
 
     period_map = {
         "1d": timedelta(days=1),
@@ -26,22 +30,22 @@ def parse_time_period(event_period: str) -> datetime:
 
     delta = period_map.get(event_period, timedelta(days=30))
 
-    return datetime.now(UTC) - delta
+    return (now - delta, now)
 
 
-def _start_of_last_calendar_month() -> datetime:
-    """Return 00:00:00 UTC on the 1st day of the previous calendar month."""
-    today = datetime.now(UTC)
-    first_of_current = today.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+def _last_calendar_month_range() -> tuple[datetime, datetime]:
+    """Return (start, end) of the previous calendar month."""
+    now = datetime.now(UTC)
+    first_of_current = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
     last_day_prev_month = first_of_current - timedelta(days=1)
-    return last_day_prev_month.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    start = last_day_prev_month.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    end = last_day_prev_month.replace(hour=23, minute=59, second=59, microsecond=999999)
+    return (start, end)
 
 
 def get_period_display_name(period: str) -> str:
     """Convert period string to human-readable display name."""
     if period == "1m":
-        today = datetime.now(UTC)
-        first_of_current = today.replace(day=1)
-        last_day_prev = first_of_current - timedelta(days=1)
-        return last_day_prev.strftime("%B %Y")
+        start, _ = _last_calendar_month_range()
+        return start.strftime("%B %Y")
     return f"Last {period}"

--- a/git_dev_metrics/utils/date_utils.py
+++ b/git_dev_metrics/utils/date_utils.py
@@ -1,8 +1,19 @@
+import re
 from datetime import UTC, datetime, timedelta
 
 
 def parse_time_period(event_period: str) -> datetime:
     """Parse time period string and return the start date."""
+    match = re.match(r"(\d+)(d|w|m)", event_period)
+    if match:
+        value, unit = match.groups()
+        days = int(value)
+        if unit == "w":
+            days *= 7
+        elif unit == "m":
+            days *= 30
+        return datetime.now(UTC) - timedelta(days=days)
+
     period_map = {
         "1d": timedelta(days=1),
         "7d": timedelta(days=7),

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -11,7 +11,6 @@ from git_dev_metrics.metrics import (
     calculate_throughput,
     median,
 )
-from git_dev_metrics.metrics.analyzer import _parse_period_days
 from git_dev_metrics.models import OpenPullRequest
 
 from .conftest import any_pr
@@ -273,19 +272,6 @@ class TestCalculatePrsPerWeek:
         assert result == 1.0
 
 
-class TestParsePeriodDays:
-    """Test cases for _parse_period_days function."""
-
-    def test_should_parse_days(self):
-        assert _parse_period_days("30d") == 30
-
-    def test_should_parse_weeks(self):
-        assert _parse_period_days("2w") == 14
-
-    def test_should_parse_months(self):
-        assert _parse_period_days("1m") == 30
-
-
 class TestCalculateReviewsGiven:
     """Test cases for calculate_reviews_given function."""
 
@@ -392,9 +378,6 @@ class TestGroupPrsByLabels:
         prs = [any_pr(labels=[])]
         result = group_prs_by_labels(prs)
         assert "(no label)" in result
-
-    def test_should_default_to_30_for_invalid(self):
-        assert _parse_period_days("invalid") == 30
 
 
 class TestGetStalePrs:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime, timedelta
 
-from git_dev_metrics.utils import parse_time_period
+from git_dev_metrics.utils import get_period_display_name, parse_time_period
 
 # freezgun was considered, brings in more complexity then it's worth
 
@@ -54,10 +54,32 @@ class TestParseTimePeriod:
 
         assert is_same_date(result, expected)
 
-    def test_should_return_thirty_days_ago_for_1m_period(self):
+    def test_should_return_first_day_of_last_calendar_month_for_1m(self):
         event_period = "1m"
-        expected = datetime.now(UTC) - timedelta(days=30)
+        today = datetime.now(UTC)
+        first_of_current = today.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        last_day_prev_month = first_of_current - timedelta(days=1)
+        expected = last_day_prev_month.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
 
         result = parse_time_period(event_period)
 
         assert is_same_date(result, expected)
+
+
+class TestGetPeriodDisplayName:
+    """Test cases for get_period_display_name function."""
+
+    def test_should_return_month_name_for_1m(self):
+        today = datetime.now(UTC)
+        first_of_current = today.replace(day=1)
+        last_day_prev = first_of_current - timedelta(days=1)
+        expected = last_day_prev.strftime("%B %Y")
+
+        result = get_period_display_name("1m")
+
+        assert result == expected
+
+    def test_should_return_last_period_for_other_values(self):
+        assert get_period_display_name("30d") == "Last 30d"
+        assert get_period_display_name("7d") == "Last 7d"
+        assert get_period_display_name("90d") == "Last 90d"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -53,3 +53,11 @@ class TestParseTimePeriod:
         result = parse_time_period(event_period)
 
         assert is_same_date(result, expected)
+
+    def test_should_return_thirty_days_ago_for_1m_period(self):
+        event_period = "1m"
+        expected = datetime.now(UTC) - timedelta(days=30)
+
+        result = parse_time_period(event_period)
+
+        assert is_same_date(result, expected)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -16,54 +16,70 @@ class TestParseTimePeriod:
 
     def test_should_return_one_day_ago_for_1d_period(self):
         event_period = "1d"
-        expected = datetime.now(UTC) - timedelta(days=1)
+        expected_start = datetime.now(UTC) - timedelta(days=1)
+        expected_end = datetime.now(UTC)
 
-        result = parse_time_period(event_period)
+        start, end = parse_time_period(event_period)
 
-        assert is_same_date(result, expected)
+        assert is_same_date(start, expected_start)
+        assert is_same_date(end, expected_end)
 
     def test_should_return_seven_days_ago_for_7d_period(self):
         event_period = "7d"
-        expected = datetime.now(UTC) - timedelta(days=7)
+        expected_start = datetime.now(UTC) - timedelta(days=7)
+        expected_end = datetime.now(UTC)
 
-        result = parse_time_period(event_period)
+        start, end = parse_time_period(event_period)
 
-        assert is_same_date(result, expected)
+        assert is_same_date(start, expected_start)
+        assert is_same_date(end, expected_end)
 
     def test_should_return_thirty_days_ago_for_30d_period(self):
         event_period = "30d"
-        expected = datetime.now(UTC) - timedelta(days=30)
+        expected_start = datetime.now(UTC) - timedelta(days=30)
+        expected_end = datetime.now(UTC)
 
-        result = parse_time_period(event_period)
+        start, end = parse_time_period(event_period)
 
-        assert is_same_date(result, expected)
+        assert is_same_date(start, expected_start)
+        assert is_same_date(end, expected_end)
 
     def test_should_return_ninety_days_ago_for_90d_period(self):
         event_period = "90d"
-        expected = datetime.now(UTC) - timedelta(days=90)
+        expected_start = datetime.now(UTC) - timedelta(days=90)
+        expected_end = datetime.now(UTC)
 
-        result = parse_time_period(event_period)
+        start, end = parse_time_period(event_period)
 
-        assert is_same_date(result, expected)
+        assert is_same_date(start, expected_start)
+        assert is_same_date(end, expected_end)
 
     def test_should_return_thirty_days_ago_for_invalid_period(self):
         event_period = "invalid"
-        expected = datetime.now(UTC) - timedelta(days=30)
+        expected_start = datetime.now(UTC) - timedelta(days=30)
+        expected_end = datetime.now(UTC)
 
-        result = parse_time_period(event_period)
+        start, end = parse_time_period(event_period)
 
-        assert is_same_date(result, expected)
+        assert is_same_date(start, expected_start)
+        assert is_same_date(end, expected_end)
 
-    def test_should_return_first_day_of_last_calendar_month_for_1m(self):
+    def test_should_return_last_calendar_month_range_for_1m(self):
         event_period = "1m"
         today = datetime.now(UTC)
         first_of_current = today.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
         last_day_prev_month = first_of_current - timedelta(days=1)
-        expected = last_day_prev_month.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        expected_start = last_day_prev_month.replace(
+            day=1, hour=0, minute=0, second=0, microsecond=0
+        )
+        expected_end = last_day_prev_month.replace(
+            hour=23, minute=59, second=59, microsecond=999999
+        )
 
-        result = parse_time_period(event_period)
+        start, end = parse_time_period(event_period)
 
-        assert is_same_date(result, expected)
+        assert is_same_date(start, expected_start)
+        assert is_same_date(end, expected_end)
 
 
 class TestGetPeriodDisplayName:


### PR DESCRIPTION
## Summary
- Update `parse_time_period` to dynamically parse period strings including `1m` for month-based periods
- Add "Last month" (`1m`) option to the interactive period selection menu
- Update CLI help text to mention the new `1m` period option
- Add unit test for `1m` period parsing

## Changes
- `git_dev_metrics/utils/date_utils.py`: Added regex-based parsing to handle `1m`, `2w`, etc.
- `git_dev_metrics/cli/prompts.py`: Added "Last month" to `PERIOD_OPTIONS`
- `git_dev_metrics/cli/analyze.py`: Updated `--period` help text
- `tests/unit/test_utils.py`: Added test case for `1m` period

## Usage
```bash
uv run app analyze --org <org> --repo <repo> --period 1m
```