### PR TITLE
Add summary output to console and markdown

### DIFF
--- a/git_dev_metrics/metrics/printer/html_printer.py
+++ b/git_dev_metrics/metrics/printer/html_printer.py
@@ -49,26 +49,31 @@ def _build_devs_list(metrics: dict) -> list[dict]:
     return devs
 
 
-def _build_summary(devs: list[dict], metrics: dict) -> dict:
+def build_summary(metrics: dict) -> dict:
     """Compute summary stats across all devs for the summary cards.
 
     Args:
-        devs: Output of _build_devs_list.
         metrics: Full metrics dict from get_combined_metrics.
 
     Returns:
         Dict with team_health, total_prs, avg_cycle, avg_pickup,
         total_reviews, ai_adoption.
     """
-    active = [d for d in devs if d["health"] > 0]
+    all_dev_metrics = list(metrics.get("dev_metrics", {}).values())
+    active = [d for d in all_dev_metrics if d.get("health", 0) > 0]
     repo_metrics = metrics.get("repo_metrics", {})
     total_prs = int(sum(m.get("pr_count", 0) for m in repo_metrics.values()))
     total_reviews = int(sum(m.get("reviews_given", 0) for m in repo_metrics.values()))
+    dev_health = sum(d.get("health", 0) for d in all_dev_metrics)
     return {
-        "team_health": round(sum(d["health"] for d in devs) / len(devs)) if devs else 0,
+        "team_health": round(dev_health / len(all_dev_metrics)) if all_dev_metrics else 0,
         "total_prs": total_prs,
-        "avg_cycle": round(sum(d["cycle"] for d in active) / len(active), 1) if active else 0,
-        "avg_pickup": round(sum(d["pickup"] for d in active) / len(active), 1) if active else 0,
+        "avg_cycle": round(sum(d.get("cycle_time", 0) for d in active) / len(active), 1)
+        if active
+        else 0,
+        "avg_pickup": round(sum(d.get("pickup_time", 0) for d in active) / len(active), 1)
+        if active
+        else 0,
         "total_reviews": total_reviews,
         "ai_adoption": round(
             sum(m.get("ai_percentage", 0) for m in repo_metrics.values()) / len(repo_metrics)
@@ -100,7 +105,7 @@ class FileHtmlPrinter(Printer):
         template = env.get_template("dashboard.html")
 
         devs = _build_devs_list(metrics)
-        summary = _build_summary(devs, metrics)
+        summary = build_summary(metrics)
 
         html = template.render(devs=devs, summary=summary, period=period)
 

--- a/git_dev_metrics/metrics/printer/printers.py
+++ b/git_dev_metrics/metrics/printer/printers.py
@@ -4,7 +4,7 @@ from ..dev_printer import ConsoleDevPrinter, FileDevPrinter
 from ..label_printer import ConsoleLabelPrinter, FileLabelPrinter
 from ..repo_printer import ConsoleRepoPrinter, FileRepoPrinter
 from .base import Printer
-from .html_printer import FileHtmlPrinter
+from .html_printer import FileHtmlPrinter, build_summary
 from .stale_printer import ConsoleStalePRPrinter, FileStalePRPrinter
 from .utils import get_default_output_path
 
@@ -18,6 +18,25 @@ class ConsolePrinter(Printer):
         self._label_printer = ConsoleLabelPrinter()
 
     def print_combined_metrics(self, metrics: dict, period: str) -> None:
+        from rich.console import Console
+        from rich.panel import Panel
+
+        console = Console()
+
+        summary = build_summary(metrics)
+        panel = Panel(
+            f"Team Health: {summary['team_health']}  |  "
+            f"Total PRs: {summary['total_prs']}  |  "
+            f"Avg Cycle: {summary['avg_cycle']}h  |  "
+            f"Avg Pickup: {summary['avg_pickup']}h  |  "
+            f"Reviews: {summary['total_reviews']}  |  "
+            f"AI: {summary['ai_adoption']}%",
+            title=f"Summary (last {period})",
+            expand=False,
+        )
+        console.print(panel)
+        console.print()
+
         self._repo_printer.print_combined_metrics(metrics, period)
         self._dev_printer.print_combined_metrics(metrics, period)
         if "label_metrics" in metrics and metrics["label_metrics"]:
@@ -34,10 +53,30 @@ class FilePrinter(Printer):
         self._label_printer = FileLabelPrinter(path)
 
     def print_combined_metrics(self, metrics: dict, period: str) -> None:
+        summary = build_summary(metrics)
+        lines = [
+            f"# Summary (last {period})",
+            "",
+            f"- **Team Health:** {summary['team_health']}",
+            f"- **Total PRs:** {summary['total_prs']}",
+            f"- **Avg Cycle Time:** {summary['avg_cycle']}h",
+            f"- **Avg Pickup Time:** {summary['avg_pickup']}h",
+            f"- **Total Reviews:** {summary['total_reviews']}",
+            f"- **AI Adoption:** {summary['ai_adoption']}%",
+            "",
+        ]
+        self._write(lines)
         self._repo_printer.print_combined_metrics(metrics, period)
         self._dev_printer.print_combined_metrics(metrics, period)
         if "label_metrics" in metrics and metrics["label_metrics"]:
             self._label_printer.print_combined_metrics(metrics, period)
+
+    def _write(self, lines: list[str]) -> None:
+
+        output_path = get_default_output_path()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, "a") as f:
+            f.write("\n".join(lines))
 
 
 class CompositePrinter(Printer):


### PR DESCRIPTION
## Summary
- Add summary panel output to console using Rich
- Add summary section to markdown file output  
- Refactor `build_summary()` to work without `devs` parameter

## Changes
- `git_dev_metrics/metrics/printer/html_printer.py`: Refactor `build_summary()` function
- `git_dev_metrics/metrics/printer/printers.py`: Add summary output to `ConsolePrinter` and `FilePrinter`