### PR TITLE
Add Review Culture section to summary outputs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,19 @@ Run `ruff check .` to verify complexity.
 ## CI
 lint → test+coverage → security audit (pip-audit)
 
+## Before opening a PR
+
+Run these locally — they mirror the CI lint+test jobs. If any fail, fix before pushing:
+
+```bash
+uv run ruff check git_dev_metrics
+uv run ruff format --check git_dev_metrics
+uv run pyright
+uv run pytest
+```
+
+If `ruff format --check` reports drift, run `./scripts/format.sh` to apply formatting and re-stage the changed files. CI runs `ruff format --check` (no fix) and will fail on any drift.
+
 ## Privacy
 
 Never include individual developer identifiers (GitHub logins, real names, handles) in PR descriptions, commit messages, issues, or any committed file. This tool measures team aggregates and trends; per-person data stays out of source control. When illustrating impact, use anonymous labels (e.g. "dev A", "dev B") or aggregate stats only.

--- a/git_dev_metrics/cli/prompts.py
+++ b/git_dev_metrics/cli/prompts.py
@@ -86,8 +86,8 @@ def prompt_open_result(default_path: Path) -> None:
     """List recent result files, open the chosen one in the default app."""
     results_dir = default_path.parent
     files = sorted(
-        results_dir.glob("metrics_*.md"),
-        key=lambda p: p.stat().st_mtime,
+        (p for p in results_dir.glob("metrics_*") if p.suffix in {".md", ".html"}),
+        key=lambda p: (p.stat().st_mtime, p.suffix),
         reverse=True,
     )[:MAX_RESULT_FILES]
     if not files:

--- a/git_dev_metrics/metrics/printer/html_printer.py
+++ b/git_dev_metrics/metrics/printer/html_printer.py
@@ -63,7 +63,7 @@ def build_summary(metrics: dict) -> dict:
     top_reviewer = ""
     max_review_share = 0
     if total_reviews > 0 and dev_reviews:
-        top_reviewer = max(sorted(dev_reviews), key=dev_reviews.get)
+        top_reviewer = max(sorted(dev_reviews), key=lambda d: dev_reviews[d])
         max_review_share = round(dev_reviews[top_reviewer] / total_reviews * 100)
 
     return {

--- a/git_dev_metrics/metrics/printer/html_printer.py
+++ b/git_dev_metrics/metrics/printer/html_printer.py
@@ -58,8 +58,7 @@ def build_summary(metrics: dict) -> dict:
     total_reviews = int(team.get("reviews_given", 0))
 
     dev_reviews = {
-        dev: int(m.get("reviews_given", 0))
-        for dev, m in (metrics.get("dev_metrics") or {}).items()
+        dev: int(m.get("reviews_given", 0)) for dev, m in (metrics.get("dev_metrics") or {}).items()
     }
     top_reviewer = ""
     max_review_share = 0

--- a/git_dev_metrics/metrics/printer/html_printer.py
+++ b/git_dev_metrics/metrics/printer/html_printer.py
@@ -50,26 +50,34 @@ def _build_devs_list(metrics: dict) -> list[dict]:
 
 
 def build_summary(metrics: dict) -> dict:
-    """Compute summary stats across all devs for the summary cards.
-
-    Args:
-        metrics: Full metrics dict from get_combined_metrics.
-
-    Returns:
-        Dict with team_health, total_prs, avg_cycle, avg_pickup,
-        total_reviews, ai_adoption, avg_lines_per_pr.
-    """
+    """Compute summary stats across all devs for the summary cards."""
     all_dev_metrics = list(metrics.get("dev_metrics", {}).values())
     health_by_dev = [calculate_dev_health_score(d, all_dev_metrics) for d in all_dev_metrics]
     team = metrics.get("team_metrics") or {}
+    pr_count = int(team.get("pr_count", 0))
+    total_reviews = int(team.get("reviews_given", 0))
+
+    dev_reviews = {
+        dev: int(m.get("reviews_given", 0))
+        for dev, m in (metrics.get("dev_metrics") or {}).items()
+    }
+    top_reviewer = ""
+    max_review_share = 0
+    if total_reviews > 0 and dev_reviews:
+        top_reviewer = max(sorted(dev_reviews), key=dev_reviews.get)
+        max_review_share = round(dev_reviews[top_reviewer] / total_reviews * 100)
+
     return {
         "team_health": round(sum(health_by_dev) / len(health_by_dev)) if health_by_dev else 0,
-        "total_prs": int(team.get("pr_count", 0)),
+        "total_prs": pr_count,
         "median_cycle": round(team.get("cycle_time", 0), 1),
         "median_pickup": round(team.get("pickup_time", 0), 1),
-        "total_reviews": int(team.get("reviews_given", 0)),
+        "total_reviews": total_reviews,
         "ai_adoption": round(team.get("ai_percentage", 0)),
         "avg_lines_per_pr": round(team.get("avg_lines_per_pr", 0), 1),
+        "review_ratio": round(total_reviews / pr_count, 2) if pr_count else 0.0,
+        "top_reviewer": top_reviewer,
+        "max_review_share": max_review_share,
     }
 
 

--- a/git_dev_metrics/metrics/printer/printers.py
+++ b/git_dev_metrics/metrics/printer/printers.py
@@ -46,6 +46,17 @@ class ConsolePrinter(Printer):
         console.print(table)
         console.print()
 
+        review_table = Table(title=f"Review Culture ({date_range})")
+        for col in ("Review Ratio", "Top Reviewer", "Max Share"):
+            review_table.add_column(col)
+        review_table.add_row(
+            f"{summary['review_ratio']}x",
+            summary["top_reviewer"] or "—",
+            f"{summary['max_review_share']}%",
+        )
+        console.print(review_table)
+        console.print()
+
         self._dev_printer.print_combined_metrics(metrics, period, date_range)
 
 
@@ -69,6 +80,12 @@ class FilePrinter(Printer):
             f"- **Median Pickup Time:** {summary['median_pickup']}h",
             f"- **Total Reviews:** {summary['total_reviews']}",
             f"- **AI Adoption:** {summary['ai_adoption']}%",
+            "",
+            f"## Review Culture ({date_range})",
+            "",
+            f"- **Review Ratio:** {summary['review_ratio']}x",
+            f"- **Top Reviewer:** {summary['top_reviewer'] or '—'} "
+            f"({summary['max_review_share']}% of reviews)",
             "",
         ]
         self._write(lines)

