### PR TITLE
Add average lines per PR to summary and all outputs

### DIFF
--- a/git_dev_metrics/metrics/__init__.py
+++ b/git_dev_metrics/metrics/__init__.py
@@ -2,6 +2,7 @@
 
 from .analyzer import get_combined_metrics, get_pull_request_metrics
 from .calculator import (
+    calculate_avg_lines_per_pr,
     calculate_cycle_time,
     calculate_pickup_time,
     calculate_pr_size,
@@ -19,6 +20,7 @@ from .repo_printer import ConsoleRepoPrinter, FileRepoPrinter
 __all__ = [
     "get_pull_request_metrics",
     "get_combined_metrics",
+    "calculate_avg_lines_per_pr",
     "calculate_cycle_time",
     "calculate_pr_size",
     "calculate_pickup_time",

--- a/git_dev_metrics/metrics/analyzer.py
+++ b/git_dev_metrics/metrics/analyzer.py
@@ -4,6 +4,7 @@ from ..github import fetch_repo_metrics
 from ..utils import parse_time_period
 from .calculator import (
     calculate_ai_percentage,
+    calculate_avg_lines_per_pr,
     calculate_cycle_time,
     calculate_pickup_time,
     calculate_pr_size,
@@ -36,6 +37,7 @@ def _build_dev_metrics(devs: dict, reviews: dict, period_days: int, reviews_give
         dev: {
             "cycle_time": calculate_cycle_time(dev_prs),
             "pr_size": calculate_pr_size(dev_prs),
+            "avg_lines_per_pr": calculate_avg_lines_per_pr(dev_prs),
             "pr_count": calculate_throughput(dev_prs),
             "pickup_time": calculate_pickup_time(dev_prs, reviews),
             "review_time": calculate_review_time(dev_prs, reviews),
@@ -60,6 +62,7 @@ def get_pull_request_metrics(token: str, org: str, repo: str, event_period: str 
     return {
         "cycle_time": calculate_cycle_time(prs),
         "pr_size": calculate_pr_size(prs),
+        "avg_lines_per_pr": calculate_avg_lines_per_pr(prs),
         "pr_count": calculate_throughput(prs),
         "pickup_time": calculate_pickup_time(prs, reviews),
         "review_time": calculate_review_time(prs, reviews),
@@ -77,6 +80,7 @@ def _build_metrics(prs: list, reviews: dict, period_days: int) -> dict:
     return {
         "cycle_time": calculate_cycle_time(prs),
         "pr_size": calculate_pr_size(prs),
+        "avg_lines_per_pr": calculate_avg_lines_per_pr(prs),
         "pr_count": calculate_throughput(prs),
         "pickup_time": calculate_pickup_time(prs, reviews),
         "review_time": calculate_review_time(prs, reviews),

--- a/git_dev_metrics/metrics/calculator.py
+++ b/git_dev_metrics/metrics/calculator.py
@@ -89,6 +89,14 @@ def calculate_pr_size(prs: list[PullRequest]) -> int:
     return round(median(pr_sizes))
 
 
+def calculate_avg_lines_per_pr(prs: list[PullRequest]) -> float:
+    """Calculate average lines changed per PR."""
+    if not prs:
+        return 0.0
+    total = sum(abs(pr.get("additions", 0)) + abs(pr.get("deletions", 0)) for pr in prs)
+    return round(total / len(prs), 1)
+
+
 def calculate_throughput(prs: list[PullRequest]) -> int:
     """Calculate number of merged PRs."""
     return len(prs)

--- a/git_dev_metrics/metrics/dev_printer.py
+++ b/git_dev_metrics/metrics/dev_printer.py
@@ -9,6 +9,7 @@ DEV_COLUMNS = [
     "Review Time (h)",
     "Cycle Time (h)",
     "PR Size",
+    "Avg Lines/PR",
     "Total PRs",
     "PRs/Week",
     "Reviews Given",
@@ -46,6 +47,7 @@ class ConsoleDevPrinter:
                 f"{m['review_time']:.2f}",
                 f"{m['cycle_time']:.2f}",
                 f"{m['pr_size']:.1f}",
+                f"{m.get('avg_lines_per_pr', 0):.1f}",
                 f"{m['pr_count']:.0f}",
                 f"{m['prs_per_week']:.2f}",
                 f"{m['reviews_given']:.0f}",
@@ -64,11 +66,11 @@ class FileDevPrinter:
     def print_combined_metrics(self, metrics: dict, period: str) -> None:
         header = (
             "| Dev | Health | Pickup Time (h) | Review Time (h) | Cycle Time (h) | "
-            "PR Size | Total PRs | PRs/Week | Reviews Given | AI |"
+            "PR Size | Avg Lines/PR | Total PRs | PRs/Week | Reviews Given | AI |"
         )
         separator = (
             "|------|--------|------------------|-----------------|----------------|"
-            "---------|-----------|-----------|---------------|-----|"
+            "---------|--------------|-----------|-----------|---------------|-----|"
         )
         lines = ["", "# Developer Metrics (combined)", "", header, separator]
 
@@ -91,6 +93,7 @@ class FileDevPrinter:
             row = (
                 f"| {dev} | {emoji}{health} | {m['pickup_time']:.2f} | "
                 f"{m['review_time']:.2f} | {m['cycle_time']:.2f} | {m['pr_size']:.1f} | "
+                f"{m.get('avg_lines_per_pr', 0):.1f} | "
                 f"{m['pr_count']:.0f} | {m['prs_per_week']:.2f} | {m['reviews_given']:.0f} | "
                 f"{m['ai_percentage']:.0f}% |"
             )

--- a/git_dev_metrics/metrics/printer/html_printer.py
+++ b/git_dev_metrics/metrics/printer/html_printer.py
@@ -57,7 +57,7 @@ def build_summary(metrics: dict) -> dict:
 
     Returns:
         Dict with team_health, total_prs, avg_cycle, avg_pickup,
-        total_reviews, ai_adoption.
+        total_reviews, ai_adoption, avg_lines_per_pr.
     """
     all_dev_metrics = list(metrics.get("dev_metrics", {}).values())
     active = [d for d in all_dev_metrics if d.get("health", 0) > 0]
@@ -77,6 +77,11 @@ def build_summary(metrics: dict) -> dict:
         "total_reviews": total_reviews,
         "ai_adoption": round(
             sum(m.get("ai_percentage", 0) for m in repo_metrics.values()) / len(repo_metrics)
+        )
+        if repo_metrics
+        else 0,
+        "avg_lines_per_pr": round(
+            sum(m.get("avg_lines_per_pr", 0) for m in repo_metrics.values()) / len(repo_metrics), 1
         )
         if repo_metrics
         else 0,

--- a/git_dev_metrics/metrics/printer/printers.py
+++ b/git_dev_metrics/metrics/printer/printers.py
@@ -27,6 +27,7 @@ class ConsolePrinter(Printer):
         panel = Panel(
             f"Team Health: {summary['team_health']}  |  "
             f"Total PRs: {summary['total_prs']}  |  "
+            f"Avg Lines/PR: {summary['avg_lines_per_pr']}  |  "
             f"Avg Cycle: {summary['avg_cycle']}h  |  "
             f"Avg Pickup: {summary['avg_pickup']}h  |  "
             f"Reviews: {summary['total_reviews']}  |  "
@@ -59,6 +60,7 @@ class FilePrinter(Printer):
             "",
             f"- **Team Health:** {summary['team_health']}",
             f"- **Total PRs:** {summary['total_prs']}",
+            f"- **Avg Lines/PR:** {summary['avg_lines_per_pr']}",
             f"- **Avg Cycle Time:** {summary['avg_cycle']}h",
             f"- **Avg Pickup Time:** {summary['avg_pickup']}h",
             f"- **Total Reviews:** {summary['total_reviews']}",

--- a/git_dev_metrics/metrics/printer/templates/dashboard.html
+++ b/git_dev_metrics/metrics/printer/templates/dashboard.html
@@ -355,6 +355,11 @@
     <div class="sub">Across all devs</div>
   </div>
   <div class="summary-card">
+    <div class="label">Avg Lines/PR</div>
+    <div class="value">{{ summary.avg_lines_per_pr }}</div>
+    <div class="sub">Average per PR</div>
+  </div>
+  <div class="summary-card">
     <div class="label">Avg Cycle Time</div>
     <div class="value">{{ summary.avg_cycle }}h</div>
     <div class="sub">Excl. inactive</div>

--- a/git_dev_metrics/metrics/repo_printer.py
+++ b/git_dev_metrics/metrics/repo_printer.py
@@ -9,6 +9,7 @@ REPO_COLUMNS = [
     "Review Time (h)",
     "Cycle Time (h)",
     "PR Size",
+    "Avg Lines/PR",
     "Total PRs",
     "PRs/Week",
     "Reviews Given",
@@ -46,6 +47,7 @@ class ConsoleRepoPrinter:
                 f"{m['review_time']:.2f}",
                 f"{m['cycle_time']:.2f}",
                 f"{m['pr_size']:.1f}",
+                f"{m.get('avg_lines_per_pr', 0):.1f}",
                 f"{m['pr_count']:.0f}",
                 f"{m['prs_per_week']:.2f}",
                 f"{m['reviews_given']:.0f}",
@@ -65,11 +67,11 @@ class FileRepoPrinter:
     def print_combined_metrics(self, metrics: dict, period: str) -> None:
         header = (
             "| Repo | Health | Pickup Time (h) | Review Time (h) | Cycle Time (h) | "
-            "PR Size | Total PRs | PRs/Week | Reviews Given | AI |"
+            "PR Size | Avg Lines/PR | Total PRs | PRs/Week | Reviews Given | AI |"
         )
         separator = (
             "|------|--------|------------------|-----------------|----------------|"
-            "---------|-----------|-----------|---------------|-----|"
+            "---------|--------------|-----------|-----------|---------------|-----|"
         )
         lines = [f"# Repo Metrics (last {period})", "", header, separator]
 
@@ -92,6 +94,7 @@ class FileRepoPrinter:
             row = (
                 f"| {repo_name} | {emoji}{health} | {m['pickup_time']:.2f} | "
                 f"{m['review_time']:.2f} | {m['cycle_time']:.2f} | {m['pr_size']:.1f} | "
+                f"{m.get('avg_lines_per_pr', 0):.1f} | "
                 f"{m['pr_count']:.0f} | {m['prs_per_week']:.2f} | {m['reviews_given']:.0f} | "
                 f"{m['ai_percentage']:.0f}% |"
             )

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -3,6 +3,7 @@
 from typing import cast
 
 from git_dev_metrics.metrics import (
+    calculate_avg_lines_per_pr,
     calculate_cycle_time,
     calculate_pickup_time,
     calculate_pr_size,
@@ -149,6 +150,34 @@ class TestCalculatePrSize:
         prs = [any_pr(additions=100, deletions=-50)]
         result = calculate_pr_size(prs)
         assert result == 150
+
+
+class TestCalculateAvgLinesPerPr:
+    """Test cases for calculate_avg_lines_per_pr function."""
+
+    def test_should_return_zero_when_no_prs_provided(self):
+        prs = []
+        result = calculate_avg_lines_per_pr(prs)
+        assert result == 0.0
+
+    def test_should_return_correct_avg_for_single_pr(self):
+        prs = [any_pr(additions=100, deletions=50)]
+        result = calculate_avg_lines_per_pr(prs)
+        assert result == 150.0
+
+    def test_should_return_mean_not_median(self):
+        prs = [
+            any_pr(additions=100, deletions=0),
+            any_pr(additions=200, deletions=0),
+            any_pr(additions=300, deletions=0),
+        ]
+        result = calculate_avg_lines_per_pr(prs)
+        assert result == 200.0
+
+    def test_should_use_absolute_values_for_deletions(self):
+        prs = [any_pr(additions=100, deletions=-50)]
+        result = calculate_avg_lines_per_pr(prs)
+        assert result == 150.0
 
 
 class TestCalculateThroughput:


### PR DESCRIPTION
## Summary
- Add `avg_lines_per_pr` metric (mean average lines changed per PR) to all summary outputs
- Display "Avg Lines/PR" column in console tables, markdown files, and HTML dashboard
- Add `calculate_avg_lines_per_pr()` function to calculator module
- Add tests for the new calculation function

## Changes
- `calculator.py`: New `calculate_avg_lines_per_pr()` function
- `analyzer.py`: Include `avg_lines_per_pr` in all metrics builders
- `html_printer.py`: Add to `build_summary()` for summary cards
- `printers.py`: Add to console panel and markdown output
- `dev_printer.py` / `repo_printer.py`: Add column to detailed tables
- `dashboard.html`: New summary card in HTML dashboard
- `test_metrics.py`: Add `TestCalculateAvgLinesPerPr` test class