### PR TITLE
Aggregate team-level time metrics from per-dev medians

### DIFF
--- a/git_dev_metrics/metrics/analyzer.py
+++ b/git_dev_metrics/metrics/analyzer.py
@@ -13,6 +13,16 @@ from .calculator import (
     calculate_reviews_given,
     calculate_throughput,
     group_prs_by_devs,
+    median,
+)
+
+_PER_DEV_AGGREGATED_KEYS = (
+    "cycle_time",
+    "pickup_time",
+    "review_time",
+    "pr_size",
+    "avg_lines_per_pr",
+    "ai_percentage",
 )
 
 
@@ -107,6 +117,9 @@ def get_combined_metrics(token: str, selected_repos: list[str], event_period: st
     all_reviews_given = calculate_reviews_given(all_prs)
     combined_dev_metrics = _build_dev_metrics(all_devs, period_days, all_reviews_given)
     team_metrics = _build_metrics(all_prs, period_days)
+    for key in _PER_DEV_AGGREGATED_KEYS:
+        values = [m[key] for m in combined_dev_metrics.values() if m.get(key)]
+        team_metrics[key] = round(median(values), 2) if values else 0.0
 
     return {
         "repo_metrics": repo_metrics,

--- a/git_dev_metrics/metrics/calculator.py
+++ b/git_dev_metrics/metrics/calculator.py
@@ -61,7 +61,12 @@ def median(values: list[float | int]) -> float:
 
 
 def calculate_cycle_time(prs: list[PullRequest]) -> float:
-    """Median hours from first commit/PR open to merge, excluding any draft window."""
+    """Median hours from first commit/ready-for-review to merge for approved PRs.
+
+    Restricted to PRs that received at least one approval so the team-level
+    invariant pickup <= cycle holds. PRs merged without review (auto-merge,
+    owner override) are excluded.
+    """
     if not prs:
         return 0.0
 
@@ -74,6 +79,8 @@ def calculate_cycle_time(prs: list[PullRequest]) -> float:
 
         if created is None or merged is None:
             continue
+        if _first_approval_at(pr) is None:
+            continue
 
         start_time = created
         if first_commit is not None and first_commit < created:
@@ -84,6 +91,8 @@ def calculate_cycle_time(prs: list[PullRequest]) -> float:
         hours = (merged - start_time).total_seconds() / 3600
         cycle_times.append(hours)
 
+    if not cycle_times:
+        return 0.0
     return round(median(cycle_times), 2)
 
 
@@ -117,16 +126,21 @@ def _first_approval_at(pr: PullRequest) -> datetime | None:
 
 
 def calculate_pickup_time(prs: list[PullRequest]) -> float:
-    """Calculate median time from PR creation to first approval (in hours)."""
+    """Median hours from PR ready-for-review to first approval, excluding draft time."""
     if not prs:
         return 0.0
 
     pickup_times = []
     for pr in prs:
         created = _to_datetime(pr["created_at"])
+        ready_for_review = _to_datetime(pr.get("ready_for_review_at"))
         first_approval = _first_approval_at(pr)
-        if created and first_approval:
-            pickup_times.append((first_approval - created).total_seconds() / 3600)
+        if not (created and first_approval):
+            continue
+        start_time = created
+        if ready_for_review is not None and ready_for_review > start_time:
+            start_time = ready_for_review
+        pickup_times.append((first_approval - start_time).total_seconds() / 3600)
 
     if not pickup_times:
         return 0.0

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -29,3 +29,8 @@ def any_pr(**overrides: Any) -> PullRequest:
         "reviews": [],
     }
     return {**defaults, **overrides}  # type: ignore[return-value]
+
+
+def approved_review(submitted_at: str = "2024-01-01T12:00:00Z", login: str = "reviewer") -> dict:
+    """Approval review row for use in PullRequest fixtures."""
+    return {"user": {"login": login}, "state": "APPROVED", "submitted_at": submitted_at}

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -15,7 +15,7 @@ from git_dev_metrics.metrics import (
 from git_dev_metrics.metrics.analyzer import _parse_period_days
 from git_dev_metrics.models import OpenPullRequest
 
-from .conftest import any_pr
+from .conftest import any_pr, approved_review
 
 
 class TestMedian:
@@ -51,7 +51,13 @@ class TestCalculateCycleTime:
         assert result == 0.0
 
     def test_should_return_correct_cycle_time_for_single_pr(self):
-        prs = [any_pr(created_at="2024-01-01T00:00:00Z", merged_at="2024-01-02T00:00:00Z")]
+        prs = [
+            any_pr(
+                created_at="2024-01-01T00:00:00Z",
+                merged_at="2024-01-02T00:00:00Z",
+                reviews=[approved_review("2024-01-01T06:00:00Z")],
+            )
+        ]
 
         result = calculate_cycle_time(prs)
 
@@ -59,8 +65,16 @@ class TestCalculateCycleTime:
 
     def test_should_return_average_cycle_time_for_multiple_prs(self):
         prs = [
-            any_pr(created_at="2024-01-01T00:00:00Z", merged_at="2024-01-02T00:00:00Z"),
-            any_pr(created_at="2024-01-01T00:00:00Z", merged_at="2024-01-03T00:00:00Z"),
+            any_pr(
+                created_at="2024-01-01T00:00:00Z",
+                merged_at="2024-01-02T00:00:00Z",
+                reviews=[approved_review("2024-01-01T06:00:00Z")],
+            ),
+            any_pr(
+                created_at="2024-01-01T00:00:00Z",
+                merged_at="2024-01-03T00:00:00Z",
+                reviews=[approved_review("2024-01-01T06:00:00Z")],
+            ),
         ]
 
         result = calculate_cycle_time(prs)
@@ -69,7 +83,11 @@ class TestCalculateCycleTime:
 
     def test_should_handle_prs_with_different_time_zones(self):
         prs = [
-            any_pr(created_at="2024-01-01T12:00:00Z", merged_at="2024-01-02T12:00:00Z"),
+            any_pr(
+                created_at="2024-01-01T12:00:00Z",
+                merged_at="2024-01-02T12:00:00Z",
+                reviews=[approved_review("2024-01-01T18:00:00Z")],
+            ),
         ]
 
         result = calculate_cycle_time(prs)
@@ -82,6 +100,7 @@ class TestCalculateCycleTime:
                 created_at="2024-01-02T00:00:00Z",
                 merged_at="2024-01-03T00:00:00Z",
                 first_commit_at="2024-01-01T00:00:00Z",
+                reviews=[approved_review("2024-01-02T12:00:00Z")],
             ),
         ]
 
