### PR TITLE
Detect AI trailers in commits and fix repo period filter

### DIFF
--- a/git_dev_metrics/cli/runner.py
+++ b/git_dev_metrics/cli/runner.py
@@ -50,11 +50,9 @@ def _fetch_stale_prs(token: str, selected: list[str]) -> list[dict]:
 
 
 def _filter_repos_by_period(repos: list, period: TimePeriod) -> list:
-    """Filter repos to those pushed within the period."""
+    """Filter repos to those with any push activity since the period started."""
     return [
-        repo
-        for repo in repos
-        if repo.get("last_pushed") and period.since <= repo["last_pushed"] < period.until
+        repo for repo in repos if repo.get("last_pushed") and repo["last_pushed"] >= period.since
     ]
 
 

--- a/git_dev_metrics/github/graphql_queries.py
+++ b/git_dev_metrics/github/graphql_queries.py
@@ -79,6 +79,7 @@ REPO_METRICS_QUERY = gql.gql(
                         nodes {
                             commit {
                                 committedDate
+                                message
                             }
                         }
                     }
@@ -163,6 +164,7 @@ SEARCH_MERGED_PRS_QUERY = gql.gql(
                         nodes {
                             commit {
                                 committedDate
+                                message
                             }
                         }
                     }

--- a/git_dev_metrics/github/queries.py
+++ b/git_dev_metrics/github/queries.py
@@ -54,6 +54,8 @@ def _map_pull_request(pr: dict) -> PullRequest:
         committed_at = commit_data.get("committedDate")
         first_commit_date = _parse_datetime(committed_at)
 
+    commit_messages = [msg for c in commits if (msg := (c.get("commit") or {}).get("message"))]
+
     return {  # type: ignore[return-value]
         "number": pr.get("number"),
         "title": pr.get("title"),
@@ -66,6 +68,7 @@ def _map_pull_request(pr: dict) -> PullRequest:
         "first_commit_at": first_commit_date,
         "body": pr.get("body"),
         "labels": [label.get("name") for label in pr.get("labels", {}).get("nodes", [])],
+        "commit_messages": commit_messages,
     }
 
 

--- a/git_dev_metrics/metrics/calculator.py
+++ b/git_dev_metrics/metrics/calculator.py
@@ -21,18 +21,22 @@ AI_TRAILER_PATTERNS = [
 ]
 
 
-def is_ai_coauthored(pr_body: str | None) -> bool:
-    """Check if PR body contains AI assistance markers."""
-    if not pr_body:
-        return False
-    return any(re.search(pattern, pr_body, re.IGNORECASE) for pattern in AI_TRAILER_PATTERNS)
+def is_ai_coauthored(pr: PullRequest) -> bool:
+    """Check if PR body or any commit message contains AI assistance markers."""
+    texts = [pr.get("body") or "", *(pr.get("commit_messages") or [])]
+    return any(
+        re.search(pattern, text, re.IGNORECASE)
+        for text in texts
+        if text
+        for pattern in AI_TRAILER_PATTERNS
+    )
 
 
 def calculate_ai_percentage(prs: list[PullRequest]) -> float:
     """Calculate percentage of PRs with AI co-authors."""
     if not prs:
         return 0.0
-    ai_count = sum(1 for pr in prs if is_ai_coauthored(pr.get("body")))
+    ai_count = sum(1 for pr in prs if is_ai_coauthored(pr))
     return round((ai_count / len(prs)) * 100, 1)
 
 

