### PR TITLE
Add stale subcommand for open PRs older than 7 days

### DIFF
--- a/git_dev_metrics/cli/app.py
+++ b/git_dev_metrics/cli/app.py
@@ -4,6 +4,7 @@ from .clear import clear
 from .dashboard import dashboard
 from .logout import logout
 from .pull import pull
+from .stale import stale
 from .summary import summary
 from .trend import trend
 
@@ -21,5 +22,6 @@ app.command()(clear)
 app.command()(dashboard)
 app.command()(logout)
 app.command()(pull)
+app.command()(stale)
 app.command()(summary)
 app.command()(trend)

--- a/git_dev_metrics/cli/stale.py
+++ b/git_dev_metrics/cli/stale.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+from pathlib import Path
+
+import typer
+
+from ..cache import list_synced_months
+from ..github import fetch_open_prs, get_github_token
+from ..metrics.calculator import get_stale_prs
+from ..metrics.printer.stale import FileStaleHtmlPrinter
+from ._browser import open_in_browser
+
+
+def _default_output() -> Path:
+    today = datetime.now().strftime("%Y-%m-%d")
+    return Path(f"./metrics_results/stale_{today}.html")
+
+
+def stale(
+    output: Path | None = typer.Option(None, "--output", help="Output HTML path"),
+    db: Path | None = typer.Option(None, "--db", help="Override cache database path"),
+) -> None:
+    """Render an HTML view of open PRs older than 7 days, across every synced repo."""
+    repos = sorted({(org, repo) for org, repo, *_ in list_synced_months(db_path=db)})
+    if not repos:
+        typer.secho("No repos in cache — run pull first.", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=1)
+
+    token = get_github_token()
+    all_stale: list[dict] = []
+    for org, repo in repos:
+        opens = fetch_open_prs(token, org, repo, quiet=True)
+        all_stale.extend(get_stale_prs(opens, f"{org}/{repo}"))
+    all_stale.sort(key=lambda x: x["age_hours"], reverse=True)
+
+    out = (output or _default_output()).with_suffix(".html")
+    FileStaleHtmlPrinter(out).render(all_stale)
+    typer.echo(f"Stale written to {out}.")
+    open_in_browser(out)

--- a/git_dev_metrics/metrics/printer/stale.py
+++ b/git_dev_metrics/metrics/printer/stale.py
@@ -1,8 +1,39 @@
 from pathlib import Path
 
+from jinja2 import Environment, PackageLoader, select_autoescape
+
 from ..calculator import summarize_stale_prs
 
 TITLE_FILE_LENGTH = 60
+
+_ENV: Environment | None = None
+
+
+def _get_env() -> Environment:
+    global _ENV
+    if _ENV is None:
+        _ENV = Environment(
+            loader=PackageLoader("git_dev_metrics.metrics.printer", "templates"),
+            autoescape=select_autoescape(["html", "xml"]),
+        )
+    return _ENV
+
+
+class FileStaleHtmlPrinter:
+    """Render a self-contained stale-PR HTML report."""
+
+    def __init__(self, output_path: Path) -> None:
+        self._output_path = output_path
+
+    def render(self, stale_prs: list[dict]) -> None:
+        total, avg_age = summarize_stale_prs(stale_prs)
+        html = (
+            _get_env()
+            .get_template("stale.html")
+            .render(total=total, avg_age=avg_age, prs=stale_prs)
+        )
+        self._output_path.parent.mkdir(parents=True, exist_ok=True)
+        self._output_path.write_text(html)
 
 
 def _truncate(text: str, length: int) -> str:

