### PR TITLE
AI Adoption: switch to mean and add per-dev dot strip

### DIFF
--- a/git_dev_metrics/metrics/analyzer.py
+++ b/git_dev_metrics/metrics/analyzer.py
@@ -22,7 +22,6 @@ _PER_DEV_AGGREGATED_KEYS = (
     "review_time",
     "pr_size",
     "avg_lines_per_pr",
-    "ai_percentage",
     "prs_per_week",
 )
 
@@ -121,6 +120,8 @@ def get_combined_metrics(token: str, selected_repos: list[str], event_period: st
     for key in _PER_DEV_AGGREGATED_KEYS:
         values = [m[key] for m in combined_dev_metrics.values() if m.get(key)]
         team_metrics[key] = round(median(values), 2) if values else 0.0
+    ai_values = [m["ai_percentage"] for m in combined_dev_metrics.values()]
+    team_metrics["ai_percentage"] = round(sum(ai_values) / len(ai_values), 1) if ai_values else 0.0
 
     return {
         "repo_metrics": repo_metrics,

--- a/git_dev_metrics/metrics/printer/templates/dashboard.html
+++ b/git_dev_metrics/metrics/printer/templates/dashboard.html
@@ -212,6 +212,24 @@
   .ai-med { background: rgba(139,92,246,0.08); color: #c4b5fd; }
   .ai-low { background: rgba(99,102,241,0.06); color: var(--muted); }
 
+  .ai-strip {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 3px;
+    margin-top: 0.5rem;
+  }
+
+  .ai-strip-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    cursor: default;
+  }
+
+  .ai-strip-high { background: #a78bfa; }
+  .ai-strip-mid  { background: #c4b5fd; }
+  .ai-strip-low  { background: var(--border); }
+
   .time-cell {
     display: flex;
     align-items: center;
@@ -392,7 +410,15 @@
   <div class="summary-card">
     <div class="label">AI Adoption</div>
     <div class="value">{{ summary.ai_adoption }}%</div>
-    <div class="sub">Share of all PRs</div>
+    <div class="sub">Mean of dev rates</div>
+    <div class="ai-strip">
+      {% for pct in summary.ai_per_dev %}
+      <span
+        class="ai-strip-dot {% if pct >= 80 %}ai-strip-high{% elif pct >= 50 %}ai-strip-mid{% else %}ai-strip-low{% endif %}"
+        title="{{ pct }}%"
+      ></span>
+      {% endfor %}
+    </div>
   </div>
   <div class="summary-card">
     <div class="label">Review Ratio</div>

--- a/git_dev_metrics/metrics/summary.py
+++ b/git_dev_metrics/metrics/summary.py
@@ -21,6 +21,10 @@ def build_summary(metrics: dict) -> dict:
         top_reviewer = max(sorted(reviewer_counts), key=lambda d: reviewer_counts[d])
         max_review_share = round(reviewer_counts[top_reviewer] / total_reviews * 100)
 
+    ai_per_dev = sorted(
+        int(m.get("ai_percentage", 0)) for m in (metrics.get("dev_metrics") or {}).values()
+    )
+
     return {
         "team_health": round(sum(health_by_dev) / len(health_by_dev)) if health_by_dev else 0,
         "total_prs": pr_count,
@@ -28,6 +32,7 @@ def build_summary(metrics: dict) -> dict:
         "median_pickup": round(team.get("pickup_time", 0), 1),
         "total_reviews": total_reviews,
         "ai_adoption": round(team.get("ai_percentage", 0)),
+        "ai_per_dev": ai_per_dev,
         "median_lines_per_pr": round(team.get("pr_size", 0), 1),
         "median_prs_per_week": round(team.get("prs_per_week", 0), 2),
         "review_ratio": round(total_reviews / pr_count, 2) if pr_count else 0.0,

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -927,6 +927,34 @@ class TestTeamAggregation:
 
         assert result["team_metrics"]["pickup_time"] <= result["team_metrics"]["cycle_time"]
 
+    def test_should_use_mean_of_dev_rates_for_ai_adoption(self, mocker):
+        from git_dev_metrics.metrics.analyzer import get_combined_metrics
+
+        # alice 100% AI, bob 40% AI -> mean 70, median 70 (only with 2 devs both
+        # match). Use 3 devs to differentiate: 100, 40, 40 -> mean 60, median 40.
+        prs = []
+        for login, count, ai_count in [("alice", 5, 5), ("bob", 5, 2), ("carol", 5, 2)]:
+            for i in range(count):
+                prs.append(
+                    any_pr(
+                        number=f"{login}-{i}",
+                        user={"login": login},
+                        created_at="2024-01-01T00:00:00Z",
+                        merged_at="2024-01-02T00:00:00Z",
+                        reviews=[approved_review("2024-01-01T06:00:00Z")],
+                        body="Co-Authored-By: Claude" if i < ai_count else "",
+                    )
+                )
+        mocker.patch("git_dev_metrics.metrics.analyzer.fetch_repo_metrics", return_value=prs)
+        mocker.patch(
+            "git_dev_metrics.metrics.analyzer.parse_time_period",
+            return_value=mocker.MagicMock(),
+        )
+
+        result = get_combined_metrics(token="t", selected_repos=["org/repo"])
+
+        assert result["team_metrics"]["ai_percentage"] == 60.0
+
 
 class TestBuildSummary:
     """Test cases for build_summary reading team_metrics."""
@@ -971,6 +999,22 @@ class TestBuildSummary:
         assert result["review_ratio"] == 0.0
         assert result["top_reviewer"] == ""
         assert result["max_review_share"] == 0
+        assert result["ai_per_dev"] == []
+
+    def test_should_emit_sorted_ai_per_dev(self):
+        from git_dev_metrics.metrics.summary import build_summary
+
+        metrics = {
+            "dev_metrics": {
+                "alice": {"ai_percentage": 90, "reviews_given": 0},
+                "bob": {"ai_percentage": 40, "reviews_given": 0},
+                "carol": {"ai_percentage": 100, "reviews_given": 0},
+            },
+            "team_metrics": {"pr_count": 3, "reviews_given": 0},
+        }
+        result = build_summary(metrics)
+
+        assert result["ai_per_dev"] == [40, 90, 100]
 
     def test_should_compute_review_ratio_from_team_totals(self):
         from git_dev_metrics.metrics.summary import build_summary


### PR DESCRIPTION
## Summary

Three PM personas (data-accuracy, EM, exec) all landed on the same recommendation: AI Adoption should use **mean of per-dev rates**, not median.

**Why mean for AI specifically:**
- AI% is bounded 0–100, no long tail. Median's outlier protection isn't earning its keep.
- Median hides bimodal splits — a team where half the devs sit at 40% and half at 90% looks like 87% under median (saturated). Mean gives 65% (the actual story).
- AI adoption is a *coverage* metric ("are engineers using AI"), not a typical-dev metric. Mean makes every dev count.
- Other team metrics still use median where it earns its keep (cycle, pickup, review, lines, throughput) — those have long tails or one-heavy-author skew.

**Dot strip:** the HTML AI card now shows a per-dev distribution as 8px dots, sorted ascending and colored by adoption tier (low / mid / high). Reveals bimodal splits at a glance without adding a new chart.

## Test plan
- [x] `pytest` (160 passed; 2 new tests covering mean-of-dev-rates and `ai_per_dev` ordering)
- [x] `ruff check` / `ruff format`
- [ ] Re-run on the kobbikobb dataset and confirm AI drops from 87% to ~73% with a clearly bimodal dot strip