### PR TITLE
Group related metrics together in summary and dev tables

### DIFF
--- a/git_dev_metrics/metrics/printer/dev.py
+++ b/git_dev_metrics/metrics/printer/dev.py
@@ -5,13 +5,13 @@ from ..health import calculate_dev_health_score, format_health, get_health_color
 DEV_COLUMNS = [
     "Dev",
     "Health",
+    "Total PRs",
+    "PRs/Week",
+    "PR Size",
+    "Avg Lines/PR",
     "Pickup Time (h)",
     "Review Time (h)",
     "Cycle Time (h)",
-    "PR Size",
-    "Avg Lines/PR",
-    "Total PRs",
-    "PRs/Week",
     "Reviews Given",
     "AI",
 ]
@@ -48,13 +48,13 @@ class ConsoleDevPrinter:
             table.add_row(
                 dev,
                 f"[{color}]{format_health(health)}[/{color}]",
+                f"{m['pr_count']:.0f}",
+                f"{m['prs_per_week']:.2f}",
+                f"{m['pr_size']:.1f}",
+                f"{m.get('avg_lines_per_pr', 0):.1f}",
                 f"{m['pickup_time']:.2f}",
                 f"{m['review_time']:.2f}",
                 f"{m['cycle_time']:.2f}",
-                f"{m['pr_size']:.1f}",
-                f"{m.get('avg_lines_per_pr', 0):.1f}",
-                f"{m['pr_count']:.0f}",
-                f"{m['prs_per_week']:.2f}",
                 f"{m['reviews_given']:.0f}",
                 f"{m['ai_percentage']:.0f}%",
             )
@@ -72,12 +72,12 @@ class FileDevPrinter:
         self, metrics: dict, period: str, date_range: str | None = None
     ) -> None:
         header = (
-            "| Dev | Health | Pickup Time (h) | Review Time (h) | Cycle Time (h) | "
-            "PR Size | Avg Lines/PR | Total PRs | PRs/Week | Reviews Given | AI |"
+            "| Dev | Health | Total PRs | PRs/Week | PR Size | Avg Lines/PR | "
+            "Pickup Time (h) | Review Time (h) | Cycle Time (h) | Reviews Given | AI |"
         )
         separator = (
-            "|------|--------|------------------|-----------------|----------------|"
-            "---------|--------------|-----------|-----------|---------------|-----|"
+            "|------|--------|-----------|-----------|---------|--------------|"
+            "------------------|-----------------|----------------|---------------|-----|"
         )
         title = (
             f"# Developer Metrics ({date_range})"
@@ -103,11 +103,11 @@ class FileDevPrinter:
             else:
                 emoji = "❌"
             row = (
-                f"| {dev} | {emoji}{health} | {m['pickup_time']:.2f} | "
-                f"{m['review_time']:.2f} | {m['cycle_time']:.2f} | {m['pr_size']:.1f} | "
-                f"{m.get('avg_lines_per_pr', 0):.1f} | "
-                f"{m['pr_count']:.0f} | {m['prs_per_week']:.2f} | {m['reviews_given']:.0f} | "
-                f"{m['ai_percentage']:.0f}% |"
+                f"| {dev} | {emoji}{health} | "
+                f"{m['pr_count']:.0f} | {m['prs_per_week']:.2f} | "
+                f"{m['pr_size']:.1f} | {m.get('avg_lines_per_pr', 0):.1f} | "
+                f"{m['pickup_time']:.2f} | {m['review_time']:.2f} | {m['cycle_time']:.2f} | "
+                f"{m['reviews_given']:.0f} | {m['ai_percentage']:.0f}% |"
             )
             lines.append(row)
 

--- a/git_dev_metrics/metrics/printer/printers.py
+++ b/git_dev_metrics/metrics/printer/printers.py
@@ -25,15 +25,15 @@ class ConsolePrinter(Printer):
         cells = [
             ("Team Health", str(summary["team_health"])),
             ("Total PRs", str(summary["total_prs"])),
-            ("Median Lines/PR", str(summary["median_lines_per_pr"])),
-            ("Median Cycle (h)", str(summary["median_cycle"])),
-            ("Median Pickup (h)", str(summary["median_pickup"])),
             ("PRs/Week per Dev", str(summary["median_prs_per_week"])),
+            ("Median Lines/PR", str(summary["median_lines_per_pr"])),
+            ("Median Pickup (h)", str(summary["median_pickup"])),
+            ("Median Cycle (h)", str(summary["median_cycle"])),
             ("Total Reviews", str(summary["total_reviews"])),
-            ("AI Adoption", f"{summary['ai_adoption']}%"),
             ("Review Ratio", f"{summary['review_ratio']}x"),
             ("Top Reviewer", summary["top_reviewer"] or "—"),
             ("Max Review Share", f"{summary['max_review_share']}%"),
+            ("AI Adoption", f"{summary['ai_adoption']}%"),
         ]
 
         console.print()
@@ -69,15 +69,15 @@ class FilePrinter(Printer):
             "",
             f"- **Team Health:** {summary['team_health']}",
             f"- **Total PRs:** {summary['total_prs']}",
-            f"- **Median Lines/PR:** {summary['median_lines_per_pr']}",
-            f"- **Median Cycle Time:** {summary['median_cycle']}h",
-            f"- **Median Pickup Time:** {summary['median_pickup']}h",
             f"- **PRs/Week per Dev:** {summary['median_prs_per_week']}",
+            f"- **Median Lines/PR:** {summary['median_lines_per_pr']}",
+            f"- **Median Pickup Time:** {summary['median_pickup']}h",
+            f"- **Median Cycle Time:** {summary['median_cycle']}h",
             f"- **Total Reviews:** {summary['total_reviews']}",
-            f"- **AI Adoption:** {summary['ai_adoption']}%",
             f"- **Review Ratio:** {summary['review_ratio']}x",
             f"- **Top Reviewer:** {summary['top_reviewer'] or '—'}",
             f"- **Max Review Share:** {summary['max_review_share']}%",
+            f"- **AI Adoption:** {summary['ai_adoption']}%",
             "",
         ]
         self._write(lines)

