### PR TITLE
Skip Copilot reviewer; lay summary out as two 5-col rows

### DIFF
--- a/git_dev_metrics/constants.py
+++ b/git_dev_metrics/constants.py
@@ -7,13 +7,19 @@ KNOWN_BOT_LOGINS: set[str] = {
     "github-actions",
     "pipx[bot]",
     "poetry[bot]",
+    "copilot-pull-request-reviewer",
+    "copilot-pull-request-reviewer[bot]",
+    "copilot",
+    "copilot[bot]",
 }
 
 
 def is_bot_login(login: str | None) -> bool:
-    """True for known bots and any login ending in -bot or [bot]."""
+    """True for known bots and any login ending in -bot, [bot], or matching common bot patterns."""
     if not login:
         return False
     if login in KNOWN_BOT_LOGINS:
         return True
-    return login.endswith("-bot") or login.endswith("[bot]")
+    if login.endswith("-bot") or login.endswith("[bot]"):
+        return True
+    return login.startswith("copilot-") and login.endswith("-reviewer")

--- a/git_dev_metrics/metrics/printer/printers.py
+++ b/git_dev_metrics/metrics/printer/printers.py
@@ -21,8 +21,7 @@ class ConsolePrinter(Printer):
         console = Console()
 
         summary = build_summary(metrics)
-        table = Table(title=f"Summary ({date_range})", show_lines=False)
-        rows = [
+        cells = [
             ("Team Health", str(summary["team_health"])),
             ("Total PRs", str(summary["total_prs"])),
             ("Mean Lines/PR", str(summary["avg_lines_per_pr"])),
@@ -34,13 +33,19 @@ class ConsolePrinter(Printer):
             ("Top Reviewer", summary["top_reviewer"] or "—"),
             ("Max Review Share", f"{summary['max_review_share']}%"),
         ]
-        table.add_column("Metric")
-        table.add_column("Value")
-        for label, value in rows:
-            table.add_row(label, value)
 
         console.print()
-        console.print(table)
+        for chunk_start in (0, 5):
+            chunk = cells[chunk_start : chunk_start + 5]
+            table = Table(
+                title=f"Summary ({date_range})" if chunk_start == 0 else None,
+                show_header=True,
+                header_style="bold",
+            )
+            for label, _ in chunk:
+                table.add_column(label, justify="left")
+            table.add_row(*(value for _, value in chunk))
+            console.print(table)
         console.print()
 
         self._dev_printer.print_combined_metrics(metrics, period, date_range)


### PR DESCRIPTION
## Summary
- Add `copilot-pull-request-reviewer` (and the `copilot-*-reviewer` pattern) to the bot allowlist. Because every reviewer-counting path goes through `calculate_reviews_given()` → `is_bot_login()`, this propagates to **Review Ratio**, **Max Review Share**, **Top Reviewer**, and the per-dev **Reviews** columns in console, markdown, and HTML — no per-output changes needed.
- Console summary: replace tall 2-column list with two 5-column tables. Easier to scan and matches the HTML 2x5 layout.

## Test plan
- [x] `pytest` (152 passed)
- [x] `ruff check` / `ruff format`
- [ ] Re-run on a real org and confirm Copilot no longer appears as Top Reviewer