### PR TITLE
Add --anonymize flag for safe team sharing

### DIFF
--- a/git_dev_metrics/cli/analyze.py
+++ b/git_dev_metrics/cli/analyze.py
@@ -13,6 +13,11 @@ def analyze(
     repo: str | None = typer.Option(None, "--repo", help="GitHub repository name"),
     period: str | None = typer.Option(None, "--period", help="Time period (e.g., 30d, 7d, 90d)"),
     output: Path | None = typer.Option(None, help="Output file path"),
+    anonymize: bool = typer.Option(
+        False,
+        "--anonymize",
+        help="Replace dev names with dev-1, dev-2, ... for safe team sharing",
+    ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show full error tracebacks"),
     log_level: str = typer.Option(
         "WARNING", "--log-level", help="Logging level (DEBUG, INFO, WARNING, ERROR)"
@@ -24,7 +29,7 @@ def analyze(
         format="%(levelname)s: %(message)s",
     )
     try:
-        run_analyze(output=output, org=org, repo=repo, period=period)
+        run_analyze(output=output, org=org, repo=repo, period=period, anonymize=anonymize)
     except AnalysisError as e:
         logger.error("Analysis failed: %s", e)
         if verbose:

--- a/git_dev_metrics/cli/app.py
+++ b/git_dev_metrics/cli/app.py
@@ -10,7 +10,15 @@ app = typer.Typer()
 def main(ctx: typer.Context) -> None:
     """Git development metrics CLI."""
     if ctx.invoked_subcommand is None:
-        analyze(org=None, repo=None, period=None, output=None, verbose=False, log_level="WARNING")
+        analyze(
+            org=None,
+            repo=None,
+            period=None,
+            output=None,
+            anonymize=False,
+            verbose=False,
+            log_level="WARNING",
+        )
 
 
 app.command()(analyze)

--- a/git_dev_metrics/cli/app.py
+++ b/git_dev_metrics/cli/app.py
@@ -7,7 +7,14 @@ app = typer.Typer()
 
 
 @app.callback(invoke_without_command=True)
-def main(ctx: typer.Context) -> None:
+def main(
+    ctx: typer.Context,
+    anonymize: bool = typer.Option(
+        False,
+        "--anonymize",
+        help="Replace dev names with dev-1, dev-2, ... for safe team sharing",
+    ),
+) -> None:
     """Git development metrics CLI."""
     if ctx.invoked_subcommand is None:
         analyze(
@@ -15,7 +22,7 @@ def main(ctx: typer.Context) -> None:
             repo=None,
             period=None,
             output=None,
-            anonymize=False,
+            anonymize=anonymize,
             verbose=False,
             log_level="WARNING",
         )

--- a/git_dev_metrics/cli/runner.py
+++ b/git_dev_metrics/cli/runner.py
@@ -80,6 +80,7 @@ def run_analyze(
     org: str | None = None,
     repo: str | None = None,
     period: str | None = None,
+    anonymize: bool = False,
 ) -> None:
     """
     Orchestrate the full analyze flow.
@@ -120,6 +121,13 @@ def run_analyze(
     except GitHubError as e:
         raise AnalysisError(str(e)) from e
 
+    mapping: dict[str, str] = {}
+    if anonymize:
+        from ..metrics.anonymize import anonymize_metrics
+
+        metrics = anonymize_metrics(metrics)
+        mapping = metrics.get("_anonymize_mapping", {})
+
     output_path = resolve_output_path(output)
     time_period = parse_time_period(period)
     since = time_period.since.strftime(_DATE_FMT)
@@ -129,6 +137,10 @@ def run_analyze(
 
     stale_prs = _fetch_stale_prs(token, selected)
     if stale_prs:
+        if anonymize:
+            from ..metrics.anonymize import anonymize_stale_prs
+
+            stale_prs = anonymize_stale_prs(stale_prs, mapping)
         print_stale_prs(stale_prs, output_path)
 
     prompt_open_result(output_path)

--- a/git_dev_metrics/metrics/anonymize.py
+++ b/git_dev_metrics/metrics/anonymize.py
@@ -1,0 +1,32 @@
+"""Replace real GitHub logins with dev-1, dev-2, ... for safe team sharing."""
+
+
+def _build_mapping(logins: list[str]) -> dict[str, str]:
+    return {login: f"dev-{i + 1}" for i, login in enumerate(sorted(logins))}
+
+
+def anonymize_metrics(metrics: dict) -> dict:
+    """Return a new metrics dict with dev logins replaced by stable pseudonyms."""
+    dev_metrics = metrics.get("dev_metrics") or {}
+    reviewer_counts = metrics.get("reviewer_counts") or {}
+    all_logins = set(dev_metrics) | set(reviewer_counts)
+    mapping = _build_mapping(list(all_logins))
+
+    return {
+        **metrics,
+        "dev_metrics": {mapping[d]: m for d, m in dev_metrics.items()},
+        "reviewer_counts": {mapping[r]: c for r, c in reviewer_counts.items()},
+        "_anonymize_mapping": mapping,
+    }
+
+
+def anonymize_stale_prs(stale_prs: list[dict], mapping: dict[str, str]) -> list[dict]:
+    """Return new stale-PR rows with `author` swapped via the mapping."""
+    rows = []
+    for pr in stale_prs:
+        author = pr.get("author", "")
+        rows.append({**pr, "author": mapping.get(author, author)})
+    return rows
+
+
+__all__ = ["anonymize_metrics", "anonymize_stale_prs"]

--- a/tests/unit/test_anonymize.py
+++ b/tests/unit/test_anonymize.py
@@ -1,0 +1,64 @@
+from git_dev_metrics.metrics.anonymize import anonymize_metrics, anonymize_stale_prs
+
+
+class TestAnonymizeMetrics:
+    def test_should_replace_dev_logins_with_pseudonyms(self):
+        metrics = {
+            "dev_metrics": {"zoe": {"pr_count": 1}, "alice": {"pr_count": 2}},
+            "reviewer_counts": {"zoe": 3, "bob": 4},
+        }
+
+        result = anonymize_metrics(metrics)
+
+        # mapping is alphabetical by login: alice -> dev-1, bob -> dev-2, zoe -> dev-3
+        assert set(result["dev_metrics"].keys()) == {"dev-1", "dev-3"}
+        assert set(result["reviewer_counts"].keys()) == {"dev-2", "dev-3"}
+        assert result["dev_metrics"]["dev-1"] == {"pr_count": 2}
+        assert result["reviewer_counts"]["dev-3"] == 3
+
+    def test_should_preserve_unrelated_keys(self):
+        metrics = {
+            "dev_metrics": {"alice": {"pr_count": 1}},
+            "reviewer_counts": {"alice": 1},
+            "team_metrics": {"pr_count": 1},
+            "repo_metrics": {"org/repo": {}},
+        }
+
+        result = anonymize_metrics(metrics)
+
+        assert result["team_metrics"] == {"pr_count": 1}
+        assert result["repo_metrics"] == {"org/repo": {}}
+
+    def test_should_handle_reviewer_only_logins(self):
+        metrics = {
+            "dev_metrics": {"alice": {"pr_count": 1}},
+            "reviewer_counts": {"alice": 1, "bob": 5},
+        }
+
+        result = anonymize_metrics(metrics)
+
+        # bob never authored, only reviewed -- still gets a pseudonym
+        assert "dev-2" in result["reviewer_counts"]
+        assert "dev-2" not in result["dev_metrics"]
+
+
+class TestAnonymizeStalePrs:
+    def test_should_replace_author_via_mapping(self):
+        mapping = {"alice": "dev-1", "bob": "dev-2"}
+        prs = [
+            {"author": "alice", "number": 1, "title": "x"},
+            {"author": "bob", "number": 2, "title": "y"},
+        ]
+
+        result = anonymize_stale_prs(prs, mapping)
+
+        assert result[0]["author"] == "dev-1"
+        assert result[1]["author"] == "dev-2"
+        assert result[0]["title"] == "x"
+
+    def test_should_pass_through_unmapped_authors(self):
+        prs = [{"author": "ghost", "number": 1, "title": "x"}]
+
+        result = anonymize_stale_prs(prs, {})
+
+        assert result[0]["author"] == "ghost"


### PR DESCRIPTION
## Summary

`--anonymize` replaces real GitHub logins with `dev-1`, `dev-2`, ... across every output: console table, markdown dev/repo tables, HTML dashboard (table + charts), stale PR list, and the Top Reviewer card.

Use case: share the team summary at a meeting or in Slack without naming individuals. Per-dev rows still tell you about distribution and outliers; nobody gets singled out.

Mapping is alphabetical by login (so reruns in the same invocation are stable). Mapping is intentionally **not persisted** between runs — there's no way to de-anonymize a shared report later, which is the safer default.

Reviewer-only people (who review but never authored a PR in the period) get a pseudonym too, so Top Reviewer still works.

## Test plan
- [x] `pytest` (165 passed, 5 new anonymize tests)
- [x] `ruff check` / `ruff format`
- [ ] Run with `--anonymize` against a real org and confirm no real logins leak in any of the four output formats