@@ -95,6 +114,7 @@ class TestCalculateCycleTime:
                 created_at="2024-01-01T00:00:00Z",
                 merged_at="2024-01-03T00:00:00Z",
                 first_commit_at="2024-01-02T00:00:00Z",
+                reviews=[approved_review("2024-01-02T12:00:00Z")],
             ),
         ]
 
@@ -108,6 +128,7 @@ class TestCalculateCycleTime:
                 created_at="2024-01-01T00:00:00Z",
                 merged_at="2024-01-02T00:00:00Z",
                 first_commit_at=None,
+                reviews=[approved_review("2024-01-01T06:00:00Z")],
             ),
         ]
 
@@ -121,6 +142,7 @@ class TestCalculateCycleTime:
                 created_at="2024-01-01T00:00:00Z",
                 ready_for_review_at="2024-01-04T00:00:00Z",
                 merged_at="2024-01-05T00:00:00Z",
+                reviews=[approved_review("2024-01-04T12:00:00Z")],
             ),
         ]
 
@@ -135,12 +157,26 @@ class TestCalculateCycleTime:
                 first_commit_at="2024-01-01T00:00:00Z",
                 ready_for_review_at="2023-12-31T00:00:00Z",
                 merged_at="2024-01-03T00:00:00Z",
+                reviews=[approved_review("2024-01-02T12:00:00Z")],
             ),
         ]
 
         result = calculate_cycle_time(prs)
 
         assert result == 48.0
+
+    def test_should_skip_prs_without_approval(self):
+        prs = [
+            any_pr(
+                created_at="2024-01-01T00:00:00Z",
+                merged_at="2024-01-02T00:00:00Z",
+                reviews=[],
+            ),
+        ]
+
+        result = calculate_cycle_time(prs)
+
+        assert result == 0.0
 
 
 class TestCalculatePrSize:
@@ -275,6 +311,19 @@ class TestCalculatePickupTime:
         ]
         result = calculate_pickup_time(prs)
         assert result == 12.0
+
+    def test_should_exclude_draft_window_from_pickup(self):
+        prs = [
+            any_pr(
+                number=1,
+                created_at="2024-01-01T00:00:00Z",
+                ready_for_review_at="2024-01-04T00:00:00Z",
+                merged_at="2024-01-05T00:00:00Z",
+                reviews=[approved_review("2024-01-04T06:00:00Z")],
+            )
+        ]
+        result = calculate_pickup_time(prs)
+        assert result == 6.0
 
 
 class TestCalculateReviewTime:
@@ -807,6 +856,76 @@ class TestCalculateAiPercentage:
         ]
         result = calculate_ai_percentage(prs)
         assert result == 50.0
