### PR TITLE
Exclude draft window from cycle time

### DIFF
--- a/git_dev_metrics/github/graphql_queries.py
+++ b/git_dev_metrics/github/graphql_queries.py
@@ -93,6 +93,13 @@ REPO_METRICS_QUERY = gql.gql(
                             submittedAt
                         }
                     }
+                    timelineItems(itemTypes: [READY_FOR_REVIEW_EVENT], first: 1) {
+                        nodes {
+                            ... on ReadyForReviewEvent {
+                                createdAt
+                            }
+                        }
+                    }
                 }
                 pageInfo {
                     hasNextPage
@@ -170,6 +177,13 @@ SEARCH_MERGED_PRS_QUERY = gql.gql(
                             }
                             state
                             submittedAt
+                        }
+                    }
+                    timelineItems(itemTypes: [READY_FOR_REVIEW_EVENT], first: 1) {
+                        nodes {
+                            ... on ReadyForReviewEvent {
+                                createdAt
+                            }
                         }
                     }
                 }

--- a/git_dev_metrics/github/queries.py
+++ b/git_dev_metrics/github/queries.py
@@ -57,6 +57,12 @@ def _map_pull_request(pr: dict) -> PullRequest:
 
     commit_messages = [msg for c in commits if (msg := (c.get("commit") or {}).get("message"))]
 
+    timeline_nodes = (pr.get("timelineItems") or {}).get("nodes") or []
+    ready_for_review = next(
+        (_parse_datetime(n.get("createdAt")) for n in timeline_nodes if n.get("createdAt")),
+        None,
+    )
+
     return {  # type: ignore[return-value]
         "number": pr.get("number"),
         "title": pr.get("title"),
@@ -67,6 +73,7 @@ def _map_pull_request(pr: dict) -> PullRequest:
         "changed_files": pr.get("changedFiles", 0),
         "user": {"login": _author_login(pr.get("author"))},
         "first_commit_at": first_commit_date,
+        "ready_for_review_at": ready_for_review,
         "body": pr.get("body"),
         "commit_messages": commit_messages,
         "reviews": [],

--- a/git_dev_metrics/metrics/calculator.py
+++ b/git_dev_metrics/metrics/calculator.py
@@ -61,7 +61,7 @@ def median(values: list[float | int]) -> float:
 
 
 def calculate_cycle_time(prs: list[PullRequest]) -> float:
-    """Calculate median time from first commit/PR creation to merge (in hours)."""
+    """Median hours from first commit/PR open to merge, excluding any draft window."""
     if not prs:
         return 0.0
 
@@ -69,6 +69,7 @@ def calculate_cycle_time(prs: list[PullRequest]) -> float:
     for pr in prs:
         created = _to_datetime(pr["created_at"])
         first_commit = _to_datetime(pr.get("first_commit_at"))
+        ready_for_review = _to_datetime(pr.get("ready_for_review_at"))
         merged = _to_datetime(pr["merged_at"])
 
         if created is None or merged is None:
@@ -77,6 +78,8 @@ def calculate_cycle_time(prs: list[PullRequest]) -> float:
         start_time = created
         if first_commit is not None and first_commit < created:
             start_time = first_commit
+        if ready_for_review is not None and ready_for_review > start_time:
+            start_time = ready_for_review
 
         hours = (merged - start_time).total_seconds() / 3600
         cycle_times.append(hours)

--- a/git_dev_metrics/models/types.py
+++ b/git_dev_metrics/models/types.py
@@ -34,6 +34,7 @@ class PullRequest(PullRequestInfo):
     deletions: int
     changed_files: int
     first_commit_at: datetime | None
+    ready_for_review_at: datetime | None
     body: str | None
     commit_messages: list[str]
     reviews: list[Review]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -23,6 +23,7 @@ def any_pr(**overrides: Any) -> PullRequest:
         "deletions": 50,
         "changed_files": 5,
         "first_commit_at": None,
+        "ready_for_review_at": None,
         "body": None,
         "commit_messages": [],
         "reviews": [],

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -115,6 +115,33 @@ class TestCalculateCycleTime:
 
         assert result == 24.0
 
+    def test_should_exclude_draft_window_using_ready_for_review_at(self):
+        prs = [
+            any_pr(
+                created_at="2024-01-01T00:00:00Z",
+                ready_for_review_at="2024-01-04T00:00:00Z",
+                merged_at="2024-01-05T00:00:00Z",
+            ),
+        ]
+
+        result = calculate_cycle_time(prs)
+
+        assert result == 24.0
+
+    def test_should_ignore_ready_for_review_when_before_start_time(self):
+        prs = [
+            any_pr(
+                created_at="2024-01-02T00:00:00Z",
+                first_commit_at="2024-01-01T00:00:00Z",
+                ready_for_review_at="2023-12-31T00:00:00Z",
+                merged_at="2024-01-03T00:00:00Z",
+            ),
+        ]
+
+        result = calculate_cycle_time(prs)
+
+        assert result == 48.0
+
 
 class TestCalculatePrSize:
     """Test cases for calculate_pr_size function."""


### PR DESCRIPTION
## Summary
- Pull `ReadyForReviewEvent.createdAt` via GraphQL `timelineItems` on the merged-PR queries (`SEARCH_MERGED_PRS_QUERY` and `REPO_METRICS_QUERY`)
- Use it as the cycle-time start when later than first commit / PR creation, so time spent in draft no longer inflates cycle time
- PRs that were never drafted are unaffected — no event, fall back to existing `min(created_at, first_commit_at)` logic
- Edge: re-draft cycles after the first ready event are still counted (we only fetch the first event); rare and not worth the extra cost

## Test plan
- [x] `pytest` (154 passed; 2 new cycle-time tests)
- [x] `ruff check` / `ruff format`
- [ ] Re-run on a real org and confirm cycle times for known draft PRs drop