--- a/git_dev_metrics/metrics/printer/templates/dashboard.html
+++ b/git_dev_metrics/metrics/printer/templates/dashboard.html
@@ -379,6 +379,16 @@
     <div class="value">{{ summary.ai_adoption }}%</div>
     <div class="sub">Share of all PRs</div>
   </div>
+  <div class="summary-card">
+    <div class="label">Review Ratio</div>
+    <div class="value">{{ summary.review_ratio }}x</div>
+    <div class="sub">Reviews per PR</div>
+  </div>
+  <div class="summary-card">
+    <div class="label">Top Reviewer</div>
+    <div class="value">{{ summary.top_reviewer or "—" }}</div>
+    <div class="sub">{{ summary.max_review_share }}% of reviews</div>
+  </div>
 </div>
 
 <div class="table-wrapper">

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -819,3 +819,72 @@ class TestBuildSummary:
         assert result["median_pickup"] == 0
         assert result["ai_adoption"] == 0
         assert result["avg_lines_per_pr"] == 0
+        assert result["review_ratio"] == 0.0
+        assert result["top_reviewer"] == ""
+        assert result["max_review_share"] == 0
+
+    def test_should_compute_review_ratio_from_team_totals(self):
+        from git_dev_metrics.metrics.printer.html_printer import build_summary
+
+        metrics = {
+            "dev_metrics": {"alice": {"reviews_given": 4}, "bob": {"reviews_given": 6}},
+            "team_metrics": {"pr_count": 5, "reviews_given": 10},
+        }
+        result = build_summary(metrics)
+
+        assert result["review_ratio"] == 2.0
+
+    def test_should_pick_top_reviewer_and_share(self):
+        from git_dev_metrics.metrics.printer.html_printer import build_summary
+
+        metrics = {
+            "dev_metrics": {
+                "alice": {"reviews_given": 3},
+                "bob": {"reviews_given": 7},
+            },
+            "team_metrics": {"pr_count": 5, "reviews_given": 10},
+        }
+        result = build_summary(metrics)
+
+        assert result["top_reviewer"] == "bob"
+        assert result["max_review_share"] == 70
+
+    def test_should_break_top_reviewer_ties_alphabetically(self):
+        from git_dev_metrics.metrics.printer.html_printer import build_summary
+
+        metrics = {
+            "dev_metrics": {
+                "carol": {"reviews_given": 5},
+                "alice": {"reviews_given": 5},
+                "bob": {"reviews_given": 5},
+            },
+            "team_metrics": {"pr_count": 5, "reviews_given": 15},
+        }
+        result = build_summary(metrics)
+
+        assert result["top_reviewer"] == "alice"
+        assert result["max_review_share"] == 33
+
+    def test_should_zero_review_culture_when_no_reviews(self):
+        from git_dev_metrics.metrics.printer.html_printer import build_summary
+
+        metrics = {
+            "dev_metrics": {"alice": {"reviews_given": 0}},
+            "team_metrics": {"pr_count": 4, "reviews_given": 0},
+        }
+        result = build_summary(metrics)
+
+        assert result["review_ratio"] == 0.0
+        assert result["top_reviewer"] == ""
+        assert result["max_review_share"] == 0
+
+    def test_should_zero_review_ratio_when_no_prs(self):
+        from git_dev_metrics.metrics.printer.html_printer import build_summary
+
+        metrics = {
+            "dev_metrics": {"alice": {"reviews_given": 2}},
+            "team_metrics": {"pr_count": 0, "reviews_given": 2},
+        }
+        result = build_summary(metrics)
+
+        assert result["review_ratio"] == 0.0


### PR DESCRIPTION
## Summary
- New "Review Culture" section in console (Rich table), markdown (`## Review Culture`), and HTML dashboard (two summary cards).
- Surfaces **Review Ratio** (team reviews / team PRs) and **Top Reviewer** with their **Max Share** of all reviews — the bus-factor signal.
- Min Review Ratio intentionally omitted (penalizes new joiners / part-time devs).
- Pure transformation of existing `team_metrics` and per-dev `reviews_given`; no new GitHub queries.
- Tiebreak for Top Reviewer is alphabetical.

Caveat: `SEARCH_MERGED_PRS_QUERY` caps reviews at 10 per PR, so heavy-review PRs still slightly undercount — same caveat already applies to the existing Total Reviews number.

## Test plan
- [x] `pytest tests/unit` — 150/150 pass, 5 new cases for `build_summary` (ratio, top reviewer, alpha tiebreak, no-reviews, no-PRs).
- [ ] Run CLI against a real org for last 30d — verify Review Ratio matches `Total Reviews / Total PRs` and Max Share matches top dev's row in the per-dev table.
- [ ] Open generated HTML — verify two new summary cards render and wrap cleanly at narrow widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)