### PR TITLE
Open result file via interactive picker

### DIFF
--- a/git_dev_metrics/cli/output.py
+++ b/git_dev_metrics/cli/output.py
@@ -18,10 +18,7 @@ def resolve_output_path(output: Path | None) -> Path:
 
 def print_metrics(metrics: dict, period: str, output_path: Path, date_range: str) -> None:
     """Print metrics to the specified output path."""
-    import typer
-
     _print_combined_metrics(metrics, period, output_path, date_range)
-    typer.secho(f"Results saved to {output_path}", fg=typer.colors.GREEN)
 
 
 def print_stale_prs(stale_prs: list[dict], output_path: Path) -> None:

--- a/git_dev_metrics/cli/prompts.py
+++ b/git_dev_metrics/cli/prompts.py
@@ -1,5 +1,10 @@
+from pathlib import Path
+
+import click
 import questionary
 from questionary import Style
+
+MAX_RESULT_FILES = 10
 
 PERIOD_OPTIONS = [
     ("Last 7 days", "7d"),
@@ -75,3 +80,28 @@ def prompt_repo_selection(repos: dict[str, str]) -> list[str]:
     ).ask()
 
     return selected or list(repos.keys())  # fallback if user cancels
+
+
+def prompt_open_result(default_path: Path) -> None:
+    """List recent result files, open the chosen one in the default app."""
+    results_dir = default_path.parent
+    files = sorted(
+        results_dir.glob("metrics_*.md"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )[:MAX_RESULT_FILES]
+    if not files:
+        return
+
+    choices = [questionary.Choice(title=f.name, value=f) for f in files]
+    choices.append(questionary.Choice(title="(skip)", value=False))
+
+    selected = questionary.select(
+        "Open a result file:",
+        choices=choices,
+        default=choices[0],
+    ).ask()
+
+    if not selected:
+        return
+    click.launch(str(selected))

--- a/git_dev_metrics/cli/runner.py
+++ b/git_dev_metrics/cli/runner.py
@@ -15,6 +15,7 @@ from ..metrics import get_combined_metrics
 from ..utils import TimePeriod, parse_time_period
 from .output import print_metrics, print_stale_prs, resolve_output_path
 from .prompts import (
+    prompt_open_result,
     prompt_org_name,
     prompt_period_selection,
     prompt_repo_selection,
@@ -129,3 +130,5 @@ def run_analyze(
     stale_prs = _fetch_stale_prs(token, selected)
     if stale_prs:
         print_stale_prs(stale_prs, output_path)
+
+    prompt_open_result(output_path)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -44,6 +44,7 @@ class TestCLI:
             "git_dev_metrics.cli.runner._filter_repos_by_period",
             side_effect=lambda repos, since: repos,
         )
+        mocker.patch("git_dev_metrics.cli.runner.prompt_open_result")
 
         result = runner.invoke(app, [])
 

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -1,6 +1,11 @@
 """Unit tests for prompts.py functions."""
 
-from git_dev_metrics.cli.prompts import PERIOD_OPTIONS, prompt_period_selection
+from git_dev_metrics.cli.prompts import (
+    MAX_RESULT_FILES,
+    PERIOD_OPTIONS,
+    prompt_open_result,
+    prompt_period_selection,
+)
 
 
 class TestPromptPeriodSelection:
@@ -63,3 +68,72 @@ class TestPromptPeriodSelection:
         call_kwargs = mock_select.call_args[1]
         assert call_kwargs["default"] == "last_month"
         assert result == "last_month"
+
+
+class TestPromptOpenResult:
+    def test_should_return_silently_when_no_files(self, tmp_path, mocker):
+        mock_select = mocker.patch("git_dev_metrics.cli.prompts.questionary.select")
+
+        prompt_open_result(tmp_path / "metrics_unused.md")
+
+        mock_select.assert_not_called()
+
+    def test_should_offer_most_recent_files_first(self, tmp_path, mocker):
+        for i, name in enumerate(["metrics_a.md", "metrics_b.md", "metrics_c.md"]):
+            f = tmp_path / name
+            f.write_text("x")
+            import os
+
+            os.utime(f, (i, i))
+        mock_select = mocker.patch("git_dev_metrics.cli.prompts.questionary.select")
+        mock_select.return_value.ask.return_value = None
+
+        prompt_open_result(tmp_path / "metrics_unused.md")
+
+        call_kwargs = mock_select.call_args[1]
+        titles = [c.title for c in call_kwargs["choices"]]
+        assert titles[:3] == ["metrics_c.md", "metrics_b.md", "metrics_a.md"]
+        assert titles[-1] == "(skip)"
+
+    def test_should_cap_at_max_result_files(self, tmp_path, mocker):
+        for i in range(MAX_RESULT_FILES + 5):
+            (tmp_path / f"metrics_{i:02d}.md").write_text("x")
+        mock_select = mocker.patch("git_dev_metrics.cli.prompts.questionary.select")
+        mock_select.return_value.ask.return_value = None
+
+        prompt_open_result(tmp_path / "metrics_unused.md")
+
+        call_kwargs = mock_select.call_args[1]
+        file_choices = [c for c in call_kwargs["choices"] if c.value is not False]
+        assert len(file_choices) == MAX_RESULT_FILES
+
+    def test_should_launch_selected_file(self, tmp_path, mocker):
+        target = tmp_path / "metrics_pick.md"
+        target.write_text("x")
+        mock_select = mocker.patch("git_dev_metrics.cli.prompts.questionary.select")
+        mock_select.return_value.ask.return_value = target
+        mock_launch = mocker.patch("git_dev_metrics.cli.prompts.click.launch")
+
+        prompt_open_result(tmp_path / "metrics_unused.md")
+
+        mock_launch.assert_called_once_with(str(target))
+
+    def test_should_skip_launch_when_user_aborts(self, tmp_path, mocker):
+        (tmp_path / "metrics_a.md").write_text("x")
+        mock_select = mocker.patch("git_dev_metrics.cli.prompts.questionary.select")
+        mock_select.return_value.ask.return_value = None
+        mock_launch = mocker.patch("git_dev_metrics.cli.prompts.click.launch")
+
+        prompt_open_result(tmp_path / "metrics_unused.md")
+
+        mock_launch.assert_not_called()
+
+    def test_should_skip_launch_when_user_picks_skip_option(self, tmp_path, mocker):
+        (tmp_path / "metrics_a.md").write_text("x")
+        mock_select = mocker.patch("git_dev_metrics.cli.prompts.questionary.select")
+        mock_select.return_value.ask.return_value = False
+        mock_launch = mocker.patch("git_dev_metrics.cli.prompts.click.launch")
+
+        prompt_open_result(tmp_path / "metrics_unused.md")
+
+        mock_launch.assert_not_called()


### PR DESCRIPTION
## Summary
After a run, replace the `Results saved to ...` line with a `questionary.select` picker showing the 10 most recent files in `metrics_results/`, newest first. Arrow-pick a file → it opens in the system's default app via `click.launch`. A `(skip)` option exits without opening.

## Notes
- Cap at 10 files to keep the list neat. Older runs are still on disk.
- Use `value=False` for the skip choice — `questionary` falls back to using `title` as value when `value=None`, which would have matched the file-launching path.

## Tests
- `TestPromptOpenResult` — empty dir, mtime ordering, cap, launch on pick, skip on abort, skip on `(skip)` selection
- Existing `test_should_run` mocks the new picker

## Test plan
- [ ] `uv run pytest` — green (145 passed)
- [ ] `uv run app` — confirm picker appears, arrow keys + enter open the file in default app
- [ ] Pick `(skip)` — confirm nothing opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)