### PR TITLE
Fix crash when invalid period default is loaded from cache

### DIFF
--- a/git_dev_metrics/cli/prompts.py
+++ b/git_dev_metrics/cli/prompts.py
@@ -13,6 +13,9 @@ PERIOD_OPTIONS = [
 
 def prompt_period_selection(default: str | None = None) -> str:
     """Prompt user to select the time period."""
+    valid_values = {value for _, value in PERIOD_OPTIONS}
+    default = default if default in valid_values else "30d"
+
     choices = [questionary.Choice(title=title, value=value) for title, value in PERIOD_OPTIONS]
 
     custom_style = Style(
@@ -25,11 +28,11 @@ def prompt_period_selection(default: str | None = None) -> str:
     selected = questionary.select(
         "Select time period:",
         choices=choices,
-        default=default or "30d",
+        default=default,
         style=custom_style,
     ).ask()
 
-    return selected or default or "30d"
+    return selected or default
 
 
 def prompt_org_name(default: str | None = None) -> str | None:

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -53,3 +53,13 @@ class TestPromptPeriodSelection:
         choice_values = {c.value for c in call_kwargs["choices"]}
         expected_values = {value for _, value in PERIOD_OPTIONS}
         assert choice_values == expected_values
+
+    def test_should_accept_last_month_as_valid_default(self, mocker):
+        mock_select = mocker.patch("git_dev_metrics.cli.prompts.questionary.select")
+        mock_select.return_value.ask.return_value = "last_month"
+
+        result = prompt_period_selection(default="last_month")
+
+        call_kwargs = mock_select.call_args[1]
+        assert call_kwargs["default"] == "last_month"
+        assert result == "last_month"

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -1,0 +1,55 @@
+"""Unit tests for prompts.py functions."""
+
+from git_dev_metrics.cli.prompts import PERIOD_OPTIONS, prompt_period_selection
+
+
+class TestPromptPeriodSelection:
+    def test_should_return_valid_default_when_none(self, mocker):
+        mock_select = mocker.patch("git_dev_metrics.cli.prompts.questionary.select")
+        mock_select.return_value.ask.return_value = None
+
+        result = prompt_period_selection(default=None)
+
+        mock_select.assert_called_once()
+        assert result == "30d"
+
+    def test_should_use_valid_default(self, mocker):
+        mock_select = mocker.patch("git_dev_metrics.cli.prompts.questionary.select")
+        mock_select.return_value.ask.return_value = "60d"
+
+        result = prompt_period_selection(default="60d")
+
+        call_kwargs = mock_select.call_args[1]
+        assert call_kwargs["default"] == "60d"
+        assert result == "60d"
+
+    def test_should_fallback_to_30d_for_invalid_default(self, mocker):
+        mock_select = mocker.patch("git_dev_metrics.cli.prompts.questionary.select")
+        mock_select.return_value.ask.return_value = None
+
+        result = prompt_period_selection(default="1m")
+
+        call_kwargs = mock_select.call_args[1]
+        assert call_kwargs["default"] == "30d"
+        assert result == "30d"
+
+    def test_should_fallback_to_30d_for_unknown_value(self, mocker):
+        mock_select = mocker.patch("git_dev_metrics.cli.prompts.questionary.select")
+        mock_select.return_value.ask.return_value = None
+
+        result = prompt_period_selection(default="invalid")
+
+        call_kwargs = mock_select.call_args[1]
+        assert call_kwargs["default"] == "30d"
+        assert result == "30d"
+
+    def test_should_include_all_period_options_in_choices(self, mocker):
+        mock_select = mocker.patch("git_dev_metrics.cli.prompts.questionary.select")
+        mock_select.return_value.ask.return_value = "30d"
+
+        prompt_period_selection(default="30d")
+
+        call_kwargs = mock_select.call_args[1]
+        choice_values = {c.value for c in call_kwargs["choices"]}
+        expected_values = {value for _, value in PERIOD_OPTIONS}
+        assert choice_values == expected_values


### PR DESCRIPTION
## Summary
- Fix `ValueError` crash when `prompt_period_selection` receives an invalid default value (e.g., `1m`) from keyring cache
- Validate default against `PERIOD_OPTIONS` before passing to questionary, falling back to `30d`
- Add test coverage for `prompt_period_selection` to prevent regression

## Details
The bug occurred because `_parse_period_days` supports `1m` format, but `PERIOD_OPTIONS` in prompts doesn't include it. When a user previously selected a period that got saved as `1m`, the app would crash on next run.

## Test Plan
- Added `tests/unit/test_prompts.py` with 5 test cases covering valid defaults, invalid defaults, and `None` defaults
- All existing tests pass
- Format and typecheck pass

## Labels
`bug`