### PR TITLE
Align console summary with dev table

### DIFF
--- a/git_dev_metrics/metrics/printer/printers.py
+++ b/git_dev_metrics/metrics/printer/printers.py
@@ -16,23 +16,34 @@ class ConsolePrinter(Printer):
 
     def print_combined_metrics(self, metrics: dict, period: str, date_range: str) -> None:
         from rich.console import Console
-        from rich.panel import Panel
+        from rich.table import Table
 
         console = Console()
 
         summary = build_summary(metrics)
-        panel = Panel(
-            f"Team Health: {summary['team_health']}  |  "
-            f"Total PRs: {summary['total_prs']}  |  "
-            f"Avg Lines/PR: {summary['avg_lines_per_pr']}  |  "
-            f"Avg Cycle: {summary['avg_cycle']}h  |  "
-            f"Avg Pickup: {summary['avg_pickup']}h  |  "
-            f"Reviews: {summary['total_reviews']}  |  "
-            f"AI: {summary['ai_adoption']}%",
-            title=f"Summary ({date_range})",
-            expand=False,
+        table = Table(title=f"Summary ({date_range})")
+        for col in (
+            "Team Health",
+            "Total PRs",
+            "Avg Lines/PR",
+            "Avg Cycle (h)",
+            "Avg Pickup (h)",
+            "Reviews",
+            "AI",
+        ):
+            table.add_column(col)
+        table.add_row(
+            str(summary["team_health"]),
+            str(summary["total_prs"]),
+            str(summary["avg_lines_per_pr"]),
+            str(summary["avg_cycle"]),
+            str(summary["avg_pickup"]),
+            str(summary["total_reviews"]),
+            f"{summary['ai_adoption']}%",
         )
-        console.print(panel)
+
+        console.print()
+        console.print(table)
         console.print()
 
         self._dev_printer.print_combined_metrics(metrics, period, date_range)


### PR DESCRIPTION
## Summary
- Replace the `Panel` summary with a single-row Rich `Table`. Now both the summary and dev sections share the same title placement, border style, and auto-width.
- Add a blank line before the summary so it visually separates from the trailing `✓ … items` fetch logs.

## Before / after
Before: panel was full-width with border-embedded title; dev table was content-width with centered italic title; no gap above panel.

After: both render as content-width Rich tables with centered italic titles and a blank line above the summary.

## Test plan
- [ ] `uv run pytest` — green (137 passed)
- [ ] `uv run app` — confirm summary + dev tables align visually and there's a clean break between fetch logs and summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)