### PR TITLE
Include HTML files in result picker

### DIFF
--- a/git_dev_metrics/cli/prompts.py
+++ b/git_dev_metrics/cli/prompts.py
@@ -86,8 +86,8 @@ def prompt_open_result(default_path: Path) -> None:
     """List recent result files, open the chosen one in the default app."""
     results_dir = default_path.parent
     files = sorted(
-        results_dir.glob("metrics_*.md"),
-        key=lambda p: p.stat().st_mtime,
+        (p for p in results_dir.glob("metrics_*") if p.suffix in {".md", ".html"}),
+        key=lambda p: (p.stat().st_mtime, p.suffix),
         reverse=True,
     )[:MAX_RESULT_FILES]
     if not files:


### PR DESCRIPTION
## Summary
- Picker globbed only `metrics_*.md`, hiding the `.html` sibling produced for the same run.
- Now lists both `.md` and `.html` entries; tiebreak keeps `.md` first when mtimes match.

## Test plan
- [ ] Run CLI, confirm picker shows both `.md` and `.html` for a single run
- [ ] Select each format, confirm `click.launch` opens correct file

🤖 Generated with [Claude Code](https://claude.com/claude-code)