### PR TITLE
Fix cross-repo PR-number collision in reviews dict

### DIFF
--- a/git_dev_metrics/github/queries.py
+++ b/git_dev_metrics/github/queries.py
@@ -69,6 +69,7 @@ def _map_pull_request(pr: dict) -> PullRequest:
         "body": pr.get("body"),
         "labels": [label.get("name") for label in pr.get("labels", {}).get("nodes", [])],
         "commit_messages": commit_messages,
+        "reviews": [],
     }
 
 
@@ -147,10 +148,9 @@ def fetch_reviews(
     return reviews_by_pr
 
 
-def _filter_and_map_pr(prs: list[dict], period: TimePeriod) -> tuple[list, dict]:
-    """Filter PRs by TimePeriod and map to internal format."""
-    mapped_prs = []
-    reviews_by_pr = {}
+def _filter_and_map_pr(prs: list[dict], period: TimePeriod) -> list[PullRequest]:
+    """Filter PRs by TimePeriod and attach reviews to each PR."""
+    mapped_prs: list[PullRequest] = []
 
     for pr in prs:
         mapped = _map_pull_request(pr)
@@ -158,18 +158,15 @@ def _filter_and_map_pr(prs: list[dict], period: TimePeriod) -> tuple[list, dict]
         if merged_at is None or merged_at < period.since or merged_at >= period.until:  # type: ignore[reportOperatorIssue]
             continue
 
-        pr_number = mapped["number"]
+        review_nodes = pr.get("reviews", {}).get("nodes", [])
+        mapped["reviews"] = [_map_review(r) for r in review_nodes]
         mapped_prs.append(mapped)
-        reviews = pr.get("reviews", {}).get("nodes", [])
-        reviews_by_pr[pr_number] = [_map_review(r) for r in reviews]
 
-    return mapped_prs, reviews_by_pr
+    return mapped_prs
 
 
-def fetch_repo_metrics(
-    token: str, org: str, repo: str, period: TimePeriod
-) -> tuple[list[PullRequest], dict[int, list[Review]]]:
-    """Fetch PRs and reviews in a single query using search API."""
+def fetch_repo_metrics(token: str, org: str, repo: str, period: TimePeriod) -> list[PullRequest]:
+    """Fetch PRs (with attached reviews) in a single query using search API."""
     client = get_client(token)
     search_query = _build_merged_prs_query(org, repo, period)
     prs = execute_paginated_query(

--- a/git_dev_metrics/metrics/analyzer.py
+++ b/git_dev_metrics/metrics/analyzer.py
@@ -31,7 +31,7 @@ def _parse_period_days(event_period: str) -> int:
     return days
 
 
-def _build_dev_metrics(devs: dict, reviews: dict, period_days: int, reviews_given: dict) -> dict:
+def _build_dev_metrics(devs: dict, period_days: int, reviews_given: dict) -> dict:
     """Build dev-level metrics dict."""
     return {
         dev: {
@@ -39,8 +39,8 @@ def _build_dev_metrics(devs: dict, reviews: dict, period_days: int, reviews_give
             "pr_size": calculate_pr_size(dev_prs),
             "avg_lines_per_pr": calculate_avg_lines_per_pr(dev_prs),
             "pr_count": calculate_throughput(dev_prs),
-            "pickup_time": calculate_pickup_time(dev_prs, reviews),
-            "review_time": calculate_review_time(dev_prs, reviews),
+            "pickup_time": calculate_pickup_time(dev_prs),
+            "review_time": calculate_review_time(dev_prs),
             "prs_per_week": calculate_prs_per_week(dev_prs, period_days),
             "reviews_given": reviews_given.get(dev, 0),
             "ai_percentage": calculate_ai_percentage(dev_prs),
@@ -53,19 +53,19 @@ def get_pull_request_metrics(token: str, org: str, repo: str, event_period: str 
     """Get development metrics for a repository over a specified time period."""
     period = parse_time_period(event_period)
     period_days = _parse_period_days(event_period)
-    prs, reviews = fetch_repo_metrics(token, org, repo, period)
+    prs = fetch_repo_metrics(token, org, repo, period)
 
     devs = group_prs_by_devs(prs)
-    reviews_given = calculate_reviews_given(reviews, devs)
-    dev_metrics = _build_dev_metrics(devs, reviews, period_days, reviews_given)
+    reviews_given = calculate_reviews_given(prs)
+    dev_metrics = _build_dev_metrics(devs, period_days, reviews_given)
 
     return {
         "cycle_time": calculate_cycle_time(prs),
         "pr_size": calculate_pr_size(prs),
         "avg_lines_per_pr": calculate_avg_lines_per_pr(prs),
         "pr_count": calculate_throughput(prs),
-        "pickup_time": calculate_pickup_time(prs, reviews),
-        "review_time": calculate_review_time(prs, reviews),
+        "pickup_time": calculate_pickup_time(prs),
+        "review_time": calculate_review_time(prs),
         "prs_per_week": calculate_prs_per_week(prs, period_days),
         "reviews_given": sum(reviews_given.values()),
         "ai_percentage": calculate_ai_percentage(prs),
@@ -73,32 +73,31 @@ def get_pull_request_metrics(token: str, org: str, repo: str, event_period: str 
     }
 
 
-def _build_metrics(prs: list, reviews: dict, period_days: int) -> dict:
+def _build_metrics(prs: list, period_days: int) -> dict:
     """Build metrics dict for a list of PRs."""
-    devs = group_prs_by_devs(prs)
-    reviews_given = calculate_reviews_given(reviews, devs)
+    reviews_given = calculate_reviews_given(prs)
     return {
         "cycle_time": calculate_cycle_time(prs),
         "pr_size": calculate_pr_size(prs),
         "avg_lines_per_pr": calculate_avg_lines_per_pr(prs),
         "pr_count": calculate_throughput(prs),
-        "pickup_time": calculate_pickup_time(prs, reviews),
-        "review_time": calculate_review_time(prs, reviews),
+        "pickup_time": calculate_pickup_time(prs),
+        "review_time": calculate_review_time(prs),
         "prs_per_week": calculate_prs_per_week(prs, period_days),
         "reviews_given": sum(reviews_given.values()),
         "ai_percentage": calculate_ai_percentage(prs),
     }
 
 
-def _build_label_metrics(labels: dict, reviews: dict, period_days: int) -> dict:
+def _build_label_metrics(labels: dict, period_days: int) -> dict:
     """Build label-level metrics dict."""
     return {
         label: {
             "cycle_time": calculate_cycle_time(label_prs),
             "pr_size": calculate_pr_size(label_prs),
             "pr_count": calculate_throughput(label_prs),
-            "pickup_time": calculate_pickup_time(label_prs, reviews),
-            "review_time": calculate_review_time(label_prs, reviews),
+            "pickup_time": calculate_pickup_time(label_prs),
+            "review_time": calculate_review_time(label_prs),
             "prs_per_week": calculate_prs_per_week(label_prs, period_days),
         }
         for label, label_prs in labels.items()
@@ -111,23 +110,21 @@ def get_combined_metrics(token: str, selected_repos: list[str], event_period: st
     period_days = _parse_period_days(event_period)
 
     all_prs: list = []
-    all_reviews: dict = {}
     repo_metrics: dict = {}
 
     for full_name in selected_repos:
         org, name = full_name.split("/", 1)
-        prs, reviews = fetch_repo_metrics(token, org, name, period)
+        prs = fetch_repo_metrics(token, org, name, period)
 
         all_prs.extend(prs)
-        all_reviews.update(reviews)
-        repo_metrics[full_name] = _build_metrics(prs, reviews, period_days)
+        repo_metrics[full_name] = _build_metrics(prs, period_days)
 
     all_devs = group_prs_by_devs(all_prs)
-    all_reviews_given = calculate_reviews_given(all_reviews, all_devs)
-    combined_dev_metrics = _build_dev_metrics(all_devs, all_reviews, period_days, all_reviews_given)
+    all_reviews_given = calculate_reviews_given(all_prs)
+    combined_dev_metrics = _build_dev_metrics(all_devs, period_days, all_reviews_given)
 
     all_labels = group_prs_by_labels(all_prs)
-    combined_label_metrics = _build_label_metrics(all_labels, all_reviews, period_days)
+    combined_label_metrics = _build_label_metrics(all_labels, period_days)
 
     return {
         "repo_metrics": repo_metrics,

--- a/git_dev_metrics/metrics/calculator.py
+++ b/git_dev_metrics/metrics/calculator.py
@@ -106,54 +106,41 @@ def calculate_throughput(prs: list[PullRequest]) -> int:
     return len(prs)
 
 
-def calculate_pickup_time(prs: list[PullRequest], reviews: dict) -> float:
+def _first_approval_at(pr: PullRequest) -> datetime | None:
+    for review in pr.get("reviews", []):
+        if review.get("state") == "APPROVED":
+            return _to_datetime(review.get("submitted_at"))
+    return None
+
+
+def calculate_pickup_time(prs: list[PullRequest]) -> float:
     """Calculate median time from PR creation to first approval (in hours)."""
     if not prs:
         return 0.0
 
     pickup_times = []
     for pr in prs:
-        pr_number = pr["number"]
-        pr_reviews = reviews.get(pr_number, [])
         created = _to_datetime(pr["created_at"])
-        if created is None:
-            continue
-
-        first_approval = None
-        for review in pr_reviews:
-            if review.get("state") == "APPROVED":
-                first_approval = _to_datetime(review.get("submitted_at"))
-                break
-
-        if first_approval:
-            hours = (first_approval - created).total_seconds() / 3600
-            pickup_times.append(hours)
+        first_approval = _first_approval_at(pr)
+        if created and first_approval:
+            pickup_times.append((first_approval - created).total_seconds() / 3600)
 
     if not pickup_times:
         return 0.0
     return round(median(pickup_times), 2)
 
 
-def calculate_review_time(prs: list[PullRequest], reviews: dict) -> float:
+def calculate_review_time(prs: list[PullRequest]) -> float:
     """Calculate median time from first approval to merge (in hours)."""
     if not prs:
         return 0.0
 
     review_times = []
     for pr in prs:
-        pr_number = pr["number"]
-        pr_reviews = reviews.get(pr_number, [])
         merged = _to_datetime(pr["merged_at"])
-
-        first_approval = None
-        for review in pr_reviews:
-            if review.get("state") == "APPROVED":
-                first_approval = _to_datetime(review.get("submitted_at"))
-                break
-
+        first_approval = _first_approval_at(pr)
         if merged and first_approval:
-            hours = (merged - first_approval).total_seconds() / 3600
-            review_times.append(hours)
+            review_times.append((merged - first_approval).total_seconds() / 3600)
 
     if not review_times:
         return 0.0
@@ -191,15 +178,14 @@ def group_prs_by_labels(prs: list[PullRequest]) -> dict[str, list[PullRequest]]:
     return labels
 
 
-def calculate_reviews_given(reviews: dict, devs: dict[str, list[PullRequest]]) -> dict[str, int]:
+def calculate_reviews_given(prs: list[PullRequest]) -> dict[str, int]:
     """Count PRs reviewed by each developer. One per PR, excludes self-reviews and bots."""
-    pr_authors = {pr["number"]: author for author, prs in devs.items() for pr in prs}
-    reviewer_counts: dict[str, int] = {dev: 0 for dev in devs}
+    reviewer_counts: dict[str, int] = {}
 
-    for pr_number, pr_reviews in reviews.items():
-        author = pr_authors.get(pr_number)
+    for pr in prs:
+        author = pr["user"]["login"]
         counted: set[str] = set()
-        for review in pr_reviews:
+        for review in pr.get("reviews", []):
             reviewer = review.get("user", {}).get("login")
             if not reviewer or is_bot_login(reviewer):
                 continue

--- a/git_dev_metrics/models/types.py
+++ b/git_dev_metrics/models/types.py
@@ -17,6 +17,12 @@ class PullRequestInfo(TypedDict):
     merged_at: str
 
 
+class Review(TypedDict):
+    user: GitHubUser
+    state: str
+    submitted_at: str
+
+
 class PullRequest(PullRequestInfo):
     id: int
     number: int
@@ -31,12 +37,7 @@ class PullRequest(PullRequestInfo):
     body: str | None
     labels: list[str]
     commit_messages: list[str]
-
-
-class Review(TypedDict):
-    user: GitHubUser
-    state: str
-    submitted_at: str
+    reviews: list[Review]
 
 
 class OpenPullRequest(TypedDict):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -26,5 +26,6 @@ def any_pr(**overrides: Any) -> PullRequest:
         "body": None,
         "labels": [],
         "commit_messages": [],
+        "reviews": [],
     }
     return {**defaults, **overrides}  # type: ignore[return-value]

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -198,47 +198,55 @@ class TestCalculatePickupTime:
     """Test cases for calculate_pickup_time function."""
 
     def test_should_return_zero_when_no_prs_provided(self):
-        prs = []
-        result = calculate_pickup_time(prs, {})
+        result = calculate_pickup_time([])
         assert result == 0.0
 
     def test_should_return_zero_when_no_reviews(self):
         prs = [
-            any_pr(number=1, created_at="2024-01-01T00:00:00Z", merged_at="2024-01-02T00:00:00Z")
+            any_pr(
+                number=1,
+                created_at="2024-01-01T00:00:00Z",
+                merged_at="2024-01-02T00:00:00Z",
+                reviews=[],
+            )
         ]
-        result = calculate_pickup_time(prs, {1: []})
+        result = calculate_pickup_time(prs)
         assert result == 0.0
 
     def test_should_return_zero_when_no_approval(self):
         prs = [
-            any_pr(number=1, created_at="2024-01-01T00:00:00Z", merged_at="2024-01-02T00:00:00Z")
+            any_pr(
+                number=1,
+                created_at="2024-01-01T00:00:00Z",
+                merged_at="2024-01-02T00:00:00Z",
+                reviews=[
+                    {
+                        "user": {"login": "reviewer"},
+                        "state": "COMMENTED",
+                        "submitted_at": "2024-01-01T12:00:00Z",
+                    }
+                ],
+            )
         ]
-        reviews = {
-            1: [
-                {
-                    "user": {"login": "reviewer"},
-                    "state": "COMMENTED",
-                    "submitted_at": "2024-01-01T12:00:00Z",
-                }
-            ]
-        }
-        result = calculate_pickup_time(prs, reviews)
+        result = calculate_pickup_time(prs)
         assert result == 0.0
 
     def test_should_calculate_pickup_time(self):
         prs = [
-            any_pr(number=1, created_at="2024-01-01T00:00:00Z", merged_at="2024-01-02T00:00:00Z")
+            any_pr(
+                number=1,
+                created_at="2024-01-01T00:00:00Z",
+                merged_at="2024-01-02T00:00:00Z",
+                reviews=[
+                    {
+                        "user": {"login": "reviewer"},
+                        "state": "APPROVED",
+                        "submitted_at": "2024-01-01T12:00:00Z",
+                    }
+                ],
+            )
         ]
-        reviews = {
-            1: [
-                {
-                    "user": {"login": "reviewer"},
-                    "state": "APPROVED",
-                    "submitted_at": "2024-01-01T12:00:00Z",
-                }
-            ]
-        }
-        result = calculate_pickup_time(prs, reviews)
+        result = calculate_pickup_time(prs)
         assert result == 12.0
 
 
@@ -246,40 +254,43 @@ class TestCalculateReviewTime:
     """Test cases for calculate_review_time function."""
 
     def test_should_return_zero_when_no_prs_provided(self):
-        prs = []
-        result = calculate_review_time(prs, {})
+        result = calculate_review_time([])
         assert result == 0.0
 
     def test_should_return_zero_when_no_approval(self):
         prs = [
-            any_pr(number=1, created_at="2024-01-01T00:00:00Z", merged_at="2024-01-02T00:00:00Z")
+            any_pr(
+                number=1,
+                created_at="2024-01-01T00:00:00Z",
+                merged_at="2024-01-02T00:00:00Z",
+                reviews=[
+                    {
+                        "user": {"login": "reviewer"},
+                        "state": "COMMENTED",
+                        "submitted_at": "2024-01-01T12:00:00Z",
+                    }
+                ],
+            )
         ]
-        reviews = {
-            1: [
-                {
-                    "user": {"login": "reviewer"},
-                    "state": "COMMENTED",
-                    "submitted_at": "2024-01-01T12:00:00Z",
-                }
-            ]
-        }
-        result = calculate_review_time(prs, reviews)
+        result = calculate_review_time(prs)
         assert result == 0.0
 
     def test_should_calculate_review_time(self):
         prs = [
-            any_pr(number=1, created_at="2024-01-01T00:00:00Z", merged_at="2024-01-03T00:00:00Z")
+            any_pr(
+                number=1,
+                created_at="2024-01-01T00:00:00Z",
+                merged_at="2024-01-03T00:00:00Z",
+                reviews=[
+                    {
+                        "user": {"login": "reviewer"},
+                        "state": "APPROVED",
+                        "submitted_at": "2024-01-02T00:00:00Z",
+                    }
+                ],
+            )
         ]
-        reviews = {
-            1: [
-                {
-                    "user": {"login": "reviewer"},
-                    "state": "APPROVED",
-                    "submitted_at": "2024-01-02T00:00:00Z",
-                }
-            ]
-        }
-        result = calculate_review_time(prs, reviews)
+        result = calculate_review_time(prs)
         assert result == 24.0
 
 
@@ -318,141 +329,196 @@ class TestParsePeriodDays:
 class TestCalculateReviewsGiven:
     """Test cases for calculate_reviews_given function."""
 
-    def test_should_return_zero_for_no_reviews(self):
+    def test_should_return_empty_for_no_prs(self):
         from git_dev_metrics.metrics.calculator import calculate_reviews_given
 
-        devs = {"alice": [], "bob": []}
-        reviews = {1: [], 2: []}
-        result = calculate_reviews_given(reviews, devs)
-        assert result == {"alice": 0, "bob": 0}
+        result = calculate_reviews_given([])
+        assert result == {}
 
     def test_should_count_reviews_from_devs(self):
-        from git_dev_metrics.metrics.calculator import calculate_reviews_given, group_prs_by_devs
+        from git_dev_metrics.metrics.calculator import calculate_reviews_given
 
         prs = [
-            any_pr(id=1, number=1, user={"login": "alice"}),
-            any_pr(id=2, number=2, user={"login": "bob"}),
+            any_pr(
+                id=1,
+                number=1,
+                user={"login": "alice"},
+                reviews=[
+                    {
+                        "user": {"login": "bob"},
+                        "state": "APPROVED",
+                        "submitted_at": "2024-01-01T01:00:00Z",
+                    },
+                ],
+            ),
+            any_pr(
+                id=2,
+                number=2,
+                user={"login": "bob"},
+                reviews=[
+                    {
+                        "user": {"login": "alice"},
+                        "state": "APPROVED",
+                        "submitted_at": "2024-01-01T02:00:00Z",
+                    },
+                ],
+            ),
         ]
-        devs = group_prs_by_devs(prs)
-        reviews = {
-            1: [
-                {
-                    "user": {"login": "bob"},
-                    "state": "APPROVED",
-                    "submitted_at": "2024-01-01T01:00:00Z",
-                },
-            ],
-            2: [
-                {
-                    "user": {"login": "alice"},
-                    "state": "APPROVED",
-                    "submitted_at": "2024-01-01T02:00:00Z",
-                },
-            ],
-        }
-        result = calculate_reviews_given(reviews, devs)
+        result = calculate_reviews_given(prs)
         assert result["alice"] == 1
         assert result["bob"] == 1
 
-    def test_should_include_reviewers_not_in_devs(self):
-        from git_dev_metrics.metrics.calculator import calculate_reviews_given, group_prs_by_devs
+    def test_should_count_external_reviewers(self):
+        from git_dev_metrics.metrics.calculator import calculate_reviews_given
 
         prs = [
-            any_pr(id=1, number=1, user={"login": "alice"}),
+            any_pr(
+                id=1,
+                number=1,
+                user={"login": "alice"},
+                reviews=[
+                    {
+                        "user": {"login": "external-reviewer"},
+                        "state": "APPROVED",
+                        "submitted_at": "2024-01-01T01:00:00Z",
+                    },
+                ],
+            ),
         ]
-        devs = group_prs_by_devs(prs)
-        reviews = {
-            1: [
-                {
-                    "user": {"login": "external-reviewer"},
-                    "state": "APPROVED",
-                    "submitted_at": "2024-01-01T01:00:00Z",
-                },
-            ],
-        }
-        result = calculate_reviews_given(reviews, devs)
-        assert result["alice"] == 0
+        result = calculate_reviews_given(prs)
         assert result["external-reviewer"] == 1
 
     def test_should_count_each_pr_only_once_per_reviewer(self):
         # Arrange: bob submits 3 review events on alice's single PR
-        from git_dev_metrics.metrics.calculator import calculate_reviews_given, group_prs_by_devs
+        from git_dev_metrics.metrics.calculator import calculate_reviews_given
 
         prs = [
-            any_pr(id=1, number=1, user={"login": "alice"}),
+            any_pr(
+                id=1,
+                number=1,
+                user={"login": "alice"},
+                reviews=[
+                    {
+                        "user": {"login": "bob"},
+                        "state": "COMMENTED",
+                        "submitted_at": "2024-01-01T01:00:00Z",
+                    },
+                    {
+                        "user": {"login": "bob"},
+                        "state": "CHANGES_REQUESTED",
+                        "submitted_at": "2024-01-01T02:00:00Z",
+                    },
+                    {
+                        "user": {"login": "bob"},
+                        "state": "APPROVED",
+                        "submitted_at": "2024-01-01T03:00:00Z",
+                    },
+                ],
+            ),
         ]
-        devs = group_prs_by_devs(prs)
-        reviews = {
-            1: [
-                {
-                    "user": {"login": "bob"},
-                    "state": "COMMENTED",
-                    "submitted_at": "2024-01-01T01:00:00Z",
-                },
-                {
-                    "user": {"login": "bob"},
-                    "state": "CHANGES_REQUESTED",
-                    "submitted_at": "2024-01-01T02:00:00Z",
-                },
-                {
-                    "user": {"login": "bob"},
-                    "state": "APPROVED",
-                    "submitted_at": "2024-01-01T03:00:00Z",
-                },
-            ],
-        }
 
         # Act
-        result = calculate_reviews_given(reviews, devs)
+        result = calculate_reviews_given(prs)
 
         # Assert
         assert result["bob"] == 1
 
     def test_should_exclude_self_reviews(self):
         # Arrange: alice reviews her own PR
-        from git_dev_metrics.metrics.calculator import calculate_reviews_given, group_prs_by_devs
+        from git_dev_metrics.metrics.calculator import calculate_reviews_given
 
         prs = [
-            any_pr(id=1, number=1, user={"login": "alice"}),
+            any_pr(
+                id=1,
+                number=1,
+                user={"login": "alice"},
+                reviews=[
+                    {
+                        "user": {"login": "alice"},
+                        "state": "APPROVED",
+                        "submitted_at": "2024-01-01T01:00:00Z",
+                    },
+                ],
+            ),
         ]
-        devs = group_prs_by_devs(prs)
-        reviews = {
-            1: [
-                {
-                    "user": {"login": "alice"},
-                    "state": "APPROVED",
-                    "submitted_at": "2024-01-01T01:00:00Z",
-                },
-            ],
-        }
 
         # Act
-        result = calculate_reviews_given(reviews, devs)
+        result = calculate_reviews_given(prs)
 
         # Assert
-        assert result["alice"] == 0
+        assert "alice" not in result
 
     def test_should_exclude_bot_suffix_reviewers(self):
         # Arrange
-        from git_dev_metrics.metrics.calculator import calculate_reviews_given, group_prs_by_devs
+        from git_dev_metrics.metrics.calculator import calculate_reviews_given
 
-        prs = [any_pr(id=1, number=1, user={"login": "alice"})]
-        devs = group_prs_by_devs(prs)
-        reviews = {
-            1: [
-                {
-                    "user": {"login": "patches-bot"},
-                    "state": "APPROVED",
-                    "submitted_at": "2024-01-01T01:00:00Z",
-                },
-            ],
-        }
+        prs = [
+            any_pr(
+                id=1,
+                number=1,
+                user={"login": "alice"},
+                reviews=[
+                    {
+                        "user": {"login": "patches-bot"},
+                        "state": "APPROVED",
+                        "submitted_at": "2024-01-01T01:00:00Z",
+                    },
+                ],
+            )
+        ]
 
         # Act
-        result = calculate_reviews_given(reviews, devs)
+        result = calculate_reviews_given(prs)
 
         # Assert
         assert "patches-bot" not in result
+
+    def test_should_not_collide_across_repos_with_same_pr_number(self):
+        # Arrange: two PRs both numbered 1 from different repos with different reviews
+        from git_dev_metrics.metrics.calculator import (
+            calculate_pickup_time,
+            calculate_reviews_given,
+        )
+
+        prs = [
+            any_pr(
+                id=10,
+                number=1,
+                user={"login": "alice"},
+                created_at="2024-01-01T00:00:00Z",
+                merged_at="2024-01-02T00:00:00Z",
+                reviews=[
+                    {
+                        "user": {"login": "bob"},
+                        "state": "APPROVED",
+                        "submitted_at": "2024-01-01T02:00:00Z",
+                    }
+                ],
+            ),
+            any_pr(
+                id=20,
+                number=1,
+                user={"login": "carol"},
+                created_at="2024-02-01T00:00:00Z",
+                merged_at="2024-02-02T00:00:00Z",
+                reviews=[
+                    {
+                        "user": {"login": "dave"},
+                        "state": "APPROVED",
+                        "submitted_at": "2024-02-01T05:00:00Z",
+                    }
+                ],
+            ),
+        ]
+
+        # Act
+        reviews_given = calculate_reviews_given(prs)
+        pickup = calculate_pickup_time(prs)
+
+        # Assert: each reviewer counted once; pickup is per-PR (median of 2h and 5h = 3.5h)
+        assert reviews_given["bob"] == 1
+        assert reviews_given["dave"] == 1
+        assert pickup == 3.5
 
 
 class TestIsBotLogin:


### PR DESCRIPTION
## Summary

Reviews were merged into a single dict keyed by PR number across all repos, so when two repos both had a PR with the same number the second `dict.update(...)` silently overwrote the first repo's reviews.

Symptom: a PR's pickup/review time was computed against the wrong reviews. Example from latest run: a same-day-merged PR showed `pickup_time = -440.59h` because it was paired with reviews from a different repo's PR with the same number.

## Fix

Attach reviews to each `PullRequest` directly. Reviews live with their owning PR; no shared dict, no key collision.

- `PullRequest.reviews: list[Review]` added to model
- `_filter_and_map_pr` now embeds reviews into each PR and returns `list[PullRequest]` (no separate dict)
- `calculate_pickup_time` / `calculate_review_time` / `calculate_reviews_given` simplified — read `pr["reviews"]` directly
- `analyzer.py` no longer maintains an `all_reviews` dict

## Investigation note

The user-reported names (`cjluci`, `lucinityArni`) do not appear in the latest 2026-04-01..2026-05-01 reports — those names are from older periods. The collision bug is real and affects current data; it's the most likely cause of any anomalous metrics observed.

## Test plan
- [x] `uv run pytest` — 142 passed, 2 skipped
- [x] `ruff check` + `ruff format --check` clean
- [x] New regression test: `test_should_not_collide_across_repos_with_same_pr_number`
- [x] Manually verified: a sample with two PR #235s now computes pickup = 1.0h instead of negative