### PR TITLE
Surface Max Review Share in summary across all outputs

### DIFF
--- a/git_dev_metrics/metrics/printer/printers.py
+++ b/git_dev_metrics/metrics/printer/printers.py
@@ -47,7 +47,7 @@ class ConsolePrinter(Printer):
         console.print()
 
         review_table = Table(title=f"Review Culture ({date_range})")
-        for col in ("Review Ratio", "Top Reviewer", "Max Share"):
+        for col in ("Review Ratio", "Top Reviewer", "Max Review Share"):
             review_table.add_column(col)
         review_table.add_row(
             f"{summary['review_ratio']}x",
@@ -84,8 +84,8 @@ class FilePrinter(Printer):
             f"## Review Culture ({date_range})",
             "",
             f"- **Review Ratio:** {summary['review_ratio']}x",
-            f"- **Top Reviewer:** {summary['top_reviewer'] or '—'} "
-            f"({summary['max_review_share']}% of reviews)",
+            f"- **Top Reviewer:** {summary['top_reviewer'] or '—'}",
+            f"- **Max Review Share:** {summary['max_review_share']}%",
             "",
         ]
         self._write(lines)

--- a/git_dev_metrics/metrics/printer/templates/dashboard.html
+++ b/git_dev_metrics/metrics/printer/templates/dashboard.html
@@ -387,7 +387,12 @@
   <div class="summary-card">
     <div class="label">Top Reviewer</div>
     <div class="value">{{ summary.top_reviewer or "—" }}</div>
-    <div class="sub">{{ summary.max_review_share }}% of reviews</div>
+    <div class="sub">Busiest reviewer</div>
+  </div>
+  <div class="summary-card">
+    <div class="label">Max Review Share</div>
+    <div class="value">{{ summary.max_review_share }}%</div>
+    <div class="sub">Reviews by top reviewer</div>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Promote **Max Review Share** (% of all reviews handled by the busiest reviewer) to a top-level summary metric so the bus-factor signal is visible everywhere
- Align console, markdown, and HTML to the same 10 summary metrics in the same order
- HTML gets a dedicated card; markdown gets its own line; console review-culture column renamed from "Max Share" to "Max Review Share"

## Test plan
- [x] `pytest` (152 passed)
- [x] `ruff check` / `ruff format --check`
- [ ] Eyeball generated `metrics_*.md` and `metrics_*.html` after a run