+
+
+class TestTeamAggregation:
+    """Combined metrics aggregate per-dev medians for time-based team stats."""
+
+    def test_should_use_median_of_dev_medians_for_time_metrics(self, mocker):
+        from git_dev_metrics.metrics.analyzer import get_combined_metrics
+
+        # heavy author: 3 PRs with cycle ~ 100h
+        # lean author: 1 PR with cycle ~ 1h
+        # PR-level median = 100h (volume-weighted), dev-level median = 50.5h
+        heavy = [
+            any_pr(
+                number=i,
+                user={"login": "kobbi"},
+                created_at="2024-01-01T00:00:00Z",
+                merged_at=f"2024-01-0{5 + i}T00:00:00Z",  # 4-6 days
+                reviews=[approved_review("2024-01-01T06:00:00Z")],
+            )
+            for i in range(1, 4)
+        ]
+        lean = [
+            any_pr(
+                number=10,
+                user={"login": "alice"},
+                created_at="2024-01-01T00:00:00Z",
+                merged_at="2024-01-01T01:00:00Z",
+                reviews=[approved_review("2024-01-01T00:30:00Z")],
+            )
+        ]
+        mocker.patch(
+            "git_dev_metrics.metrics.analyzer.fetch_repo_metrics",
+            return_value=heavy + lean,
+        )
+        mocker.patch(
+            "git_dev_metrics.metrics.analyzer.parse_time_period",
+            return_value=mocker.MagicMock(),
+        )
+
+        result = get_combined_metrics(token="t", selected_repos=["org/repo"])
+
+        team = result["team_metrics"]
+        kobbi_cycle = result["dev_metrics"]["kobbi"]["cycle_time"]
+        alice_cycle = result["dev_metrics"]["alice"]["cycle_time"]
+        # team cycle is the median of the two dev cycle medians, not pulled by PR volume
+        assert team["cycle_time"] == round((kobbi_cycle + alice_cycle) / 2, 2)
+        assert team["pr_count"] == 4  # counts stay sum-based
+
+    def test_should_keep_pickup_le_cycle_at_team_level(self, mocker):
+        from git_dev_metrics.metrics.analyzer import get_combined_metrics
+
+        prs = [
+            any_pr(
+                number=1,
+                user={"login": "dev"},
+                created_at="2024-01-01T00:00:00Z",
+                ready_for_review_at="2024-01-04T00:00:00Z",
+                merged_at="2024-01-05T00:00:00Z",
+                reviews=[approved_review("2024-01-04T12:00:00Z")],
+            )
+        ]
+        mocker.patch("git_dev_metrics.metrics.analyzer.fetch_repo_metrics", return_value=prs)
+        mocker.patch(
+            "git_dev_metrics.metrics.analyzer.parse_time_period",
+            return_value=mocker.MagicMock(),
+        )
+
+        result = get_combined_metrics(token="t", selected_repos=["org/repo"])
+
+        assert result["team_metrics"]["pickup_time"] <= result["team_metrics"]["cycle_time"]
 
 
 class TestBuildSummary:


### PR DESCRIPTION
## Summary

Three related fixes for skewed team summary numbers when one author dominates volume (sandbox repos, bot-like accounts):

1. **Pickup time** now subtracts the draft window: starts at `max(created_at, ready_for_review_at)`, matching cycle time. Previously a PR that sat 3 days in draft showed a 3-day pickup.

2. **Cycle time** is restricted to PRs that received at least one approval. PRs auto-merged or merged without review are excluded, so the per-PR invariant `pickup ≤ cycle` holds. **Heads up:** for teams with many no-review merges this will shift cycle medians upward — that's the intended, more honest number.

3. **Team-level** cycle, pickup, review, pr_size, avg_lines_per_pr, and ai_percentage now aggregate as **median of per-dev medians** rather than median across all PRs. A single high-volume author (or sandbox repo) can no longer dominate the team summary. Counts (total PRs, total reviews, AI adoption based on counts) stay sum-based.

### Industry standard?

DORA / LinearB / Athenian report PR-level medians by default. Switching to median-of-dev-medians at the team level is a deliberate choice — it weights every contributor equally, which matches the intuition the user expressed when they noticed kobbikobb's 264 sandbox PRs were dragging the team review ratio down to 0.75. The dev table still shows PR-level per-dev medians, so the underlying data is preserved.

### Out of scope (worth a follow-up)

- Sandbox repo / author exclusion list (would also help review ratio).
- Surface both PR-level and dev-level team aggregates side-by-side so users can see the spread.

## Test plan
- [x] `pytest` (158 passed, 2 new analyzer tests covering median-of-dev-medians and pickup ≤ cycle invariant)
- [x] `ruff check` / `ruff format`
- [ ] Re-run on the kobbikobb-heavy dataset; expect cycle/pickup to look more like the team's typical PR rather than the heavy author's.