### PR TITLE
Add vulture dead code check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
           uv run ruff check git_dev_metrics
           uv run ruff format --check git_dev_metrics
 
+      - name: Dead code check
+        run: uv run vulture
+
       - name: Type check
         run: uv run pyright
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,11 @@ max-complexity = 10  # Rule 2: max nesting/branching depth
 typeCheckingMode = "standard"
 pythonVersion = "3.14"
 
+[tool.vulture]
+paths = ["git_dev_metrics"]
+min_confidence = 80
+ignore_decorators = ["@app.callback", "@app.command"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-v --strict-markers"


### PR DESCRIPTION
## Problem

Dead code accumulates because nothing flags it on PRs. Ruff catches unused imports and locals only; unused functions, classes, methods, and attributes slip through. `vulture` was already a dependency but unused.

## Solution

Wire `vulture` into the `lint` CI job. Config in `[tool.vulture]` scans `git_dev_metrics` at `min_confidence = 80` and ignores `@app.callback`/`@app.command` decorators so Typer entry points don't false-flag. Baseline is clean. Non-zero exit on findings blocks merge once branch protection covers `lint`.