--- a/git_dev_metrics/metrics/printer/repo.py
+++ b/git_dev_metrics/metrics/printer/repo.py
@@ -5,13 +5,13 @@ from ..health import calculate_health_score
 REPO_COLUMNS = [
     "Repo",
     "Health",
+    "Total PRs",
+    "PRs/Week",
+    "PR Size",
+    "Avg Lines/PR",
     "Pickup Time (h)",
     "Review Time (h)",
     "Cycle Time (h)",
-    "PR Size",
-    "Avg Lines/PR",
-    "Total PRs",
-    "PRs/Week",
     "Reviews Given",
     "AI",
 ]
@@ -27,12 +27,12 @@ class FileRepoPrinter:
         self, metrics: dict, period: str, date_range: str | None = None
     ) -> None:
         header = (
-            "| Repo | Health | Pickup Time (h) | Review Time (h) | Cycle Time (h) | "
-            "PR Size | Avg Lines/PR | Total PRs | PRs/Week | Reviews Given | AI |"
+            "| Repo | Health | Total PRs | PRs/Week | PR Size | Avg Lines/PR | "
+            "Pickup Time (h) | Review Time (h) | Cycle Time (h) | Reviews Given | AI |"
         )
         separator = (
-            "|------|--------|------------------|-----------------|----------------|"
-            "---------|--------------|-----------|-----------|---------------|-----|"
+            "|------|--------|-----------|-----------|---------|--------------|"
+            "------------------|-----------------|----------------|---------------|-----|"
         )
         title = (
             f"# Repo Metrics ({date_range})" if date_range else (f"# Repo Metrics (last {period})")
@@ -58,11 +58,11 @@ class FileRepoPrinter:
             else:
                 emoji = "❌"
             row = (
-                f"| {repo_name} | {emoji}{health} | {m['pickup_time']:.2f} | "
-                f"{m['review_time']:.2f} | {m['cycle_time']:.2f} | {m['pr_size']:.1f} | "
-                f"{m.get('avg_lines_per_pr', 0):.1f} | "
-                f"{m['pr_count']:.0f} | {m['prs_per_week']:.2f} | {m['reviews_given']:.0f} | "
-                f"{m['ai_percentage']:.0f}% |"
+                f"| {repo_name} | {emoji}{health} | "
+                f"{m['pr_count']:.0f} | {m['prs_per_week']:.2f} | "
+                f"{m['pr_size']:.1f} | {m.get('avg_lines_per_pr', 0):.1f} | "
+                f"{m['pickup_time']:.2f} | {m['review_time']:.2f} | {m['cycle_time']:.2f} | "
+                f"{m['reviews_given']:.0f} | {m['ai_percentage']:.0f}% |"
             )
             lines.append(row)
 

--- a/git_dev_metrics/metrics/printer/templates/dashboard.html
+++ b/git_dev_metrics/metrics/printer/templates/dashboard.html
@@ -365,13 +365,13 @@
     <div class="sub">Across all devs</div>
   </div>
   <div class="summary-card">
-    <div class="label">Median Lines/PR</div>
-    <div class="value">{{ summary.median_lines_per_pr }}</div>
-    <div class="sub">Median of dev medians</div>
+    <div class="label">PRs/Week per Dev</div>
+    <div class="value">{{ summary.median_prs_per_week }}</div>
+    <div class="sub">Median of dev rates</div>
   </div>
   <div class="summary-card">
-    <div class="label">Median Cycle Time</div>
-    <div class="value">{{ summary.median_cycle }}h</div>
+    <div class="label">Median Lines/PR</div>
+    <div class="value">{{ summary.median_lines_per_pr }}</div>
     <div class="sub">Median of dev medians</div>
   </div>
   <div class="summary-card">
@@ -380,19 +380,14 @@
     <div class="sub">Median of dev medians</div>
   </div>
   <div class="summary-card">
-    <div class="label">PRs/Week per Dev</div>
-    <div class="value">{{ summary.median_prs_per_week }}</div>
-    <div class="sub">Median of dev rates</div>
+    <div class="label">Median Cycle Time</div>
+    <div class="value">{{ summary.median_cycle }}h</div>
+    <div class="sub">Median of dev medians</div>
   </div>
   <div class="summary-card">
     <div class="label">Reviews Given</div>
     <div class="value">{{ summary.total_reviews }}</div>
     <div class="sub">Total team reviews</div>
-  </div>
-  <div class="summary-card">
-    <div class="label">AI Adoption</div>
-    <div class="value">{{ summary.ai_adoption }}%</div>
-    <div class="sub">Share of all PRs</div>
   </div>
   <div class="summary-card">
     <div class="label">Review Ratio</div>
@@ -408,6 +403,11 @@
     <div class="label">Max Review Share</div>
     <div class="value">{{ summary.max_review_share }}%</div>
     <div class="sub">Reviews by top reviewer</div>
+  </div>
+  <div class="summary-card">
+    <div class="label">AI Adoption</div>
+    <div class="value">{{ summary.ai_adoption }}%</div>
+    <div class="sub">Share of all PRs</div>
   </div>
 </div>
 
@@ -468,12 +468,12 @@ const columns = [
     const cls = v >= 100 ? "health-100" : v >= 90 ? "health-90" : v >= 85 ? "health-85" : "health-0";
     return `<span class="health-badge ${cls}"><span class="health-dot"></span>${v}</span>`;
   }},
