### PR TITLE
Add "Pick a month" wizard option

### DIFF
--- a/git_dev_metrics/cli/prompts.py
+++ b/git_dev_metrics/cli/prompts.py
@@ -1,3 +1,5 @@
+import re
+from datetime import UTC, datetime
 from pathlib import Path
 
 import click
@@ -6,6 +8,9 @@ from questionary import Style
 
 MAX_RESULT_FILES = 10
 
+PICK_MONTH_SENTINEL = "__pick_month__"
+CUSTOM_MONTH_SENTINEL = "__custom_month__"
+
 PERIOD_OPTIONS = [
     ("Last 7 days", "7d"),
     ("Last 14 days", "14d"),
@@ -13,7 +18,58 @@ PERIOD_OPTIONS = [
     ("Last 60 days", "60d"),
     ("Last 90 days", "90d"),
     ("Last month (calendar)", "last_month"),
+    ("Pick a month…", PICK_MONTH_SENTINEL),
 ]
+
+_YEAR_MONTH_RE = re.compile(r"^\d{4}-(0[1-9]|1[0-2])$")
+
+
+def _last_six_months(now: datetime) -> list[tuple[str, str]]:
+    out: list[tuple[str, str]] = []
+    year, month = now.year, now.month
+    for _ in range(6):
+        label = datetime(year, month, 1).strftime("%B %Y")
+        out.append((label, f"{year:04d}-{month:02d}"))
+        month -= 1
+        if month == 0:
+            month = 12
+            year -= 1
+    return out
+
+
+def _validate_year_month(text: str) -> bool | str:
+    return True if _YEAR_MONTH_RE.match(text) else "Use format YYYY-MM (e.g. 2026-03)"
+
+
+def prompt_month_selection() -> str | None:
+    """Sub-prompt: last 6 calendar months newest-first, plus custom YYYY-MM."""
+    custom_style = Style(
+        [
+            ("highlighted", "fg:#00b4d8 bold"),
+            ("selected", "fg:#90e0ef"),
+        ]
+    )
+
+    months = _last_six_months(datetime.now(UTC))
+    choices = [questionary.Choice(title=title, value=value) for title, value in months]
+    choices.append(questionary.Choice(title="Custom (YYYY-MM)…", value=CUSTOM_MONTH_SENTINEL))
+
+    selected = questionary.select(
+        "Select month:",
+        choices=choices,
+        style=custom_style,
+    ).ask()
+
+    if selected is None:
+        return None
+    if selected != CUSTOM_MONTH_SENTINEL:
+        return selected
+
+    return questionary.text(
+        "Enter year-month (YYYY-MM):",
+        validate=_validate_year_month,
+        style=custom_style,
+    ).ask()
 
 
 def prompt_period_selection(default: str | None = None) -> str:
@@ -36,6 +92,9 @@ def prompt_period_selection(default: str | None = None) -> str:
         default=default,
         style=custom_style,
     ).ask()
+
+    if selected == PICK_MONTH_SENTINEL:
+        return prompt_month_selection() or default
 
     return selected or default
 

--- a/git_dev_metrics/metrics/analyzer.py
+++ b/git_dev_metrics/metrics/analyzer.py
@@ -1,7 +1,5 @@
-import re
-
 from ..github import fetch_repo_metrics
