### PR TITLE
Weight summary AI and avg-lines by PR count

### DIFF
--- a/git_dev_metrics/metrics/printer/html_printer.py
+++ b/git_dev_metrics/metrics/printer/html_printer.py
@@ -65,6 +65,23 @@ def build_summary(metrics: dict) -> dict:
     repo_metrics = metrics.get("repo_metrics", {})
     total_prs = int(sum(m.get("pr_count", 0) for m in repo_metrics.values()))
     total_reviews = int(sum(m.get("reviews_given", 0) for m in repo_metrics.values()))
+    ai_adoption = (
+        round(
+            sum(m.get("ai_percentage", 0) * m.get("pr_count", 0) for m in repo_metrics.values())
+            / total_prs
+        )
+        if total_prs
+        else 0
+    )
+    avg_lines_per_pr = (
+        round(
+            sum(m.get("avg_lines_per_pr", 0) * m.get("pr_count", 0) for m in repo_metrics.values())
+            / total_prs,
+            1,
+        )
+        if total_prs
+        else 0
+    )
     return {
         "team_health": round(sum(health_by_dev) / len(health_by_dev)) if health_by_dev else 0,
         "total_prs": total_prs,
@@ -75,16 +92,8 @@ def build_summary(metrics: dict) -> dict:
         if active
         else 0,
         "total_reviews": total_reviews,
-        "ai_adoption": round(
-            sum(m.get("ai_percentage", 0) for m in repo_metrics.values()) / len(repo_metrics)
-        )
-        if repo_metrics
-        else 0,
-        "avg_lines_per_pr": round(
-            sum(m.get("avg_lines_per_pr", 0) for m in repo_metrics.values()) / len(repo_metrics), 1
-        )
-        if repo_metrics
-        else 0,
+        "ai_adoption": ai_adoption,
+        "avg_lines_per_pr": avg_lines_per_pr,
     }
 
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -780,3 +780,38 @@ class TestCalculateAiPercentage:
         ]
         result = calculate_ai_percentage(prs)
         assert result == 50.0
+
+
+class TestBuildSummary:
+    """Test cases for build_summary AI/lines weighting."""
+
+    def test_should_weight_ai_adoption_by_pr_count(self):
+        from git_dev_metrics.metrics.printer.html_printer import build_summary
+
+        metrics = {
+            "dev_metrics": {},
+            "repo_metrics": {
+                "big": {"pr_count": 100, "ai_percentage": 80, "avg_lines_per_pr": 100},
+                "small": {"pr_count": 1, "ai_percentage": 0, "avg_lines_per_pr": 0},
+            },
+        }
+        result = build_summary(metrics)
+
+        assert result["ai_adoption"] == 79
+        assert result["avg_lines_per_pr"] == 99.0
+
+    def test_should_ignore_zero_pr_repos_in_weighting(self):
+        from git_dev_metrics.metrics.printer.html_printer import build_summary
+
+        metrics = {
+            "dev_metrics": {},
+            "repo_metrics": {
+                "active": {"pr_count": 10, "ai_percentage": 50, "avg_lines_per_pr": 200},
+                "empty1": {"pr_count": 0, "ai_percentage": 0, "avg_lines_per_pr": 0},
+                "empty2": {"pr_count": 0, "ai_percentage": 0, "avg_lines_per_pr": 0},
+            },
+        }
+        result = build_summary(metrics)
+
+        assert result["ai_adoption"] == 50
+        assert result["avg_lines_per_pr"] == 200.0


### PR DESCRIPTION
## Summary
The summary card showed `AI: 33%` while the dev table averaged ~70%+ — same disagreement on `Avg Lines/PR`. Cause: `build_summary` did a plain mean of `ai_percentage` / `avg_lines_per_pr` across **all** repo entries, including the ones with zero PRs in the period (which contribute 0 and drag the mean down).

Fix: switch both to a PR-weighted average — Σ(metric × pr_count) ÷ Σ(pr_count). Zero-PR repos drop out naturally, and the summary now reflects the actual mix.

## Tests
- `TestBuildSummary::test_should_weight_ai_adoption_by_pr_count` — one big high-AI repo dominates one tiny zero-AI repo
- `TestBuildSummary::test_should_ignore_zero_pr_repos_in_weighting` — empties don't drag the mean

## Test plan
- [ ] `uv run pytest` — green (139 passed)
- [ ] `uv run app` — confirm summary AI now lands in the same range as the dev table

🤖 Generated with [Claude Code](https://claude.com/claude-code)