### PR TITLE
Drop zero-PR repos from file output, align spacing

### DIFF
--- a/git_dev_metrics/metrics/printer/printers.py
+++ b/git_dev_metrics/metrics/printer/printers.py
@@ -42,9 +42,9 @@ class FilePrinter(Printer):
     """Print metrics to markdown file."""
 
     def __init__(self, output_path: Path | None = None) -> None:
-        path = output_path or get_default_output_path()
-        self._repo_printer = FileRepoPrinter(path)
-        self._dev_printer = FileDevPrinter(path)
+        self._path = output_path or get_default_output_path()
+        self._repo_printer = FileRepoPrinter(self._path)
+        self._dev_printer = FileDevPrinter(self._path)
 
     def print_combined_metrics(self, metrics: dict, period: str, date_range: str) -> None:
         summary = build_summary(metrics)
@@ -65,10 +65,8 @@ class FilePrinter(Printer):
         self._dev_printer.print_combined_metrics(metrics, period, date_range)
 
     def _write(self, lines: list[str]) -> None:
-
-        output_path = get_default_output_path()
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(output_path, "a") as f:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self._path, "a") as f:
             f.write("\n".join(lines))
 
 

--- a/git_dev_metrics/metrics/repo_printer.py
+++ b/git_dev_metrics/metrics/repo_printer.py
@@ -37,12 +37,14 @@ class FileRepoPrinter:
         title = (
             f"# Repo Metrics ({date_range})" if date_range else (f"# Repo Metrics (last {period})")
         )
-        lines = [title, "", header, separator]
-
-        all_repo_metrics = list(metrics["repo_metrics"].values())
+        lines = ["", title, "", header, separator]
+        active_repos = {
+            name: m for name, m in metrics["repo_metrics"].items() if m.get("pr_count", 0) > 0
+        }
+        all_repo_metrics = list(active_repos.values())
 
         sorted_repos = []
-        for repo_name, m in metrics["repo_metrics"].items():
+        for repo_name, m in active_repos.items():
             health = calculate_health_score(m, all_repo_metrics)
             sorted_repos.append((repo_name, m, health))
 


### PR DESCRIPTION
## Summary
- Filter out repos with `pr_count == 0` from the file repo table — the all-zero rows were noise. Health distribution is now computed from the active set.
- Add a leading blank line before the repo title so spacing matches the dev/stale sections.
- Fix `FilePrinter._write` reading from `get_default_output_path()` instead of the path passed in — the summary block was landing in the wrong file when a custom output path was used.

## Notes on dropped scope
- Em-dash for empty cells: would have been dead code once zero-PR repos are filtered. Skipped.
- Console headers/spacing: already coherent after the PR1 trim — only Summary panel + Dev table now, both Rich-styled.

## Test plan
- [ ] `uv run pytest` — green (137 passed)
- [ ] `uv run app` — open the markdown file, confirm zero-PR repos are gone and section breaks look even
- [ ] Pass `--output` to a custom path and confirm summary lands there

🤖 Generated with [Claude Code](https://claude.com/claude-code)