-from ..utils import parse_time_period
+from ..utils import TimePeriod, parse_time_period
 from .calculator import (
     calculate_ai_percentage,
     calculate_avg_lines_per_pr,
@@ -26,18 +24,9 @@ _PER_DEV_AGGREGATED_KEYS = (
 )
 
 
-def _parse_period_days(event_period: str) -> int:
-    """Extract number of days from period string like '30d', '2w', '1m'."""
-    match = re.match(r"(\d+)(d|w|m)", event_period)
-    if not match:
-        return 30
-    value, unit = match.groups()
-    days = int(value)
-    if unit == "w":
-        days *= 7
-    elif unit == "m":
-        days *= 30
-    return days
+def _period_days(period: TimePeriod) -> int:
+    """Whole days spanned by the TimePeriod (min 1). Source of truth for prs_per_week."""
+    return max(1, round((period.until - period.since).total_seconds() / 86400))
 
 
 def _build_dev_metrics(devs: dict, period_days: int, reviews_given: dict) -> dict:
@@ -61,7 +50,7 @@ def _build_dev_metrics(devs: dict, period_days: int, reviews_given: dict) -> dic
 def get_pull_request_metrics(token: str, org: str, repo: str, event_period: str = "30d") -> dict:
     """Get development metrics for a repository over a specified time period."""
     period = parse_time_period(event_period)
-    period_days = _parse_period_days(event_period)
+    period_days = _period_days(period)
     prs = fetch_repo_metrics(token, org, repo, period)
 
     devs = group_prs_by_devs(prs)
@@ -101,7 +90,7 @@ def _build_metrics(prs: list, period_days: int) -> dict:
 def get_combined_metrics(token: str, selected_repos: list[str], event_period: str = "30d") -> dict:
     """Get combined metrics for multiple repositories."""
     period = parse_time_period(event_period)
-    period_days = _parse_period_days(event_period)
+    period_days = _period_days(period)
 
     all_prs: list = []
     repo_metrics: dict = {}

--- a/git_dev_metrics/utils/date_utils.py
+++ b/git_dev_metrics/utils/date_utils.py
@@ -1,3 +1,4 @@
+import re
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
@@ -12,21 +13,33 @@ class TimePeriod:
             raise ValueError("since must be before until.")
 
 
+def month_range(year: int, month: int) -> TimePeriod:
+    """TimePeriod covering the calendar month [first 00:00 UTC, first of next 00:00 UTC)."""
+    if not 1 <= month <= 12:
+        raise ValueError(f"Unsupported period: {year:04d}-{month:02d}")
+    since = datetime(year, month, 1, tzinfo=UTC)
+    until = datetime(year + (month // 12), (month % 12) + 1, 1, tzinfo=UTC)
+    return TimePeriod(since=since, until=until)
+
+
 def get_last_month() -> TimePeriod:
     """Gets the TimePeriod for last month"""
     now = datetime.now(UTC)
+    year, month = (now.year - 1, 12) if now.month == 1 else (now.year, now.month - 1)
+    return month_range(year, month)
 
-    first_of_this_month = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-    since = (first_of_this_month - timedelta(days=1)).replace(day=1)
-    until = first_of_this_month
 
-    return TimePeriod(since=since, until=until)
+_YEAR_MONTH_RE = re.compile(r"^(\d{4})-(\d{2})$")
 
 
 def parse_time_period(event_period: str) -> TimePeriod:
     """Parse time period string and return a TimePeriod."""
     if event_period == "last_month":
         return get_last_month()
+
+    if m := _YEAR_MONTH_RE.match(event_period):
+        return month_range(int(m.group(1)), int(m.group(2)))
+
     period_map = {
         "1d": timedelta(days=1),
         "7d": timedelta(days=7),

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,5 +1,6 @@
 """Unit tests for reports.py functions."""
 
+from datetime import UTC, datetime
 from typing import cast
 
 from git_dev_metrics.metrics import (
@@ -12,8 +13,9 @@ from git_dev_metrics.metrics import (
     calculate_throughput,
     median,
 )
-from git_dev_metrics.metrics.analyzer import _parse_period_days
+from git_dev_metrics.metrics.analyzer import _period_days
 from git_dev_metrics.models import OpenPullRequest
+from git_dev_metrics.utils import TimePeriod
 
 from .conftest import any_pr, approved_review
 
@@ -389,20 +391,65 @@ class TestCalculatePrsPerWeek:
         assert result == 1.0
 
 
-class TestParsePeriodDays:
-    """Test cases for _parse_period_days function."""
+class TestPeriodDays:
+    """Test cases for _period_days function — derives whole days from a TimePeriod.
 
-    def test_should_parse_days(self):
-        assert _parse_period_days("30d") == 30
+    This is the source of truth for the prs_per_week denominator. Must reflect the
+    real span (28/29/30/31) for calendar months, not the period-string shape.
+    """
 
-    def test_should_parse_weeks(self):
-        assert _parse_period_days("2w") == 14
+    def test_should_return_28_for_february_non_leap(self):
+        period = TimePeriod(
+            since=datetime(2026, 2, 1, tzinfo=UTC),
+            until=datetime(2026, 3, 1, tzinfo=UTC),
+        )
 
-    def test_should_parse_months(self):
-        assert _parse_period_days("1m") == 30
+        assert _period_days(period) == 28
 
-    def test_should_default_to_30_for_invalid(self):
-        assert _parse_period_days("invalid") == 30
+    def test_should_return_29_for_february_leap(self):
+        period = TimePeriod(
+            since=datetime(2024, 2, 1, tzinfo=UTC),
+            until=datetime(2024, 3, 1, tzinfo=UTC),
+        )
+
+        assert _period_days(period) == 29
+
+    def test_should_return_31_for_thirty_one_day_month(self):
+        period = TimePeriod(
+            since=datetime(2026, 3, 1, tzinfo=UTC),
+            until=datetime(2026, 4, 1, tzinfo=UTC),
+        )
+
+        assert _period_days(period) == 31
+
+    def test_should_return_exact_days_for_sliding_window(self):
+        until = datetime(2026, 5, 8, 12, 0, tzinfo=UTC)
+        since = datetime(2026, 4, 8, 12, 0, tzinfo=UTC)
+        period = TimePeriod(since=since, until=until)
+
+        assert _period_days(period) == 30
+
+    def test_should_clamp_to_one_for_zero_span(self):
+        instant = datetime(2026, 5, 8, tzinfo=UTC)
+        period = TimePeriod(since=instant, until=instant)
+
+        assert _period_days(period) == 1
+
+
+class TestCalculatePrsPerWeekUsesActualSpan:
+    """Regression: prs_per_week was computed with hard-coded 30 for `last_month` and YYYY-MM."""
+
+    def test_should_match_calendar_month_length_for_february(self):
+        period = TimePeriod(
+            since=datetime(2026, 2, 1, tzinfo=UTC),
+            until=datetime(2026, 3, 1, tzinfo=UTC),
+        )
+        prs = [any_pr(id=i, number=i) for i in range(1, 5)]
+
+        result = calculate_prs_per_week(prs, _period_days(period))
+
+        # 4 PRs over 28d = 1.0/wk; old 30d default would give ≈ 0.93
+        assert result == 1.0
 
 
 class TestCalculateReviewsGiven:
@@ -892,7 +939,10 @@ class TestTeamAggregation:
         )
         mocker.patch(
             "git_dev_metrics.metrics.analyzer.parse_time_period",
-            return_value=mocker.MagicMock(),
+            return_value=TimePeriod(
+                since=datetime(2024, 1, 1, tzinfo=UTC),
+                until=datetime(2024, 1, 31, tzinfo=UTC),
+            ),
         )
 
         result = get_combined_metrics(token="t", selected_repos=["org/repo"])
@@ -920,7 +970,10 @@ class TestTeamAggregation:
         mocker.patch("git_dev_metrics.metrics.analyzer.fetch_repo_metrics", return_value=prs)
         mocker.patch(
             "git_dev_metrics.metrics.analyzer.parse_time_period",
-            return_value=mocker.MagicMock(),
+            return_value=TimePeriod(
+                since=datetime(2024, 1, 1, tzinfo=UTC),
+                until=datetime(2024, 1, 31, tzinfo=UTC),
+            ),
         )
 
         result = get_combined_metrics(token="t", selected_repos=["org/repo"])
@@ -948,7 +1001,10 @@ class TestTeamAggregation:
         mocker.patch("git_dev_metrics.metrics.analyzer.fetch_repo_metrics", return_value=prs)
         mocker.patch(
             "git_dev_metrics.metrics.analyzer.parse_time_period",
-            return_value=mocker.MagicMock(),
+            return_value=TimePeriod(
+                since=datetime(2024, 1, 1, tzinfo=UTC),
+                until=datetime(2024, 1, 31, tzinfo=UTC),
+            ),
         )
 
         result = get_combined_metrics(token="t", selected_repos=["org/repo"])

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -1,8 +1,17 @@
 """Unit tests for prompts.py functions."""
 
+from datetime import UTC, datetime
+
+from freezegun import freeze_time
+
 from git_dev_metrics.cli.prompts import (
+    CUSTOM_MONTH_SENTINEL,
     MAX_RESULT_FILES,
     PERIOD_OPTIONS,
+    PICK_MONTH_SENTINEL,
+    _last_six_months,
+    _validate_year_month,
+    prompt_month_selection,
     prompt_open_result,
     prompt_period_selection,
 )
@@ -68,6 +77,86 @@ class TestPromptPeriodSelection:
         call_kwargs = mock_select.call_args[1]
         assert call_kwargs["default"] == "last_month"
         assert result == "last_month"
+
+
+class TestPromptMonthSelection:
+    @freeze_time("2026-05-08 12:00:00")
+    def test_should_return_selected_year_month_value(self, mocker):
+        mock_select = mocker.patch("git_dev_metrics.cli.prompts.questionary.select")
+        mock_select.return_value.ask.return_value = "2026-03"
+
+        result = prompt_month_selection()
+
+        assert result == "2026-03"
+
+    @freeze_time("2026-05-08 12:00:00")
+    def test_should_offer_six_months_newest_first_plus_custom(self, mocker):
+        mock_select = mocker.patch("git_dev_metrics.cli.prompts.questionary.select")
+        mock_select.return_value.ask.return_value = "2026-05"
+
+        prompt_month_selection()
+
+        choices = mock_select.call_args[1]["choices"]
+        values = [c.value for c in choices]
+        assert values == [
+            "2026-05",
+            "2026-04",
+            "2026-03",
+            "2026-02",
+            "2026-01",
+            "2025-12",
+            CUSTOM_MONTH_SENTINEL,
+        ]
+
+    @freeze_time("2026-05-08 12:00:00")
+    def test_should_prompt_for_custom_year_month_when_chosen(self, mocker):
+        mock_select = mocker.patch("git_dev_metrics.cli.prompts.questionary.select")
+        mock_select.return_value.ask.return_value = CUSTOM_MONTH_SENTINEL
+        mock_text = mocker.patch("git_dev_metrics.cli.prompts.questionary.text")
+        mock_text.return_value.ask.return_value = "2025-11"
+
+        result = prompt_month_selection()
+
+        assert result == "2025-11"
+        mock_text.assert_called_once()
+
+    @freeze_time("2026-05-08 12:00:00")
+    def test_should_return_none_when_user_aborts_main(self, mocker):
+        mock_select = mocker.patch("git_dev_metrics.cli.prompts.questionary.select")
+        mock_select.return_value.ask.return_value = None
+
+        assert prompt_month_selection() is None
+
+
+class TestValidateYearMonth:
+    def test_should_accept_valid_year_month(self):
+        assert _validate_year_month("2026-03") is True
+
+    def test_should_reject_invalid_month(self):
+        assert isinstance(_validate_year_month("2026-13"), str)
+
+    def test_should_reject_garbage(self):
+        assert isinstance(_validate_year_month("foo"), str)
+
+
+class TestLastSixMonths:
+    def test_should_handle_year_boundary(self):
+        result = _last_six_months(datetime(2026, 2, 15, tzinfo=UTC))
+
+        values = [v for _, v in result]
+        assert values == ["2026-02", "2026-01", "2025-12", "2025-11", "2025-10", "2025-09"]
+
+
+class TestPromptPeriodSelectionWithMonth:
+    @freeze_time("2026-05-08 12:00:00")
+    def test_should_drill_into_month_picker_when_sentinel_selected(self, mocker):
+        mock_select = mocker.patch("git_dev_metrics.cli.prompts.questionary.select")
+        mock_select.return_value.ask.side_effect = [PICK_MONTH_SENTINEL, "2026-03"]
+
+        result = prompt_period_selection(default="30d")
+
+        assert result == "2026-03"
+        assert mock_select.call_count == 2
 
 
 class TestPromptOpenResult:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -6,6 +6,7 @@ import pytest
 from freezegun import freeze_time
 
 from git_dev_metrics.utils import TimePeriod, get_last_month, parse_time_period
+from git_dev_metrics.utils.date_utils import month_range
 
 
 class TestTimePeriod:
@@ -69,6 +70,32 @@ class TestParseTimePeriod:
         expected = get_last_month()
         assert result.since == expected.since
         assert result.until == expected.until
+
+    def test_should_return_calendar_month_for_year_month_string(self):
+        result = parse_time_period("2026-03")
+
+        assert result.since == datetime(2026, 3, 1, tzinfo=UTC)
+        assert result.until == datetime(2026, 4, 1, tzinfo=UTC)
+
+    def test_should_cross_year_boundary_for_december(self):
+        result = parse_time_period("2025-12")
+
+        assert result.since == datetime(2025, 12, 1, tzinfo=UTC)
+        assert result.until == datetime(2026, 1, 1, tzinfo=UTC)
+
+    def test_should_raise_for_invalid_month_in_year_month(self):
+        with pytest.raises(ValueError, match="Unsupported period"):
+            parse_time_period("2026-13")
+
+
+class TestMonthRange:
+    def test_should_raise_for_month_zero(self):
+        with pytest.raises(ValueError, match="Unsupported period"):
+            month_range(2026, 0)
+
+    def test_should_raise_for_month_thirteen(self):
+        with pytest.raises(ValueError, match="Unsupported period"):
+            month_range(2026, 13)
 
 
 class TestGetLastMonth:


### PR DESCRIPTION
## Summary
- New "Pick a month…" entry in the period wizard opens a sub-menu listing the last 6 calendar months (newest first) plus a "Custom (YYYY-MM)…" text prompt with regex validation
- `parse_time_period` now accepts `YYYY-MM` via a new shared `month_range(year, month)` helper; `get_last_month` refactored to delegate
- CLI `--period` flag surface unchanged — month picking is wizard-only

## Test plan
- [x] `uv run pytest tests/unit -q` (179 passed)
- [x] `uv run ruff check git_dev_metrics tests` clean
- [ ] Manual: `uv run app --org <org> --repo <repo>` → select "Pick a month…" → confirm 6 months + custom path
- [ ] Manual: pick a month, verify HTML/console date range matches `YYYY-MM-01..(next month)-01`
- [ ] Manual: custom prompt rejects `2025-13` and `foo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)