### PR TITLE
Rewrite health score: drop PR size, hybrid citizenship, dedupe reviews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,3 +54,7 @@ Run `ruff check .` to verify complexity.
 
 ## CI
 lint → test+coverage → security audit (pip-audit)
+
+## Privacy
+
+Never include individual developer identifiers (GitHub logins, real names, handles) in PR descriptions, commit messages, issues, or any committed file. This tool measures team aggregates and trends; per-person data stays out of source control. When illustrating impact, use anonymous labels (e.g. "dev A", "dev B") or aggregate stats only.

--- a/git_dev_metrics/constants.py
+++ b/git_dev_metrics/constants.py
@@ -8,3 +8,12 @@ KNOWN_BOT_LOGINS: set[str] = {
     "pipx[bot]",
     "poetry[bot]",
 }
+
+
+def is_bot_login(login: str | None) -> bool:
+    """True for known bots and any login ending in -bot or [bot]."""
+    if not login:
+        return False
+    if login in KNOWN_BOT_LOGINS:
+        return True
+    return login.endswith("-bot") or login.endswith("[bot]")

--- a/git_dev_metrics/metrics/__init__.py
+++ b/git_dev_metrics/metrics/__init__.py
@@ -12,7 +12,7 @@ from .calculator import (
     median,
 )
 from .dev_printer import ConsoleDevPrinter, FileDevPrinter
-from .health import calculate_health_score
+from .health import calculate_dev_health_score, calculate_health_score
 from .label_printer import ConsoleLabelPrinter, FileLabelPrinter
 from .printer import CompositePrinter, Printer, get_default_output_path
 from .repo_printer import ConsoleRepoPrinter, FileRepoPrinter