+  { key:"prs", label:"Total PRs", fmt: v => v },
+  { key:"prsWeek", label:"PRs/Week", fmt: v => v.toFixed(1) },
+  { key:"size", label:"PR Size", fmt: v => v.toLocaleString() },
   { key:"pickup", label:"Pickup (h)", fmt: (v,d) => timeBar(v, 20, "#6366f1") },
   { key:"review", label:"Review (h)", fmt: (v,d) => timeBar(v, 15, "#3b82f6") },
   { key:"cycle", label:"Cycle (h)", fmt: (v,d) => timeBar(v, 25, "#06b6d4") },
-  { key:"size", label:"PR Size", fmt: v => v.toLocaleString() },
-  { key:"prs", label:"Total PRs", fmt: v => v },
-  { key:"prsWeek", label:"PRs/Week", fmt: v => v.toFixed(1) },
   { key:"reviews", label:"Reviews", fmt: v => v },
   { key:"ai", label:"AI %", fmt: v => {
     const cls = v >= 60 ? "ai-high" : v > 0 ? "ai-med" : "ai-low";


### PR DESCRIPTION
## Summary

Pure reordering — no metric added or removed, no math change. Columns now sit next to the metrics they relate to in console, markdown, and HTML.

**Summary (left → right):**
- Volume: Team Health, Total PRs, PRs/Week per Dev, Median Lines/PR
- Speed: Median Pickup, Median Cycle
- Collaboration: Total Reviews, Review Ratio, Top Reviewer, Max Review Share
- Tooling: AI Adoption

**Dev / Repo tables:**
- Identity + score: Dev/Repo, Health
- Volume: Total PRs, PRs/Week, PR Size, Avg Lines/PR
- Speed: Pickup, Review, Cycle
- Collaboration: Reviews Given
- Tooling: AI

## Test plan
- [x] `pytest` (158 passed)
- [x] `ruff check` / `ruff format`
- [ ] Eyeball console / md / html outputs side by side