### PR TITLE
Fix Max Review Share divisor; collapse summary into single grid

### DIFF
--- a/git_dev_metrics/metrics/analyzer.py
+++ b/git_dev_metrics/metrics/analyzer.py
@@ -112,4 +112,5 @@ def get_combined_metrics(token: str, selected_repos: list[str], event_period: st
         "repo_metrics": repo_metrics,
         "dev_metrics": combined_dev_metrics,
         "team_metrics": team_metrics,
+        "reviewer_counts": all_reviews_given,
     }

--- a/git_dev_metrics/metrics/printer/html_printer.py
+++ b/git_dev_metrics/metrics/printer/html_printer.py
@@ -57,14 +57,17 @@ def build_summary(metrics: dict) -> dict:
     pr_count = int(team.get("pr_count", 0))
     total_reviews = int(team.get("reviews_given", 0))
 
-    dev_reviews = {
-        dev: int(m.get("reviews_given", 0)) for dev, m in (metrics.get("dev_metrics") or {}).items()
-    }
+    raw_counts = metrics.get("reviewer_counts")
+    if raw_counts is None:
+        raw_counts = {
+            dev: m.get("reviews_given", 0) for dev, m in (metrics.get("dev_metrics") or {}).items()
+        }
+    reviewer_counts = {r: int(c) for r, c in raw_counts.items() if c}
     top_reviewer = ""
     max_review_share = 0
-    if total_reviews > 0 and dev_reviews:
-        top_reviewer = max(sorted(dev_reviews), key=lambda d: dev_reviews[d])
-        max_review_share = round(dev_reviews[top_reviewer] / total_reviews * 100)
+    if total_reviews > 0 and reviewer_counts:
+        top_reviewer = max(sorted(reviewer_counts), key=lambda d: reviewer_counts[d])
+        max_review_share = round(reviewer_counts[top_reviewer] / total_reviews * 100)
 
     return {
         "team_health": round(sum(health_by_dev) / len(health_by_dev)) if health_by_dev else 0,

--- a/git_dev_metrics/metrics/printer/printers.py
+++ b/git_dev_metrics/metrics/printer/printers.py
@@ -21,40 +21,26 @@ class ConsolePrinter(Printer):
         console = Console()
 
         summary = build_summary(metrics)
-        table = Table(title=f"Summary ({date_range})")
-        for col in (
-            "Team Health",
-            "Total PRs",
-            "Mean Lines/PR",
-            "Median Cycle (h)",
-            "Median Pickup (h)",
-            "Reviews",
-            "AI",
-        ):
-            table.add_column(col)
-        table.add_row(
-            str(summary["team_health"]),
-            str(summary["total_prs"]),
-            str(summary["avg_lines_per_pr"]),
-            str(summary["median_cycle"]),
-            str(summary["median_pickup"]),
-            str(summary["total_reviews"]),
-            f"{summary['ai_adoption']}%",
-        )
+        table = Table(title=f"Summary ({date_range})", show_lines=False)
+        rows = [
+            ("Team Health", str(summary["team_health"])),
+            ("Total PRs", str(summary["total_prs"])),
+            ("Mean Lines/PR", str(summary["avg_lines_per_pr"])),
+            ("Median Cycle (h)", str(summary["median_cycle"])),
+            ("Median Pickup (h)", str(summary["median_pickup"])),
+            ("Total Reviews", str(summary["total_reviews"])),
+            ("AI Adoption", f"{summary['ai_adoption']}%"),
+            ("Review Ratio", f"{summary['review_ratio']}x"),
+            ("Top Reviewer", summary["top_reviewer"] or "—"),
+            ("Max Review Share", f"{summary['max_review_share']}%"),
+        ]
+        table.add_column("Metric")
+        table.add_column("Value")
+        for label, value in rows:
+            table.add_row(label, value)
 
         console.print()
         console.print(table)
-        console.print()
-
-        review_table = Table(title=f"Review Culture ({date_range})")
-        for col in ("Review Ratio", "Top Reviewer", "Max Review Share"):
-            review_table.add_column(col)
-        review_table.add_row(
-            f"{summary['review_ratio']}x",
-            summary["top_reviewer"] or "—",
-            f"{summary['max_review_share']}%",
-        )
-        console.print(review_table)
         console.print()
 
         self._dev_printer.print_combined_metrics(metrics, period, date_range)
@@ -80,9 +66,6 @@ class FilePrinter(Printer):
             f"- **Median Pickup Time:** {summary['median_pickup']}h",
             f"- **Total Reviews:** {summary['total_reviews']}",
             f"- **AI Adoption:** {summary['ai_adoption']}%",
-            "",
-            f"## Review Culture ({date_range})",
-            "",
             f"- **Review Ratio:** {summary['review_ratio']}x",
             f"- **Top Reviewer:** {summary['top_reviewer'] or '—'}",
             f"- **Max Review Share:** {summary['max_review_share']}%",

--- a/git_dev_metrics/metrics/printer/templates/dashboard.html
+++ b/git_dev_metrics/metrics/printer/templates/dashboard.html
@@ -49,12 +49,19 @@
 
   .summary {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    grid-template-columns: repeat(5, 1fr);
     gap: 1rem;
     margin-bottom: 2rem;
     max-width: 1400px;
     margin-left: auto;
     margin-right: auto;
+  }
+
+  @media (max-width: 1100px) {
+    .summary { grid-template-columns: repeat(3, 1fr); }
+  }
+  @media (max-width: 700px) {
+    .summary { grid-template-columns: repeat(2, 1fr); }
   }
 
   .summary-card {


### PR DESCRIPTION
## Summary
- **Bug:** Max Review Share numerator came from `dev_metrics` (PR authors only) while denominator came from `team_metrics` (all reviewers, incl. reviewer-only people). On real data this read 12% instead of the actual ~25%.
- Stash the full `reviewer_counts` dict on the metrics payload and read from it in `build_summary`.
- Console + markdown: collapse the separate Review Culture section into the main Summary so all 10 metrics live in one grid.
- HTML: lock the summary grid to 5 columns so cards lay out 2x5 on wide screens (3 / 2 cols on narrower).

## Test plan
- [x] `pytest` (152 passed)
- [x] `ruff check` / `ruff format`
- [ ] Re-run on a real org and confirm Max Review Share matches `top dev reviews / total team reviews`