@@ -28,6 +28,7 @@ __all__ = [
     "calculate_prs_per_week",
     "calculate_throughput",
     "calculate_health_score",
+    "calculate_dev_health_score",
     "median",
     "get_default_output_path",
     "Printer",

--- a/git_dev_metrics/metrics/calculator.py
+++ b/git_dev_metrics/metrics/calculator.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from collections.abc import Callable
 from datetime import datetime
 
-from ..constants import KNOWN_BOT_LOGINS
+from ..constants import is_bot_login
 from ..models import OpenPullRequest, PullRequest
 
 AI_TRAILER_PATTERNS = [
@@ -173,7 +173,7 @@ def group_prs_by_devs(prs: list[PullRequest]) -> dict[str, list[PullRequest]]:
     devs = defaultdict(list)
     for pr in prs:
         dev = pr["user"]["login"]
-        if dev not in KNOWN_BOT_LOGINS:
+        if not is_bot_login(dev):
             devs[dev].append(pr)
     return devs
 
@@ -192,17 +192,21 @@ def group_prs_by_labels(prs: list[PullRequest]) -> dict[str, list[PullRequest]]:
 
 
 def calculate_reviews_given(reviews: dict, devs: dict[str, list[PullRequest]]) -> dict[str, int]:
-    """Calculate number of PRs reviewed by each developer, excluding bots."""
+    """Count PRs reviewed by each developer. One per PR, excludes self-reviews and bots."""
+    pr_authors = {pr["number"]: author for author, prs in devs.items() for pr in prs}
     reviewer_counts: dict[str, int] = {dev: 0 for dev in devs}
 
-    for _pr_number, pr_reviews in reviews.items():
+    for pr_number, pr_reviews in reviews.items():
+        author = pr_authors.get(pr_number)
+        counted: set[str] = set()
         for review in pr_reviews:
             reviewer = review.get("user", {}).get("login")
-            if reviewer and reviewer not in KNOWN_BOT_LOGINS:
-                if reviewer in reviewer_counts:
-                    reviewer_counts[reviewer] += 1
-                elif reviewer not in devs:
-                    reviewer_counts[reviewer] = 1
+            if not reviewer or is_bot_login(reviewer):
+                continue
+            if reviewer == author or reviewer in counted:
+                continue
+            counted.add(reviewer)
+            reviewer_counts[reviewer] = reviewer_counts.get(reviewer, 0) + 1
 
     return reviewer_counts
 

--- a/git_dev_metrics/metrics/dev_printer.py
+++ b/git_dev_metrics/metrics/dev_printer.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from .health import calculate_health_score, format_health, get_health_color
+from .health import calculate_dev_health_score, format_health, get_health_color
 
 DEV_COLUMNS = [
     "Dev",
@@ -38,7 +38,7 @@ class ConsoleDevPrinter:
 
         sorted_devs = []
         for dev, m in metrics["dev_metrics"].items():
-            health = calculate_health_score(m, all_dev_metrics)
+            health = calculate_dev_health_score(m, all_dev_metrics)
             sorted_devs.append((dev, m, health))
 
         sorted_devs.sort(key=lambda x: x[2], reverse=True)
@@ -90,7 +90,7 @@ class FileDevPrinter:
 
         sorted_devs = []
         for dev, m in metrics["dev_metrics"].items():
-            health = calculate_health_score(m, all_dev_metrics)
+            health = calculate_dev_health_score(m, all_dev_metrics)
             sorted_devs.append((dev, m, health))
 
         sorted_devs.sort(key=lambda x: x[2], reverse=True)

--- a/git_dev_metrics/metrics/health.py
+++ b/git_dev_metrics/metrics/health.py
@@ -1,155 +1,116 @@
 from typing import Any
 
-BENCHMARKS: dict[str, dict[str, int]] = {
-    "cycle_time": {"excellent": 24, "good": 48, "ok": 96, "cap": 168},  # hours
-    "pr_size": {"excellent": 200, "good": 500, "ok": 1000, "cap": 10000},  # lines
-    "pickup_time": {"excellent": 4, "good": 12, "ok": 48},  # hours
-    "prs_per_week": {"excellent": 4, "good": 3, "ok": 2, "bad": 1},  # count
+TEAM_WEIGHTS = {
+    "throughput": 0.25,
+    "speed": 0.20,
+    "pickup": 0.20,
+    "citizenship": 0.35,
 }
 
-LOG_SCALE_DEFAULT_CAP = 2000
+DEV_WEIGHTS = {
+    "throughput": 0.25,
+    "speed": 0.30,
+    "citizenship": 0.45,
+}
+
+THROUGHPUT_GOOD = 6.0
+THROUGHPUT_ELITE = 60.0
+
+CYCLE_BANDS = (4, 24, 48, 96)
+PICKUP_BANDS = (2, 8, 24, 48)
 
 
-def _log_scale(value: float, cap: float) -> float:
-    """Apply log scaling to handle outliers."""
-    import math
+def _throughput_score(prs_per_week: float) -> float:
+    if prs_per_week <= 0:
+        return 0.0
+    if prs_per_week >= THROUGHPUT_ELITE:
+        return 100.0
+    if prs_per_week >= THROUGHPUT_GOOD:
+        return 80.0 + (prs_per_week - THROUGHPUT_GOOD) / (THROUGHPUT_ELITE - THROUGHPUT_GOOD) * 20
+    return prs_per_week / THROUGHPUT_GOOD * 80
 
+
+def _time_score(value: float, bands: tuple[int, int, int, int]) -> float:
     if value <= 0:
-        return 0
-    return min(math.log1p(value) / math.log1p(cap) * cap, cap)
+        return 100.0
+    excellent, good, ok, bad = bands
+    if value <= excellent:
+        return 100.0
+    if value <= good:
+        return 80.0
+    if value <= ok:
+        return 60.0
+    if value <= bad:
+        return 40.0
+    return 20.0
 
 
-def _get_thresholds(metric: str) -> dict[str, int | float]:
-    """Get thresholds for a metric."""
-    return BENCHMARKS.get(metric, {})  # type: ignore[return-value]
+def _citizenship_score(
+    reviews_given: int,
+    pr_count: int,
+    all_metrics: list[dict[str, Any]] | None = None,
+) -> float:
+    """50% ratio + 50% absolute. Absolute scaled vs team max so prolific authors
+    aren't penalized for not maintaining 2x review ratio at high PR volume."""
+    if pr_count == 0:
+        return 0.0
 
+    ratio = reviews_given / pr_count
+    ratio_score = min(100.0, ratio * 50)
 
-def _calc_prs_per_week_penalty(current: float) -> int:
-    """Calculate penalty for prs_per_week (higher is better)."""
-    thresholds = BENCHMARKS["prs_per_week"]
-    if current >= thresholds["excellent"]:
-        return 0
-    if current >= thresholds["good"]:
-        return 10
-    if current >= thresholds["ok"]:
-        return 20
-    if current >= thresholds["bad"]:
-        return 30
-    return 35
+    if all_metrics:
+        max_reviews = max((m.get("reviews_given", 0) for m in all_metrics), default=0)
+        absolute_score = (reviews_given / max_reviews * 100) if max_reviews > 0 else 0.0
+    else:
+        absolute_score = min(100.0, reviews_given / 100 * 100)
 
-
-def _calc_time_penalty(current: float, thresholds: dict[str, float]) -> int:
-    """Calculate penalty for time-based metrics."""
-    if current <= thresholds.get("excellent", 0):
-        return 0
-    if current <= thresholds.get("good", 0):
-        return 10
-    if current <= thresholds.get("ok", 0):
-        return 20
-    return 35
-
-
-def calc_benchmark_penalty(current: float, metric: str, use_log: bool = False) -> int:
-    """Calculate penalty based on industry benchmarks."""
-    if metric not in BENCHMARKS or current <= 0:
-        return 0
-
-    bench = _get_thresholds(metric)
-    cap = bench.get("cap", None)
-    ok_threshold = bench.get("ok", None)
-
-    if cap and current > cap:
-        current = cap
-
-    if use_log and ok_threshold and current > ok_threshold:
-        current = _log_scale(current, cap or LOG_SCALE_DEFAULT_CAP)
-
-    if metric == "prs_per_week":
-        return _calc_prs_per_week_penalty(current)
-
-    if metric == "pickup_time":
-        return _calc_time_penalty(current, bench)
-
-    return _calc_time_penalty(current, bench)
-
-
-def format_health(score: int) -> str:
-    """Format health score for display."""
-    return str(score)
-
-
-def get_health_color(score: int) -> str:
-    """Return color for health score."""
-    if score >= 80:
-        return "green"
-    if score >= 60:
-        return "yellow"
-    return "red"
+    return 0.5 * ratio_score + 0.5 * absolute_score
 
 
 def calculate_health_score(
     metrics: dict[str, Any], all_metrics: list[dict[str, Any]] | None = None
 ) -> int:
-    """Calculate health score (0-100) based on industry benchmarks.
-
-    Uses DORA/GitHub engineering benchmarks:
-    - cycle_time: ≤24h excellent, ≤48h good, ≤96h ok, >96h penalty (capped at 168h)
-    - pr_size: ≤200 excellent, ≤500 good, ≤1000 ok, >1000 penalty (log scaled)
-    - pickup_time: ≤4h excellent, ≤12h good, ≤48h ok, >48h penalty
-    - prs_per_week: 4+ excellent, <4 penalty
-    - reviews_given: +10 if ≥2× PRs, +5 if ≥1× PRs, -15 if <50% of PRs
-
-    Relative bonuses (if all_metrics provided):
-    - +10 for highest prs_per_week
-    - +10 for most reviews_given
-    - +10 for lowest cycle_time (fastest)
-    """
+    """Team/repo composite 0-100. Includes pickup time (team responsiveness)."""
     pr_count = metrics.get("pr_count", 0)
     if pr_count == 0:
         return 0
 
-    score = 100
+    components = {
+        "throughput": _throughput_score(metrics.get("prs_per_week", 0)),
+        "speed": _time_score(metrics.get("cycle_time", 0), CYCLE_BANDS),
+        "pickup": _time_score(metrics.get("pickup_time", 0), PICKUP_BANDS),
+        "citizenship": _citizenship_score(metrics.get("reviews_given", 0), pr_count, all_metrics),
+    }
 
-    score -= calc_benchmark_penalty(metrics.get("cycle_time", 0), "cycle_time")
-    score -= calc_benchmark_penalty(metrics.get("pr_size", 0), "pr_size", use_log=True)
-    score -= calc_benchmark_penalty(metrics.get("pickup_time", 0), "pickup_time")
-    score -= calc_benchmark_penalty(metrics.get("prs_per_week", 0), "prs_per_week")
-
-    reviews_given = metrics.get("reviews_given", 0)
-    if reviews_given >= pr_count * 2:
-        score += 10
-    elif reviews_given >= pr_count:
-        score += 5
-
-    if reviews_given < pr_count * 0.5:
-        score -= 15
-
-    if all_metrics:
-        score = _apply_relative_bonuses(metrics, all_metrics, score)
-
-    return max(0, min(100, score))
+    score = sum(TEAM_WEIGHTS[k] * v for k, v in components.items())
+    return round(max(0.0, min(100.0, score)))
 
 
-def _apply_relative_bonuses(
-    metrics: dict[str, Any], all_metrics: list[dict[str, Any]], score: int
+def calculate_dev_health_score(
+    metrics: dict[str, Any], all_metrics: list[dict[str, Any]] | None = None
 ) -> int:
-    """Apply relative bonuses based on group performance."""
-    prs_per_week = metrics.get("prs_per_week", 0)
-    reviews_given = metrics.get("reviews_given", 0)
-    cycle_time = metrics.get("cycle_time", 0)
+    """Per-developer composite 0-100. Excludes pickup time (reviewer behavior, not author)."""
+    pr_count = metrics.get("pr_count", 0)
+    if pr_count == 0:
+        return 0
 
-    max_prs_per_week = max((m.get("prs_per_week", 0) for m in all_metrics), default=0)
-    max_reviews_given = max((m.get("reviews_given", 0) for m in all_metrics), default=0)
-    min_cycle_time = min(
-        (m.get("cycle_time", float("inf")) for m in all_metrics if m.get("cycle_time", 0) > 0),
-        default=0,
-    )
+    components = {
+        "throughput": _throughput_score(metrics.get("prs_per_week", 0)),
+        "speed": _time_score(metrics.get("cycle_time", 0), CYCLE_BANDS),
+        "citizenship": _citizenship_score(metrics.get("reviews_given", 0), pr_count, all_metrics),
+    }
 
-    if prs_per_week > 0 and prs_per_week >= max_prs_per_week:
-        score += 10
-    if reviews_given > 0 and reviews_given >= max_reviews_given:
-        score += 10
-    if cycle_time > 0 and min_cycle_time > 0 and cycle_time <= min_cycle_time:
-        score += 10
+    score = sum(DEV_WEIGHTS[k] * v for k, v in components.items())
+    return round(max(0.0, min(100.0, score)))
 
-    return score
+
+def format_health(score: int) -> str:
+    return str(score)
+
+
+def get_health_color(score: int) -> str:
+    if score >= 80:
+        return "green"
+    if score >= 60:
+        return "yellow"
+    return "red"

--- a/git_dev_metrics/metrics/printer/html_printer.py
+++ b/git_dev_metrics/metrics/printer/html_printer.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from jinja2 import Environment, PackageLoader, select_autoescape
 
-from ..health import calculate_health_score
+from ..health import calculate_dev_health_score
 from .base import Printer
 
 _ENV: Environment | None = None
@@ -31,7 +31,7 @@ def _build_devs_list(metrics: dict) -> list[dict]:
     all_dev_metrics = list(metrics["dev_metrics"].values())
     devs = []
     for dev, m in metrics["dev_metrics"].items():
-        health = calculate_health_score(m, all_dev_metrics)
+        health = calculate_dev_health_score(m, all_dev_metrics)
         devs.append(
             {
                 "name": dev,
@@ -60,7 +60,7 @@ def build_summary(metrics: dict) -> dict:
         total_reviews, ai_adoption, avg_lines_per_pr.
     """
     all_dev_metrics = list(metrics.get("dev_metrics", {}).values())
-    health_by_dev = [calculate_health_score(d, all_dev_metrics) for d in all_dev_metrics]
+    health_by_dev = [calculate_dev_health_score(d, all_dev_metrics) for d in all_dev_metrics]
     active = [d for d, h in zip(all_dev_metrics, health_by_dev, strict=True) if h > 0]
     repo_metrics = metrics.get("repo_metrics", {})
     total_prs = int(sum(m.get("pr_count", 0) for m in repo_metrics.values()))

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,189 +1,306 @@
-from git_dev_metrics.metrics.health import calc_benchmark_penalty, calculate_health_score
+from git_dev_metrics.metrics.health import (
+    _citizenship_score,
+    _throughput_score,
+    _time_score,
+    calculate_dev_health_score,
+    calculate_health_score,
+)
 
 
-class TestCalcBenchmarkPenalty:
-    """Test cases for calc_benchmark_penalty function."""
+class TestThroughputScore:
+    def test_should_return_zero_for_zero(self):
+        assert _throughput_score(0) == 0
 
-    def test_should_return_zero_for_unknown_metric(self):
-        result = calc_benchmark_penalty(10, "unknown")
-        assert result == 0
+    def test_should_return_zero_for_negative(self):
+        assert _throughput_score(-1) == 0
 
-    def test_should_return_zero_for_zero_value(self):
-        result = calc_benchmark_penalty(0, "cycle_time")
-        assert result == 0
+    def test_should_return_80_at_good_target(self):
+        assert _throughput_score(6) == 80
 
-    def test_should_return_zero_for_negative_value(self):
-        result = calc_benchmark_penalty(-1, "cycle_time")
-        assert result == 0
+    def test_should_return_100_at_elite(self):
+        assert _throughput_score(60) == 100
 
-    def test_should_return_zero_for_excellent_cycle_time(self):
-        result = calc_benchmark_penalty(2, "cycle_time")
-        assert result == 0
+    def test_should_cap_at_100_above_elite(self):
+        assert _throughput_score(120) == 100
 
-    def test_should_return_zero_for_good_cycle_time(self):
-        result = calc_benchmark_penalty(20, "cycle_time")
-        assert result == 0
+    def test_should_scale_below_good_target(self):
+        assert _throughput_score(3) == 40
 
-    def test_should_return_20_for_ok_cycle_time(self):
-        result = calc_benchmark_penalty(50, "cycle_time")
-        assert result == 20
+    def test_should_reward_extreme_volume_above_baseline(self):
+        # 12/wk should clearly beat 6/wk (was tied at 100 in old formula)
+        assert _throughput_score(12) > _throughput_score(6)
 
-    def test_should_return_35_for_bad_cycle_time(self):
-        result = calc_benchmark_penalty(100, "cycle_time")
-        assert result == 35
 
-    def test_should_return_zero_for_excellent_pr_size(self):
-        result = calc_benchmark_penalty(50, "pr_size")
-        assert result == 0
+class TestTimeScore:
+    bands = (4, 24, 48, 96)
 
-    def test_should_return_zero_for_good_pr_size(self):
-        result = calc_benchmark_penalty(200, "pr_size")
-        assert result == 0
+    def test_should_return_100_for_excellent(self):
+        assert _time_score(2, self.bands) == 100
 
-    def test_should_return_20_for_ok_pr_size(self):
-        result = calc_benchmark_penalty(600, "pr_size")
-        assert result == 20
+    def test_should_return_80_for_good(self):
+        assert _time_score(20, self.bands) == 80
 
-    def test_should_return_20_for_bad_pr_size(self):
-        result = calc_benchmark_penalty(1000, "pr_size")
-        assert result == 20
+    def test_should_return_60_for_ok(self):
+        assert _time_score(40, self.bands) == 60
 
-    def test_should_return_zero_for_excellent_prs_per_week(self):
-        result = calc_benchmark_penalty(6, "prs_per_week")
-        assert result == 0
+    def test_should_return_40_for_bad(self):
+        assert _time_score(80, self.bands) == 40
 
-    def test_should_return_zero_for_good_prs_per_week(self):
-        result = calc_benchmark_penalty(4, "prs_per_week")
-        assert result == 0
+    def test_should_return_20_for_very_bad(self):
+        assert _time_score(200, self.bands) == 20
 
-    def test_should_return_20_for_ok_prs_per_week(self):
-        result = calc_benchmark_penalty(2, "prs_per_week")
-        assert result == 20
+    def test_should_treat_zero_as_no_signal(self):
+        assert _time_score(0, self.bands) == 100
 
-    def test_should_return_30_for_bad_prs_per_week(self):
-        result = calc_benchmark_penalty(1, "prs_per_week")
-        assert result == 30
+    def test_should_treat_negative_as_no_signal(self):
+        assert _time_score(-50, self.bands) == 100
+
+
+class TestCitizenshipScore:
+    def test_should_return_zero_when_no_prs(self):
+        assert _citizenship_score(5, 0) == 0
+
+    def test_should_return_zero_for_zero_reviews(self):
+        assert _citizenship_score(0, 5) == 0
+
+    def test_should_score_full_at_2x_ratio_and_full_absolute(self):
+        # Standalone (no team): 50 absolute (50/100) + 50 ratio (2x) → 75
+        assert _citizenship_score(50, 25) == 75
+
+    def test_should_score_top_absolute_when_team_provided(self):
+        # Top reviewer in team gets full absolute, even with low ratio
+        all_m = [{"reviews_given": 300}, {"reviews_given": 50}]
+        # ratio 300/100 = 3 → 100 ratio_score; absolute 300/300 → 100. Avg 100.
+        assert _citizenship_score(300, 100, all_m) == 100
+
+    def test_should_punish_high_volume_author_with_low_relative_reviews(self):
+        # Big author, modest reviews vs team max
+        all_m = [{"reviews_given": 1000}, {"reviews_given": 100}]
+        # ratio 100/200 = 0.5 → 25; absolute 100/1000 = 10. Avg 17.5
+        assert _citizenship_score(100, 200, all_m) == 17.5
+
+    def test_should_reward_prolific_reviewer_at_top_of_team(self):
+        # Kobbi-like: high author volume + top absolute reviews
+        all_m = [{"reviews_given": 335}, {"reviews_given": 35}]
+        # ratio 335/264 = 1.27 → 63.4; absolute 335/335 → 100. Avg ~81.7
+        result = _citizenship_score(335, 264, all_m)
+        assert 80 < result < 83
 
 
 class TestCalculateHealthScore:
-    """Test cases for calculate_health_score function."""
+    def test_should_return_zero_when_no_prs(self):
+        result = calculate_health_score({"pr_count": 0})
+        assert result == 0
 
-    def test_should_return_100_for_perfect_metrics(self):
+    def test_should_return_100_for_elite_metrics(self):
+        # Arrange: elite throughput + excellent times + top reviewer
         metrics = {
+            "pr_count": 30,
+            "prs_per_week": 60,
             "cycle_time": 2,
-            "pr_size": 50,
-            "prs_per_week": 6,
-            "pr_count": 5,
-            "reviews_given": 5,
+            "pickup_time": 1,
+            "reviews_given": 200,
         }
+
+        # Act
         result = calculate_health_score(metrics)
+
+        # Assert
         assert result == 100
 
-    def test_should_penalize_high_cycle_time(self):
-        metrics = {
-            "cycle_time": 100,
-            "pr_size": 50,
-            "prs_per_week": 6,
-            "pr_count": 5,
-            "reviews_given": 5,
-        }
-        result = calculate_health_score(metrics)
-        assert result == 70
-
-    def test_should_penalize_large_pr_size(self):
-        metrics = {
+    def test_should_ignore_pr_size(self):
+        # Arrange: same metrics with vastly different pr_size should score identically
+        small = {
+            "pr_count": 30,
+            "prs_per_week": 60,
             "cycle_time": 2,
-            "pr_size": 1000,
-            "prs_per_week": 6,
-            "pr_count": 5,
-            "reviews_given": 5,
-        }
-        result = calculate_health_score(metrics)
-        assert result == 85
-
-    def test_should_penalize_low_prs_per_week(self):
-        metrics = {
-            "cycle_time": 2,
+            "pickup_time": 1,
+            "reviews_given": 200,
             "pr_size": 50,
-            "prs_per_week": 1,
-            "pr_count": 1,
-            "reviews_given": 1,
         }
-        result = calculate_health_score(metrics)
-        assert result == 75
+        huge = {**small, "pr_size": 10000, "avg_lines_per_pr": 5000}
 
-    def test_should_penalize_low_review_ratio(self):
-        metrics = {
-            "cycle_time": 2,
-            "pr_size": 50,
-            "prs_per_week": 6,
-            "pr_count": 10,
-            "reviews_given": 1,
-        }
-        result = calculate_health_score(metrics)
-        assert result == 85
+        # Act / Assert
+        assert calculate_health_score(small) == calculate_health_score(huge)
 
-    def test_should_not_penalize_high_review_ratio(self):
+    def test_should_penalize_slow_cycle_time(self):
+        # Arrange
         metrics = {
-            "cycle_time": 2,
-            "pr_size": 50,
-            "prs_per_week": 6,
-            "pr_count": 5,
-            "reviews_given": 10,
-        }
-        result = calculate_health_score(metrics)
-        assert result == 100
-
-    def test_should_return_0_for_worst_metrics(self):
-        metrics = {
+            "pr_count": 30,
+            "prs_per_week": 60,
             "cycle_time": 200,
-            "pr_size": 2000,
-            "prs_per_week": 0.1,
+            "pickup_time": 1,
+            "reviews_given": 200,
+        }
+
+        # Act
+        result = calculate_health_score(metrics)
+
+        # Assert: speed drops 100→20, costs 0.20*80 = 16 points. 100-16 = 84
+        assert result == 84
+
+    def test_should_penalize_slow_pickup(self):
+        # Arrange
+        metrics = {
+            "pr_count": 30,
+            "prs_per_week": 60,
+            "cycle_time": 2,
+            "pickup_time": 100,
+            "reviews_given": 200,
+        }
+
+        # Act
+        result = calculate_health_score(metrics)
+
+        # Assert
+        assert result == 84
+
+    def test_should_penalize_low_throughput(self):
+        # Arrange
+        metrics = {
             "pr_count": 1,
+            "prs_per_week": 1,
+            "cycle_time": 2,
+            "pickup_time": 1,
+            "reviews_given": 100,
+        }
+
+        # Act
+        result = calculate_health_score(metrics)
+
+        # Assert: throughput 13.3 (1/6*80), citizenship 100 (top abs + top ratio).
+        # 0.25*13.3 + 0.20*100 + 0.20*100 + 0.35*100 = 78.33 → 78
+        assert result == 78
+
+    def test_should_penalize_low_citizenship(self):
+        # Arrange
+        metrics = {
+            "pr_count": 10,
+            "prs_per_week": 60,
+            "cycle_time": 2,
+            "pickup_time": 1,
             "reviews_given": 0,
         }
+
+        # Act
         result = calculate_health_score(metrics)
-        assert result == 0
+
+        # Assert: citizenship 0 (no reviews). 0.25*100 + 0.20*100 + 0.20*100 + 0.35*0 = 65
+        assert result == 65
+
+    def test_should_handle_negative_pickup_time_as_no_signal(self):
+        # Arrange
+        metrics = {
+            "pr_count": 30,
+            "prs_per_week": 60,
+            "cycle_time": 2,
+            "pickup_time": -440,
+            "reviews_given": 200,
+        }
+
+        # Act
+        result = calculate_health_score(metrics)
+
+        # Assert
+        assert result == 100
+
+    def test_should_floor_at_zero(self):
+        # Arrange
+        metrics = {
+            "pr_count": 1,
+            "prs_per_week": 0,
+            "cycle_time": 200,
+            "pickup_time": 100,
+            "reviews_given": 0,
+        }
+
+        # Act
+        result = calculate_health_score(metrics)
+
+        # Assert: all components 0/20/20/0. 0.25*0 + 0.20*20 + 0.20*20 + 0.35*0 = 8
+        assert result == 8
 
     def test_should_handle_missing_metrics(self):
-        metrics = {}
-        result = calculate_health_score(metrics)
+        result = calculate_health_score({})
         assert result == 0
 
-    def test_should_handle_zero_pr_count_no_review_penalty(self):
-        metrics = {
+    def test_should_use_team_max_for_relative_citizenship(self):
+        # Arrange: top reviewer in team gets max citizenship even with modest ratio
+        prolific = {
+            "pr_count": 264,
+            "prs_per_week": 60,
             "cycle_time": 2,
-            "pr_size": 50,
-            "prs_per_week": 6,
-            "pr_count": 0,
+            "pickup_time": 3,
+            "reviews_given": 335,
+        }
+        small = {
+            "pr_count": 23,
+            "prs_per_week": 5,
+            "cycle_time": 2,
+            "pickup_time": 1,
+            "reviews_given": 35,
+        }
+        all_m = [prolific, small]
+
+        # Act
+        prolific_score = calculate_health_score(prolific, all_m)
+        small_score = calculate_health_score(small, all_m)
+
+        # Assert: prolific (top reviewer + top throughput) should beat small dev
+        assert prolific_score > small_score
+
+
+class TestCalculateDevHealthScore:
+    def test_should_return_zero_when_no_prs(self):
+        assert calculate_dev_health_score({"pr_count": 0}) == 0
+
+    def test_should_ignore_pickup_time(self):
+        # Arrange: same metrics with vastly different pickup should score identically
+        fast_pickup = {
+            "pr_count": 30,
+            "prs_per_week": 60,
+            "cycle_time": 2,
+            "pickup_time": 1,
+            "reviews_given": 200,
+        }
+        slow_pickup = {**fast_pickup, "pickup_time": 100}
+
+        # Act / Assert
+        assert calculate_dev_health_score(fast_pickup) == calculate_dev_health_score(slow_pickup)
+
+    def test_should_return_100_for_elite_metrics(self):
+        # Arrange: elite throughput + excellent cycle + top reviewer
+        metrics = {
+            "pr_count": 30,
+            "prs_per_week": 60,
+            "cycle_time": 2,
+            "reviews_given": 200,
+        }
+
+        # Act
+        result = calculate_dev_health_score(metrics)
+
+        # Assert
+        assert result == 100
+
+    def test_should_weight_cycle_more_than_team_score(self):
+        # Same slow-cycle metrics; dev formula penalizes cycle harder (30% vs 20%)
+        slow = {
+            "pr_count": 30,
+            "prs_per_week": 60,
+            "cycle_time": 200,
+            "pickup_time": 1,
+            "reviews_given": 200,
+        }
+        # dev score: throughput 100, speed 20, citizenship 100. 0.25*100+0.30*20+0.45*100 = 76
+        assert calculate_dev_health_score(slow) == 76
+
+    def test_should_weight_citizenship_at_45_percent(self):
+        # No reviews → citizenship 0; everything else 100. 0.25*100 + 0.30*100 + 0.45*0 = 55
+        metrics = {
+            "pr_count": 10,
+            "prs_per_week": 60,
+            "cycle_time": 2,
             "reviews_given": 0,
         }
-        result = calculate_health_score(metrics)
-        assert result == 0
-
-    def test_should_add_relative_bonus_for_highest_prs_per_week(self):
-        all_metrics = [
-            {"prs_per_week": 2, "reviews_given": 5, "cycle_time": 10, "pr_count": 2},
-            {"prs_per_week": 6, "reviews_given": 3, "cycle_time": 20, "pr_count": 6},
-        ]
-        metrics = {"prs_per_week": 6, "reviews_given": 3, "cycle_time": 20, "pr_count": 6}
-        result = calculate_health_score(metrics, all_metrics)
-        assert result == 100
-
-    def test_should_add_relative_bonus_for_most_reviews(self):
-        all_metrics = [
-            {"prs_per_week": 5, "reviews_given": 2, "cycle_time": 10},
-            {"prs_per_week": 3, "reviews_given": 10, "cycle_time": 20},
-        ]
-        metrics = {"prs_per_week": 3, "reviews_given": 10, "cycle_time": 20, "pr_count": 5}
-        result = calculate_health_score(metrics, all_metrics)
-        assert result == 100
-
-    def test_should_add_relative_bonus_for_fastest_cycle_time(self):
-        all_metrics = [
-            {"prs_per_week": 5, "reviews_given": 5, "cycle_time": 10, "pr_count": 5},
-            {"prs_per_week": 3, "reviews_given": 3, "cycle_time": 5, "pr_count": 3},
-        ]
-        metrics = {"prs_per_week": 3, "reviews_given": 3, "cycle_time": 5, "pr_count": 3}
-        result = calculate_health_score(metrics, all_metrics)
-        assert result == 100
+        assert calculate_dev_health_score(metrics) == 55

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -374,6 +374,126 @@ class TestCalculateReviewsGiven:
         assert result["alice"] == 0
         assert result["external-reviewer"] == 1
 
+    def test_should_count_each_pr_only_once_per_reviewer(self):
+        # Arrange: bob submits 3 review events on alice's single PR
+        from git_dev_metrics.metrics.calculator import calculate_reviews_given, group_prs_by_devs
+
+        prs = [
+            any_pr(id=1, number=1, user={"login": "alice"}),
+        ]
+        devs = group_prs_by_devs(prs)
+        reviews = {
+            1: [
+                {
+                    "user": {"login": "bob"},
+                    "state": "COMMENTED",
+                    "submitted_at": "2024-01-01T01:00:00Z",
+                },
+                {
+                    "user": {"login": "bob"},
+                    "state": "CHANGES_REQUESTED",
+                    "submitted_at": "2024-01-01T02:00:00Z",
+                },
+                {
+                    "user": {"login": "bob"},
+                    "state": "APPROVED",
+                    "submitted_at": "2024-01-01T03:00:00Z",
+                },
+            ],
+        }
+
+        # Act
+        result = calculate_reviews_given(reviews, devs)
+
+        # Assert
+        assert result["bob"] == 1
+
+    def test_should_exclude_self_reviews(self):
+        # Arrange: alice reviews her own PR
+        from git_dev_metrics.metrics.calculator import calculate_reviews_given, group_prs_by_devs
+
+        prs = [
+            any_pr(id=1, number=1, user={"login": "alice"}),
+        ]
+        devs = group_prs_by_devs(prs)
+        reviews = {
+            1: [
+                {
+                    "user": {"login": "alice"},
+                    "state": "APPROVED",
+                    "submitted_at": "2024-01-01T01:00:00Z",
+                },
+            ],
+        }
+
+        # Act
+        result = calculate_reviews_given(reviews, devs)
+
+        # Assert
+        assert result["alice"] == 0
+
+    def test_should_exclude_bot_suffix_reviewers(self):
+        # Arrange
+        from git_dev_metrics.metrics.calculator import calculate_reviews_given, group_prs_by_devs
+
+        prs = [any_pr(id=1, number=1, user={"login": "alice"})]
+        devs = group_prs_by_devs(prs)
+        reviews = {
+            1: [
+                {
+                    "user": {"login": "patches-bot"},
+                    "state": "APPROVED",
+                    "submitted_at": "2024-01-01T01:00:00Z",
+                },
+            ],
+        }
+
+        # Act
+        result = calculate_reviews_given(reviews, devs)
+
+        # Assert
+        assert "patches-bot" not in result
+
+
+class TestIsBotLogin:
+    def test_should_match_known_bot(self):
+        from git_dev_metrics.constants import is_bot_login
+
+        assert is_bot_login("dependabot") is True
+
+    def test_should_match_dash_bot_suffix(self):
+        from git_dev_metrics.constants import is_bot_login
+
+        assert is_bot_login("patches-bot") is True
+
+    def test_should_match_bracket_bot_suffix(self):
+        from git_dev_metrics.constants import is_bot_login
+
+        assert is_bot_login("custom[bot]") is True
+
+    def test_should_not_match_human_login(self):
+        from git_dev_metrics.constants import is_bot_login
+
+        assert is_bot_login("alice") is False
+
+    def test_should_handle_none(self):
+        from git_dev_metrics.constants import is_bot_login
+
+        assert is_bot_login(None) is False
+
+
+class TestGroupPrsByDevsBotExclusion:
+    def test_should_exclude_dash_bot_authors(self):
+        from git_dev_metrics.metrics.calculator import group_prs_by_devs
+
+        prs = [
+            any_pr(id=1, number=1, user={"login": "alice"}),
+            any_pr(id=2, number=2, user={"login": "patches-bot"}),
+        ]
+        result = group_prs_by_devs(prs)
+        assert "alice" in result
+        assert "patches-bot" not in result
+
 
 class TestGroupPrsByLabels:
     """Test cases for group_prs_by_labels function."""


### PR DESCRIPTION
## Summary

- Drop PR size from health score — measures shape, not quality.
- Drop relative bonuses (+10 stacks).
- Reviews-given dedupe: one count per reviewer per PR; self-reviews excluded.
- Bot exclusion now matches any `-bot` or `[bot]` suffix (covers internal bots without manual allowlist updates).
- Add privacy rule to `AGENTS.md`.

## New formula

Composite weighted average, 0-100, no cap-stacking:

| Component | Weight | Notes |
|---|---|---|
| throughput | 25% | piecewise: 6/wk → 80, 60/wk → 100 |
| speed (cycle time) | 20% | bands: ≤4h, ≤24h, ≤48h, ≤96h |
| pickup time | 20% | bands: ≤2h, ≤8h, ≤24h, ≤48h |
| citizenship | 35% | hybrid: 50% absolute reviews vs team max + 50% ratio |

Citizenship hybrid prevents penalizing high-volume authors who can't maintain a 2× review ratio at scale.

## Test plan
- [x] `uv run pytest` — 136 passed, 2 skipped
- [x] `ruff check` + `ruff format --check` clean