--- a/git_dev_metrics/metrics/printer/templates/stale.html
+++ b/git_dev_metrics/metrics/printer/templates/stale.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Stale PRs</title>
+<style>
+  :root {
+    --bg: #0f1117;
+    --card: #1a1d27;
+    --border: #2a2d3a;
+    --text: #e1e4ed;
+    --muted: #8b8fa3;
+    --warn: #eab308;
+    --crit: #ef4444;
+    --ok: #22c55e;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    background: var(--bg); color: var(--text); padding: 2rem;
+  }
+  .header { text-align: center; margin-bottom: 2rem; }
+  .header h1 { font-size: 1.5rem; letter-spacing: -0.02em; }
+  .header p { color: var(--muted); font-size: 0.875rem; margin-top: 0.25rem; }
+  .wrap { max-width: 1200px; margin: 0 auto; }
+  .card { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 1.25rem; }
+  table { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
+  th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--border); }
+  th { color: var(--muted); font-weight: 600; }
+  tr:last-child td { border-bottom: none; }
+  a { color: #6366f1; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .age-warn { color: var(--warn); }
+  .age-crit { color: var(--crit); font-weight: 600; }
+  .badge { font-size: 0.7rem; padding: 0.1rem 0.4rem; border-radius: 4px; background: var(--border); color: var(--muted); }
+  .badge-approved { background: rgba(34,197,94,0.15); color: var(--ok); }
+  .empty { text-align: center; color: var(--muted); padding: 3rem; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="header">
+    <h1>Stale PRs</h1>
+    <p>{{ total }} open &gt; 7 days · avg age {{ "%.1f"|format(avg_age) }} days</p>
+  </div>
+  <div class="card">
+    {% if prs %}
+    <table>
+      <thead>
+        <tr>
+          <th>PR</th><th>Title</th><th>Repo</th><th>Author</th><th>Age</th><th>Flags</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for pr in prs %}
+        <tr>
+          <td><a href="{{ pr.url }}" target="_blank">#{{ pr.number }}</a></td>
+          <td>{{ pr.title }}</td>
+          <td>{{ pr.repo }}</td>
+          <td>{{ pr.author }}</td>
+          <td class="{% if pr.age_days >= 30 %}age-crit{% elif pr.age_days >= 14 %}age-warn{% endif %}">{{ "%.1f"|format(pr.age_days) }}d</td>
+          <td>
+            {% if pr.is_draft %}<span class="badge">draft</span>{% endif %}
+            {% if pr.is_approved %}<span class="badge badge-approved">approved</span>{% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% else %}
+    <div class="empty">No stale PRs.</div>
+    {% endif %}
+  </div>
+</div>
+</body>
+</html>

--- a/tests/unit/test_cli_no_subcommand.py
+++ b/tests/unit/test_cli_no_subcommand.py
@@ -22,6 +22,7 @@ class TestNoSubcommand:
         assert "summary" in result.output
         assert "dashboard" in result.output
         assert "trend" in result.output
+        assert "stale" in result.output
         assert "clear" in result.output
         assert "logout" in result.output
         assert "analyze" not in result.output

--- a/tests/unit/test_stale_command.py
+++ b/tests/unit/test_stale_command.py
@@ -1,0 +1,130 @@
+from freezegun import freeze_time
+from typer.testing import CliRunner
+
+from git_dev_metrics.cache import seal_month
+from git_dev_metrics.cli.app import app
+
+runner = CliRunner()
+
+
+def _open_pr(number: int, login: str, created_at: str, is_draft: bool = False) -> dict:
+    return {
+        "number": number,
+        "title": f"PR #{number}",
+        "created_at": created_at,
+        "merged_at": None,
+        "user": {"login": login},
+        "is_draft": is_draft,
+        "is_approved": False,
+    }
+
+
+class TestStale:
+    @freeze_time("2026-05-12")
+    def test_should_render_html_for_stale_prs_across_synced_repos(
+        self, tmp_path, mocker, _stub_webbrowser
+    ):
+        # Arrange
+        db_path = tmp_path / "cache.db"
+        seal_month("myorg", "repoA", 2026, 4, db_path=db_path)
+        seal_month("myorg", "repoB", 2026, 4, db_path=db_path)
+
+        def fake_open_prs(_token, _org, repo, **_kwargs):
+            if repo == "repoA":
+                return [_open_pr(1, "alice", "2026-04-01T08:00:00Z")]  # ~41d
+            return [_open_pr(2, "bob", "2026-05-01T08:00:00Z")]  # ~11d
+
+        mocker.patch("git_dev_metrics.cli.stale.get_github_token", return_value="fake-token")
+        mocker.patch("git_dev_metrics.cli.stale.fetch_open_prs", side_effect=fake_open_prs)
+        out = tmp_path / "stale.html"
+
+        # Act
+        result = runner.invoke(app, ["stale", "--db", str(db_path), "--output", str(out)])
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        html = out.read_text()
+        assert "Stale PRs" in html
+        assert "myorg/repoA" in html
+        assert "myorg/repoB" in html
+        assert "alice" in html
+        assert "bob" in html
+        _stub_webbrowser.assert_called_once_with(out.resolve().as_uri())
+
+    @freeze_time("2026-05-12")
+    def test_should_sort_oldest_first(self, tmp_path, mocker):
+        # Arrange
+        db_path = tmp_path / "cache.db"
+        seal_month("myorg", "repoA", 2026, 4, db_path=db_path)
+
+        mocker.patch("git_dev_metrics.cli.stale.get_github_token", return_value="fake-token")
+        mocker.patch(
+            "git_dev_metrics.cli.stale.fetch_open_prs",
+            return_value=[
+                _open_pr(10, "young", "2026-05-01T08:00:00Z"),  # ~11d
+                _open_pr(11, "old", "2026-04-01T08:00:00Z"),  # ~41d
+            ],
+        )
+        out = tmp_path / "stale.html"
+
+        # Act
+        result = runner.invoke(app, ["stale", "--db", str(db_path), "--output", str(out)])
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        html = out.read_text()
+        old_idx = html.find("#11")
+        young_idx = html.find("#10")
+        assert 0 < old_idx < young_idx
+
+    @freeze_time("2026-05-12")
+    def test_should_render_empty_state_when_no_stale_prs(self, tmp_path, mocker):
+        # Arrange
+        db_path = tmp_path / "cache.db"
+        seal_month("myorg", "repoA", 2026, 4, db_path=db_path)
+
+        mocker.patch("git_dev_metrics.cli.stale.get_github_token", return_value="fake-token")
+        mocker.patch(
+            "git_dev_metrics.cli.stale.fetch_open_prs",
+            return_value=[_open_pr(1, "alice", "2026-05-10T08:00:00Z")],  # ~2d, fresh
+        )
+        out = tmp_path / "stale.html"
+
+        # Act
+        result = runner.invoke(app, ["stale", "--db", str(db_path), "--output", str(out)])
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        assert "No stale PRs" in out.read_text()
+
+    def test_should_exit_when_no_repos_in_cache(self, tmp_path):
+        # Arrange
+        db_path = tmp_path / "cache.db"
+
+        # Act
+        result = runner.invoke(app, ["stale", "--db", str(db_path)])
+
+        # Assert
+        assert result.exit_code == 1
+        assert "No repos in cache" in result.stderr
+
+    @freeze_time("2026-05-12")
+    def test_should_write_default_path_when_no_output(self, tmp_path, monkeypatch, mocker):
+        # Arrange
+        db_path = tmp_path / "cache.db"
+        seal_month("myorg", "repoA", 2026, 4, db_path=db_path)
+        monkeypatch.chdir(tmp_path)
+
+        mocker.patch("git_dev_metrics.cli.stale.get_github_token", return_value="fake-token")
+        mocker.patch(
+            "git_dev_metrics.cli.stale.fetch_open_prs",
+            return_value=[_open_pr(1, "alice", "2026-04-01T08:00:00Z")],
+        )
+
+        # Act
+        result = runner.invoke(app, ["stale", "--db", str(db_path)])
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        expected = tmp_path / "metrics_results" / "stale_2026-05-12.html"
+        assert expected.exists()


### PR DESCRIPTION
## Problem
The CLI had no way to see which open PRs are dragging — a daily nag report that's the whole point of having metrics. The existing cache is sealed-month, merged-only by design, so it can't answer "what's stale right now?" — that question changes every minute as PRs merge or age.

## Solution
Add a `stale` subcommand that bypasses the cache and live-fetches open PRs from GitHub for every repo found in the local cache (so the user's existing `pull` history doubles as the repo list). PRs older than 7 days are aggregated, sorted oldest-first, rendered to a self-contained HTML view, and opened in the browser. No new table, no `--refresh` step — caching would just make the answer wrong by the time anyone reads it.