--- a/git_dev_metrics/metrics/printer/html_printer.py
+++ b/git_dev_metrics/metrics/printer/html_printer.py
@@ -60,13 +60,13 @@ def build_summary(metrics: dict) -> dict:
         total_reviews, ai_adoption, avg_lines_per_pr.
     """
     all_dev_metrics = list(metrics.get("dev_metrics", {}).values())
-    active = [d for d in all_dev_metrics if d.get("health", 0) > 0]
+    health_by_dev = [calculate_health_score(d, all_dev_metrics) for d in all_dev_metrics]
+    active = [d for d, h in zip(all_dev_metrics, health_by_dev, strict=True) if h > 0]
     repo_metrics = metrics.get("repo_metrics", {})
     total_prs = int(sum(m.get("pr_count", 0) for m in repo_metrics.values()))
     total_reviews = int(sum(m.get("reviews_given", 0) for m in repo_metrics.values()))
-    dev_health = sum(d.get("health", 0) for d in all_dev_metrics)
     return {
-        "team_health": round(dev_health / len(all_dev_metrics)) if all_dev_metrics else 0,
+        "team_health": round(sum(health_by_dev) / len(health_by_dev)) if health_by_dev else 0,
         "total_prs": total_prs,
         "avg_cycle": round(sum(d.get("cycle_time", 0) for d in active) / len(active), 1)
         if active

--- a/git_dev_metrics/models/types.py
+++ b/git_dev_metrics/models/types.py
@@ -30,6 +30,7 @@ class PullRequest(PullRequestInfo):
     first_commit_at: datetime | None
     body: str | None
     labels: list[str]
+    commit_messages: list[str]
 
 
 class Review(TypedDict):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -25,5 +25,6 @@ def any_pr(**overrides: Any) -> PullRequest:
         "first_commit_at": None,
         "body": None,
         "labels": [],
+        "commit_messages": [],
     }
     return {**defaults, **overrides}  # type: ignore[return-value]

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -515,46 +515,69 @@ class TestGetStalePrs:
 class TestIsAiCoauthored:
     """Test cases for is_ai_coauthored function."""
 
-    def test_should_return_false_for_none(self):
+    def test_should_return_false_for_none_body(self):
         from git_dev_metrics.metrics.calculator import is_ai_coauthored
 
-        result = is_ai_coauthored(None)
+        result = is_ai_coauthored(any_pr(body=None))
         assert result is False
 
-    def test_should_return_false_for_empty_string(self):
+    def test_should_return_false_for_empty_body(self):
         from git_dev_metrics.metrics.calculator import is_ai_coauthored
 
-        result = is_ai_coauthored("")
+        result = is_ai_coauthored(any_pr(body=""))
         assert result is False
 
-    def test_should_return_false_for_no_coauthored_by(self):
+    def test_should_return_false_for_no_trailer(self):
         from git_dev_metrics.metrics.calculator import is_ai_coauthored
 
-        result = is_ai_coauthored("This is a regular PR description")
+        result = is_ai_coauthored(any_pr(body="This is a regular PR description"))
         assert result is False
-
-    def test_should_return_true_for_coauthored_by(self):
-        from git_dev_metrics.metrics.calculator import is_ai_coauthored
-
-        result = is_ai_coauthored("Co-Authored-By: GitHub <noreply@github.com>")
-        assert result is True
 
     def test_should_return_true_for_coauthored_by_in_body(self):
         from git_dev_metrics.metrics.calculator import is_ai_coauthored
 
-        body = """
-        This PR was created with help from an AI assistant.
-
-        Co-Authored-By: Copilot <copilot@github.com>
-        """
-        result = is_ai_coauthored(body)
+        result = is_ai_coauthored(any_pr(body="Co-Authored-By: GitHub <noreply@github.com>"))
         assert result is True
 
     def test_should_be_case_insensitive(self):
         from git_dev_metrics.metrics.calculator import is_ai_coauthored
 
-        result = is_ai_coauthored("co-authored-by: someone@example.com")
+        result = is_ai_coauthored(any_pr(body="co-authored-by: someone@example.com"))
         assert result is True
+
+    def test_should_return_true_when_trailer_only_in_commit_message(self):
+        from git_dev_metrics.metrics.calculator import is_ai_coauthored
+
+        pr = any_pr(
+            body=None,
+            commit_messages=["Fix bug\n\nCo-Authored-By: Claude <noreply@anthropic.com>"],
+        )
+        result = is_ai_coauthored(pr)
+        assert result is True
+
+    def test_should_return_true_when_trailer_in_one_of_many_commits(self):
+        from git_dev_metrics.metrics.calculator import is_ai_coauthored
+
+        pr = any_pr(
+            body="Regular PR",
+            commit_messages=[
+                "Refactor module",
+                "Add tests",
+                "Polish\n\n🤖 Generated with Claude Code",
+            ],
+        )
+        result = is_ai_coauthored(pr)
+        assert result is True
+
+    def test_should_return_false_when_no_trailer_in_body_or_commits(self):
+        from git_dev_metrics.metrics.calculator import is_ai_coauthored
+
+        pr = any_pr(
+            body="Regular PR",
+            commit_messages=["Refactor module", "Add tests"],
+        )
+        result = is_ai_coauthored(pr)
+        assert result is False
 
 
 class TestCalculateAiPercentage:
@@ -609,3 +632,13 @@ class TestCalculateAiPercentage:
         ]
         result = calculate_ai_percentage(prs)
         assert result == 33.3
+
+    def test_should_count_pr_with_trailer_only_in_commit_message(self):
+        from git_dev_metrics.metrics.calculator import calculate_ai_percentage
+
+        prs = [
+            any_pr(body="Regular PR", commit_messages=["Co-Authored-By: Claude"]),
+            any_pr(body="Regular PR", commit_messages=["Refactor"]),
+        ]
+        result = calculate_ai_percentage(prs)
+        assert result == 50.0


### PR DESCRIPTION
## Summary
- Scan commit messages alongside PR body for AI co-author trailers; catches squash-merges where the trailer ends up in the commit message instead of the PR body.
- Drop the upper bound on the repo last-pushed filter — it was excluding any repo pushed after `period.until`, which removes most active repos and undercounts PRs.

## Test plan
- [x] `uv run pytest -q` (123 pass, 2 skipped)
- [ ] Re-run analyze for last month and confirm PR volumes match `gh search prs` counts