### PR TITLE
Show date range in all outputs (CLI, markdown, HTML)

### DIFF
--- a/git_dev_metrics/cli/output.py
+++ b/git_dev_metrics/cli/output.py
@@ -16,11 +16,11 @@ def resolve_output_path(output: Path | None) -> Path:
     return output if output else get_default_output_path()
 
 
-def print_metrics(metrics: dict, period: str, output_path: Path) -> None:
+def print_metrics(metrics: dict, period: str, output_path: Path, date_range: str) -> None:
     """Print metrics to the specified output path."""
     import typer
 
-    _print_combined_metrics(metrics, period, output_path)
+    _print_combined_metrics(metrics, period, output_path, date_range)
     typer.secho(f"Results saved to {output_path}", fg=typer.colors.GREEN)
 
 

--- a/git_dev_metrics/cli/runner.py
+++ b/git_dev_metrics/cli/runner.py
@@ -22,6 +22,8 @@ from .prompts import (
 
 logger = logging.getLogger(__name__)
 
+_DATE_FMT = "%Y-%m-%d"
+
 
 class AnalysisError(Exception):
     """Failed during analysis (auth, fetch, etc)."""
@@ -116,7 +118,11 @@ def run_analyze(
         raise AnalysisError(str(e)) from e
 
     output_path = resolve_output_path(output)
-    print_metrics(metrics, period, output_path)
+    time_period = parse_time_period(period)
+    since = time_period.since.strftime(_DATE_FMT)
+    until = time_period.until.strftime(_DATE_FMT)
+    date_range = f"{since} to {until}"
+    print_metrics(metrics, period, output_path, date_range)
 
     stale_prs = _fetch_stale_prs(token, selected)
     if stale_prs:

--- a/git_dev_metrics/metrics/dev_printer.py
+++ b/git_dev_metrics/metrics/dev_printer.py
@@ -20,12 +20,17 @@ DEV_COLUMNS = [
 class ConsoleDevPrinter:
     """Print dev metrics to console using Rich."""
 
-    def print_combined_metrics(self, metrics: dict, period: str) -> None:
+    def print_combined_metrics(
+        self, metrics: dict, period: str, date_range: str | None = None
+    ) -> None:
         from rich.console import Console
         from rich.table import Table
 
         console = Console()
-        table = Table(title="Developer Metrics (combined)")
+        title = (
+            f"Developer Metrics ({date_range})" if date_range else ("Developer Metrics (combined)")
+        )
+        table = Table(title=title)
         for col in DEV_COLUMNS:
             table.add_column(col)
 
@@ -63,7 +68,9 @@ class FileDevPrinter:
     def __init__(self, output_path: Path):
         self.output_path = output_path
 
-    def print_combined_metrics(self, metrics: dict, period: str) -> None:
+    def print_combined_metrics(
+        self, metrics: dict, period: str, date_range: str | None = None
+    ) -> None:
         header = (
             "| Dev | Health | Pickup Time (h) | Review Time (h) | Cycle Time (h) | "
             "PR Size | Avg Lines/PR | Total PRs | PRs/Week | Reviews Given | AI |"
@@ -72,7 +79,12 @@ class FileDevPrinter:
             "|------|--------|------------------|-----------------|----------------|"
             "---------|--------------|-----------|-----------|---------------|-----|"
         )
-        lines = ["", "# Developer Metrics (combined)", "", header, separator]
+        title = (
+            f"# Developer Metrics ({date_range})"
+            if date_range
+            else ("# Developer Metrics (combined)")
+        )
+        lines = ["", title, "", header, separator]
 
         all_dev_metrics = list(metrics["dev_metrics"].values())
 

--- a/git_dev_metrics/metrics/label_printer.py
+++ b/git_dev_metrics/metrics/label_printer.py
@@ -28,12 +28,15 @@ def _sort_by_health(metrics: dict) -> list[tuple]:
 class ConsoleLabelPrinter:
     """Print label metrics to console using Rich."""
 
-    def print_combined_metrics(self, metrics: dict, period: str) -> None:
+    def print_combined_metrics(
+        self, metrics: dict, period: str, date_range: str | None = None
+    ) -> None:
         from rich.console import Console
         from rich.table import Table
 
         console = Console()
-        table = Table(title="Label Metrics (combined)")
+        title = f"Label Metrics ({date_range})" if date_range else "Label Metrics (combined)"
+        table = Table(title=title)
         for col in LABEL_COLUMNS:
             table.add_column(col)
 
@@ -59,7 +62,9 @@ class FileLabelPrinter:
     def __init__(self, output_path: Path):
         self.output_path = output_path
 
-    def print_combined_metrics(self, metrics: dict, period: str) -> None:
+    def print_combined_metrics(
+        self, metrics: dict, period: str, date_range: str | None = None
+    ) -> None:
         header = (
             "| Label | Health | Pickup Time (h) | Review Time (h) | Cycle Time (h) | "
             "PR Size | Total PRs | PRs/Week |"
@@ -68,7 +73,8 @@ class FileLabelPrinter:
             "|------|--------|------------------|-----------------|----------------|"
             "---------|-----------|-----------|"
         )
-        lines = ["", "# Label Metrics (combined)", "", header, separator]
+        title = f"# Label Metrics ({date_range})" if date_range else "# Label Metrics (combined)"
+        lines = ["", title, "", header, separator]
 
         for label, m, health in _sort_by_health(metrics["label_metrics"]):
             if health >= 80:

--- a/git_dev_metrics/metrics/printer/base.py
+++ b/git_dev_metrics/metrics/printer/base.py
@@ -5,6 +5,6 @@ class Printer(ABC):
     """Abstract base class for printing combined metrics."""
 
     @abstractmethod
-    def print_combined_metrics(self, metrics: dict, period: str) -> None:
+    def print_combined_metrics(self, metrics: dict, period: str, date_range: str) -> None:
         """Print both repo and dev metrics."""
         ...

--- a/git_dev_metrics/metrics/printer/html_printer.py
+++ b/git_dev_metrics/metrics/printer/html_printer.py
@@ -99,12 +99,13 @@ class FileHtmlPrinter(Printer):
         """
         self._output_path = output_path
 
-    def print_combined_metrics(self, metrics: dict, period: str) -> None:
+    def print_combined_metrics(self, metrics: dict, period: str, date_range: str) -> None:
         """Render and write the HTML dashboard to disk.
 
         Args:
             metrics: Combined metrics dict with dev_metrics.
             period: Time period string (e.g. "30d") for the header.
+            date_range: Date range string (e.g. "2026-01-01 to 2026-01-31").
         """
         env = _get_env()
         template = env.get_template("dashboard.html")
@@ -112,7 +113,7 @@ class FileHtmlPrinter(Printer):
         devs = _build_devs_list(metrics)
         summary = build_summary(metrics)
 
-        html = template.render(devs=devs, summary=summary, period=period)
+        html = template.render(devs=devs, summary=summary, period=period, date_range=date_range)
 
         html_path = self._output_path.with_suffix(".html")
         html_path.parent.mkdir(parents=True, exist_ok=True)

--- a/git_dev_metrics/metrics/printer/printers.py
+++ b/git_dev_metrics/metrics/printer/printers.py
@@ -17,7 +17,7 @@ class ConsolePrinter(Printer):
         self._dev_printer = ConsoleDevPrinter()
         self._label_printer = ConsoleLabelPrinter()
 
-    def print_combined_metrics(self, metrics: dict, period: str) -> None:
+    def print_combined_metrics(self, metrics: dict, period: str, date_range: str) -> None:
         from rich.console import Console
         from rich.panel import Panel
 
@@ -32,16 +32,16 @@ class ConsolePrinter(Printer):
             f"Avg Pickup: {summary['avg_pickup']}h  |  "
             f"Reviews: {summary['total_reviews']}  |  "
             f"AI: {summary['ai_adoption']}%",
-            title=f"Summary (last {period})",
+            title=f"Summary ({date_range})",
             expand=False,
         )
         console.print(panel)
         console.print()
 
-        self._repo_printer.print_combined_metrics(metrics, period)
-        self._dev_printer.print_combined_metrics(metrics, period)
+        self._repo_printer.print_combined_metrics(metrics, period, date_range)
+        self._dev_printer.print_combined_metrics(metrics, period, date_range)
         if "label_metrics" in metrics and metrics["label_metrics"]:
-            self._label_printer.print_combined_metrics(metrics, period)
+            self._label_printer.print_combined_metrics(metrics, period, date_range)
 
 
 class FilePrinter(Printer):
@@ -53,10 +53,10 @@ class FilePrinter(Printer):
         self._dev_printer = FileDevPrinter(path)
         self._label_printer = FileLabelPrinter(path)
 
-    def print_combined_metrics(self, metrics: dict, period: str) -> None:
+    def print_combined_metrics(self, metrics: dict, period: str, date_range: str) -> None:
         summary = build_summary(metrics)
         lines = [
-            f"# Summary (last {period})",
+            f"# Summary ({date_range})",
             "",
             f"- **Team Health:** {summary['team_health']}",
             f"- **Total PRs:** {summary['total_prs']}",
@@ -68,10 +68,10 @@ class FilePrinter(Printer):
             "",
         ]
         self._write(lines)
-        self._repo_printer.print_combined_metrics(metrics, period)
-        self._dev_printer.print_combined_metrics(metrics, period)
+        self._repo_printer.print_combined_metrics(metrics, period, date_range)
+        self._dev_printer.print_combined_metrics(metrics, period, date_range)
         if "label_metrics" in metrics and metrics["label_metrics"]:
-            self._label_printer.print_combined_metrics(metrics, period)
+            self._label_printer.print_combined_metrics(metrics, period, date_range)
 
     def _write(self, lines: list[str]) -> None:
 
@@ -91,19 +91,24 @@ class CompositePrinter(Printer):
         self._console_stale_printer = ConsoleStalePRPrinter()
         self._file_stale_printer = FileStalePRPrinter(output_path or get_default_output_path())
 
-    def print_combined_metrics(self, metrics: dict, period: str) -> None:
-        self._console_printer.print_combined_metrics(metrics, period)
-        self._file_printer.print_combined_metrics(metrics, period)
-        self._html_printer.print_combined_metrics(metrics, period)
+    def print_combined_metrics(self, metrics: dict, period: str, date_range: str) -> None:
+        self._console_printer.print_combined_metrics(metrics, period, date_range)
+        self._file_printer.print_combined_metrics(metrics, period, date_range)
+        self._html_printer.print_combined_metrics(metrics, period, date_range)
 
     def print_stale_prs(self, stale_prs: list[dict]) -> None:
         self._console_stale_printer.print_stale_prs(stale_prs)
         self._file_stale_printer.print_stale_prs(stale_prs)
 
 
-def print_combined_metrics(metrics: dict, period: str, output_path: Path | None = None) -> None:
+def print_combined_metrics(
+    metrics: dict,
+    period: str,
+    output_path: Path | None = None,
+    date_range: str | None = None,
+) -> None:
     """Print metrics to console and file."""
-    CompositePrinter(output_path).print_combined_metrics(metrics, period)
+    CompositePrinter(output_path).print_combined_metrics(metrics, period, date_range or period)
 
 
 def print_stale_prs(stale_prs: list[dict], output_path: Path | None = None) -> None:

--- a/git_dev_metrics/metrics/printer/templates/dashboard.html
+++ b/git_dev_metrics/metrics/printer/templates/dashboard.html
@@ -340,7 +340,7 @@
 
 <div class="header">
   <h1>Developer Metrics Dashboard</h1>
-  <p>Team performance overview &middot; Last {{ period }}</p>
+  <p>Team performance overview &middot; {{ date_range or ("Last " + period) }}</p>
 </div>
 
 <div class="summary">

--- a/git_dev_metrics/metrics/repo_printer.py
+++ b/git_dev_metrics/metrics/repo_printer.py
@@ -20,12 +20,15 @@ REPO_COLUMNS = [
 class ConsoleRepoPrinter:
     """Print repo metrics to console using Rich."""
 
-    def print_combined_metrics(self, metrics: dict, period: str) -> None:
+    def print_combined_metrics(
+        self, metrics: dict, period: str, date_range: str | None = None
+    ) -> None:
         from rich.console import Console
         from rich.table import Table
 
         console = Console()
-        table = Table(title=f"Repo Metrics (last {period})")
+        title = f"Repo Metrics ({date_range})" if date_range else (f"Repo Metrics (last {period})")
+        table = Table(title=title)
         for col in REPO_COLUMNS:
             table.add_column(col)
 
@@ -64,7 +67,9 @@ class FileRepoPrinter:
     def __init__(self, output_path: Path):
         self.output_path = output_path
 
-    def print_combined_metrics(self, metrics: dict, period: str) -> None:
+    def print_combined_metrics(
+        self, metrics: dict, period: str, date_range: str | None = None
+    ) -> None:
         header = (
             "| Repo | Health | Pickup Time (h) | Review Time (h) | Cycle Time (h) | "
             "PR Size | Avg Lines/PR | Total PRs | PRs/Week | Reviews Given | AI |"
@@ -73,7 +78,10 @@ class FileRepoPrinter:
             "|------|--------|------------------|-----------------|----------------|"
             "---------|--------------|-----------|-----------|---------------|-----|"
         )
-        lines = [f"# Repo Metrics (last {period})", "", header, separator]
+        title = (
+            f"# Repo Metrics ({date_range})" if date_range else (f"# Repo Metrics (last {period})")
+        )
+        lines = [title, "", header, separator]
 
         all_repo_metrics = list(metrics["repo_metrics"].values())
 


### PR DESCRIPTION
## Summary
- Compute exact date range from parsed `TimePeriod` in `runner.py`
- Display date range as `YYYY-MM-DD to YYYY-MM-DD` in:
  - CLI console output (Rich panels/tables)
  - Markdown file output (headers)
  - HTML dashboard header
- Update all printer classes to accept and pass through `date_range` parameter

## Changes
- `git_dev_metrics/cli/runner.py`: Compute `date_range` string and pass to `print_metrics`
- `git_dev_metrics/cli/output.py`: Pass `date_range` through to printers
- `git_dev_metrics/metrics/printer/base.py`: Update `Printer` base class signature
- `git_dev_metrics/metrics/printer/printers.py`: Update `ConsolePrinter`, `FilePrinter`, `CompositePrinter`
- `git_dev_metrics/metrics/printer/html_printer.py`: Pass `date_range` to template
- `git_dev_metrics/metrics/printer/templates/dashboard.html`: Display `date_range`
- `git_dev_metrics/metrics/repo_printer.py`: Update console and file printers
- `git_dev_metrics/metrics/dev_printer.py`: Update console and file printers
- `git_dev_metrics/metrics/label_printer.py`: Update console and file printers

## Testing
- All 120 tests pass
- Linting passes (`ruff check`, `ruff format`)
- Type checking passes (`pyright`)