### PR TITLE
Encode period in default result filenames

### DIFF
--- a/git_dev_metrics/cli/output.py
+++ b/git_dev_metrics/cli/output.py
@@ -11,9 +11,9 @@ from ..metrics.printer import (
 )
 
 
-def resolve_output_path(output: Path | None) -> Path:
-    """Resolve output path from user input or return default."""
-    return output if output else get_default_output_path()
+def resolve_output_path(output: Path | None, period: str = "") -> Path:
+    """Resolve output path from user input or return default with period encoded."""
+    return output if output else get_default_output_path(period)
 
 
 def print_metrics(metrics: dict, period: str, output_path: Path, date_range: str) -> None:

--- a/git_dev_metrics/cli/runner.py
+++ b/git_dev_metrics/cli/runner.py
@@ -128,7 +128,7 @@ def run_analyze(
         metrics = anonymize_metrics(metrics)
         mapping = metrics.get("_anonymize_mapping", {})
 
-    output_path = resolve_output_path(output)
+    output_path = resolve_output_path(output, period)
     time_period = parse_time_period(period)
     since = time_period.since.strftime(_DATE_FMT)
     until = time_period.until.strftime(_DATE_FMT)

--- a/git_dev_metrics/metrics/printer/utils.py
+++ b/git_dev_metrics/metrics/printer/utils.py
@@ -2,7 +2,9 @@ from datetime import datetime
 from pathlib import Path
 
 
-def get_default_output_path() -> Path:
-    """Get default output path with timestamp."""
+def get_default_output_path(period: str = "") -> Path:
+    """Default output path with timestamp; appends period slug when provided."""
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    return Path(f"./metrics_results/metrics_{timestamp}.md")
+    slug = period.replace("_", "-")
+    suffix = f"_{slug}" if slug else ""
+    return Path(f"./metrics_results/metrics_{timestamp}{suffix}.md")

--- a/tests/unit/test_printer_utils.py
+++ b/tests/unit/test_printer_utils.py
@@ -1,0 +1,49 @@
+"""Unit tests for default output path naming."""
+
+from pathlib import Path
+
+from freezegun import freeze_time
+
+from git_dev_metrics.cli.output import resolve_output_path
+from git_dev_metrics.metrics.printer.utils import get_default_output_path
+
+
+class TestGetDefaultOutputPath:
+    @freeze_time("2026-05-08 09:04:07")
+    def test_should_encode_simple_period_after_timestamp(self):
+        result = get_default_output_path("30d")
+
+        assert result == Path("./metrics_results/metrics_2026-05-08_09-04-07_30d.md")
+
+    @freeze_time("2026-05-08 09:04:07")
+    def test_should_swap_underscore_in_period_to_hyphen(self):
+        result = get_default_output_path("last_month")
+
+        assert result == Path("./metrics_results/metrics_2026-05-08_09-04-07_last-month.md")
+
+    @freeze_time("2026-05-08 09:04:07")
+    def test_should_pass_through_year_month_period(self):
+        result = get_default_output_path("2026-03")
+
+        assert result == Path("./metrics_results/metrics_2026-05-08_09-04-07_2026-03.md")
+
+    @freeze_time("2026-05-08 09:04:07")
+    def test_should_omit_suffix_when_period_empty(self):
+        result = get_default_output_path()
+
+        assert result == Path("./metrics_results/metrics_2026-05-08_09-04-07.md")
+
+
+class TestResolveOutputPath:
+    @freeze_time("2026-05-08 09:04:07")
+    def test_should_use_default_with_period_when_no_override(self):
+        result = resolve_output_path(None, "30d")
+
+        assert result == Path("./metrics_results/metrics_2026-05-08_09-04-07_30d.md")
+
+    def test_should_honour_explicit_override(self):
+        explicit = Path("/tmp/custom.md")
+
+        result = resolve_output_path(explicit, "30d")
+
+        assert result == explicit


### PR DESCRIPTION
## Summary
- Default output filenames change from `metrics_<timestamp>.md` to `metrics_<timestamp>_<period>.md` so prior runs are scannable by period without opening each file
- `last_month` → `last-month` in the slug to keep period as one underscore-separated segment; `30d` and `YYYY-MM` pass through
- Sibling files (`.html`, `_stale.md`) follow automatically (they derive from the base path)
- `--output` overrides remain untouched
- Existing files in `metrics_results/` keep their old names; lister glob `metrics_*` matches both

Examples:
- `metrics_2026-05-08_09-04-07_30d.md`
- `metrics_2026-05-08_09-04-07_last-month.md`
- `metrics_2026-05-08_09-04-07_2026-03.md`

## Test plan
- [x] `uv run pytest tests/unit -q` (187 passed)
- [x] `uv run ruff check git_dev_metrics tests` clean
- [ ] Manual: `uv run app --org <org> --repo <repo> --period 30d` → confirm `metrics_<ts>_30d.md/.html/_stale.md`
- [ ] Manual: wizard month-pick → file ends `_2026-03.md`
- [ ] Manual: `--output custom.md` → exactly `custom.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)