### PR TITLE
Add MetricsSnapshot for one-period analysis

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,39 @@
+# Domain glossary
+
+Vocabulary used across the codebase. Use these terms exactly. If a new concept needs a name, add it here.
+
+## Core objects
+
+- **PR** — a GitHub pull request, hydrated with reviews. Shape: `models.PullRequest` TypedDict (number, state, author, timestamps, additions/deletions, commits, reviews).
+- **Repo** — `org/name` pair on GitHub. Always referenced as `"org/repo"` in strings.
+- **Dev** — a GitHub login authoring or reviewing PRs. Bots filtered via `constants.is_bot_login`.
+- **Period** — closed time window `[since, until)` for one analysis run. Type: `utils.TimePeriod`.
+- **Month** — `(year, month)` tuple. The cache seals data at month granularity.
+- **Sealed month** — a `(org, repo, year, month)` that has been pulled into the cache and marked complete. Once sealed, contents are immutable.
+
+## Metrics
+
+- **Cycle time** — hours from first commit to merge. See `metrics.calculator.calculate_cycle_time`.
+- **Pickup time** — hours from PR ready-for-review to first reviewer action.
+- **Review time** — hours of active review.
+- **PR size** — lines changed (additions + deletions).
+- **Throughput** — total PRs in period.
+- **PRs/week** — throughput normalised by period length.
+- **Reviews given** — count of reviews a dev submitted on others' PRs.
+- **AI percentage** — share of PRs flagged as AI-assisted (heuristic on commit messages / body).
+
+## Aggregation
+
+- **Snapshot** — a `MetricsSnapshot`: a frozen, fully-computed analysis of one period across one or more repos. Owns team, dev, repo rows + summary + reviewer counts. Built once via `MetricsSnapshot.from_repo_prs(repo_prs, period)`. Printers consume snapshots; they do not recompute.
+- **Row** — one row of metrics (`Row` dataclass): all per-entity numbers (cycle, pickup, …) plus `health` and `band`. Used for team, dev, repo with the same shape.
+- **Summary** — typed cross-format aggregate exposed by the snapshot for the dashboard header (team health, totals, top reviewer, AI distribution).
+- **Trend** — a sequence of per-month aggregates across the same scope. Distinct from snapshot: trend is many months × few metrics; snapshot is one period × full breadth. Lives in `metrics.trend_calculator`.
+- **Stale PR** — open PR older than the staleness threshold (currently 7 days, `constants`). Lives outside snapshot.
+
+## Health
+
+- **Health score** — 0–100 composite. Two formulas:
+  - **Team health**: throughput + speed + pickup + citizenship. Used for team and repo rows.
+  - **Dev health**: throughput + speed + citizenship (no pickup — reviewer responsiveness isn't an authoring property).
+- **Band** — bucket a health score falls into: `good` (≥80), `ok` (≥60), `bad` (<60). Computed once on the row. Printers map band → emoji or band → colour; they never read the raw thresholds.
+- **Citizenship cohort** — when computing dev citizenship, the absolute-review-count component is normalised against the rest of the cohort. The snapshot passes the cohort through internally; callers never have to remember.

--- a/git_dev_metrics/metrics/__init__.py
+++ b/git_dev_metrics/metrics/__init__.py
@@ -13,6 +13,7 @@ from .calculator import (
 )
 from .health import calculate_dev_health_score, calculate_health_score
 from .printer import ConsolePrinter, Printer
+from .snapshot import Band, MetricsSnapshot, Row, Summary
 
 __all__ = [
     "build_combined_metrics_for_repos",
@@ -29,4 +30,8 @@ __all__ = [
     "median",
     "Printer",
     "ConsolePrinter",
+    "Band",
+    "MetricsSnapshot",
+    "Row",
+    "Summary",
 ]

--- a/git_dev_metrics/metrics/snapshot.py
+++ b/git_dev_metrics/metrics/snapshot.py
@@ -1,0 +1,212 @@
+"""Frozen, fully-computed metrics for one period across one or more repos.
+
+Built once via `MetricsSnapshot.from_repo_prs`. Printers consume snapshots;
+they do not recompute health, bands, sort orders, or aggregations.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from ..models import PullRequest
+from ..utils import TimePeriod
+from .calculator import (
+    calculate_ai_percentage,
+    calculate_avg_lines_per_pr,
+    calculate_cycle_time,
+    calculate_pickup_time,
+    calculate_pr_size,
+    calculate_prs_per_week,
+    calculate_review_time,
+    calculate_reviews_given,
+    calculate_throughput,
+    group_prs_by_devs,
+    median,
+)
+from .health import calculate_dev_health_score, calculate_health_score
+
+Band = Literal["good", "ok", "bad"]
+
+_PER_DEV_AGGREGATED_KEYS = (
+    "cycle_time",
+    "pickup_time",
+    "review_time",
+    "pr_size",
+    "avg_lines_per_pr",
+    "prs_per_week",
+)
+
+
+def _band(health: int) -> Band:
+    if health >= 80:
+        return "good"
+    if health >= 60:
+        return "ok"
+    return "bad"
+
+
+@dataclass(frozen=True)
+class Row:
+    name: str
+    pr_count: int
+    cycle_time: float
+    pickup_time: float
+    review_time: float
+    pr_size: float
+    avg_lines_per_pr: float
+    prs_per_week: float
+    reviews_given: int
+    ai_percentage: float
+    health: int
+    band: Band
+
+
+@dataclass(frozen=True)
+class Summary:
+    ai_per_dev: tuple[int, ...]
+    review_ratio: float
+    top_reviewer: str
+    max_review_share: int
+
+
+@dataclass(frozen=True)
+class MetricsSnapshot:
+    period: TimePeriod
+    team: Row
+    devs: tuple[Row, ...]
+    repos: tuple[Row, ...]
+    summary: Summary
+    reviewer_counts: dict[str, int]
+
+    @classmethod
+    def from_repo_prs(
+        cls,
+        repo_prs: dict[str, list[PullRequest]],
+        period: TimePeriod,
+    ) -> MetricsSnapshot:
+        period_days = max(1, round((period.until - period.since).total_seconds() / 86400))
+        all_prs: list[PullRequest] = [pr for prs in repo_prs.values() for pr in prs]
+        reviewer_counts = calculate_reviews_given(all_prs)
+
+        dev_raws = _dev_raws(all_prs, period_days, reviewer_counts)
+        devs = _rank(dev_raws, calculate_dev_health_score)
+
+        repo_raws = _active_repo_raws(repo_prs, period_days)
+        repos = _rank(repo_raws, calculate_health_score)
+
+        team = _team_row(all_prs, period_days, dev_raws, devs, reviewer_counts)
+
+        return cls(
+            period=period,
+            team=team,
+            devs=devs,
+            repos=repos,
+            summary=_build_summary(devs, reviewer_counts, team),
+            reviewer_counts=reviewer_counts,
+        )
+
+
+def _row_dict(prs: list[PullRequest], period_days: int, reviews_given: int) -> dict[str, Any]:
+    return {
+        "cycle_time": calculate_cycle_time(prs),
+        "pr_size": calculate_pr_size(prs),
+        "avg_lines_per_pr": calculate_avg_lines_per_pr(prs),
+        "pr_count": calculate_throughput(prs),
+        "pickup_time": calculate_pickup_time(prs),
+        "review_time": calculate_review_time(prs),
+        "prs_per_week": calculate_prs_per_week(prs, period_days),
+        "reviews_given": reviews_given,
+        "ai_percentage": calculate_ai_percentage(prs),
+    }
+
+
+def _dev_raws(
+    all_prs: list[PullRequest], period_days: int, reviewer_counts: dict[str, int]
+) -> dict[str, dict[str, Any]]:
+    return {
+        dev: _row_dict(dev_prs, period_days, reviewer_counts.get(dev, 0))
+        for dev, dev_prs in group_prs_by_devs(all_prs).items()
+    }
+
+
+def _active_repo_raws(
+    repo_prs: dict[str, list[PullRequest]], period_days: int
+) -> dict[str, dict[str, Any]]:
+    raws: dict[str, dict[str, Any]] = {}
+    for name, prs in repo_prs.items():
+        reviews_given = sum(calculate_reviews_given(prs).values())
+        raw = _row_dict(prs, period_days, reviews_given)
+        if raw["pr_count"] > 0:
+            raws[name] = raw
+    return raws
+
+
+def _team_row(
+    all_prs: list[PullRequest],
+    period_days: int,
+    dev_raws: dict[str, dict[str, Any]],
+    devs: tuple[Row, ...],
+    reviewer_counts: dict[str, int],
+) -> Row:
+    raw = _row_dict(all_prs, period_days, sum(reviewer_counts.values()))
+    for key in _PER_DEV_AGGREGATED_KEYS:
+        values = [m[key] for m in dev_raws.values() if m.get(key)]
+        raw[key] = round(median(values), 2) if values else 0.0
+    ai_values = [m["ai_percentage"] for m in dev_raws.values()]
+    raw["ai_percentage"] = round(sum(ai_values) / len(ai_values), 1) if ai_values else 0.0
+    team_health = round(sum(r.health for r in devs) / len(devs)) if devs else 0
+    return _to_row("team", raw, team_health)
+
+
+def _rank(
+    raws: dict[str, dict[str, Any]],
+    health_fn: Callable[[dict[str, Any], list[dict[str, Any]]], int],
+) -> tuple[Row, ...]:
+    cohort = list(raws.values())
+    rows = [_to_row(name, m, health_fn(m, cohort)) for name, m in raws.items()]
+    rows.sort(key=lambda r: r.health, reverse=True)
+    return tuple(rows)
+
+
+def _to_row(name: str, m: dict[str, Any], health: int) -> Row:
+    return Row(
+        name=name,
+        pr_count=int(m.get("pr_count", 0)),
+        cycle_time=float(m.get("cycle_time", 0)),
+        pickup_time=float(m.get("pickup_time", 0)),
+        review_time=float(m.get("review_time", 0)),
+        pr_size=float(m.get("pr_size", 0)),
+        avg_lines_per_pr=float(m.get("avg_lines_per_pr", 0)),
+        prs_per_week=float(m.get("prs_per_week", 0)),
+        reviews_given=int(m.get("reviews_given", 0)),
+        ai_percentage=float(m.get("ai_percentage", 0)),
+        health=health,
+        band=_band(health),
+    )
+
+
+def _build_summary(
+    devs: tuple[Row, ...],
+    reviewer_counts: dict[str, int],
+    team: Row,
+) -> Summary:
+    ai_per_dev = tuple(sorted(int(r.ai_percentage) for r in devs))
+    total_reviews = team.reviews_given
+    pr_count = team.pr_count
+
+    filtered_reviewers = {r: int(c) for r, c in reviewer_counts.items() if c}
+    top_reviewer = ""
+    max_review_share = 0
+    if total_reviews > 0 and filtered_reviewers:
+        top_reviewer = max(sorted(filtered_reviewers), key=lambda d: filtered_reviewers[d])
+        max_review_share = round(filtered_reviewers[top_reviewer] / total_reviews * 100)
+
+    return Summary(
+        ai_per_dev=ai_per_dev,
+        review_ratio=round(total_reviews / pr_count, 2) if pr_count else 0.0,
+        top_reviewer=top_reviewer,
+        max_review_share=max_review_share,
+    )
+
+
+__all__ = ["Band", "MetricsSnapshot", "Row", "Summary"]

--- a/tests/unit/test_snapshot.py
+++ b/tests/unit/test_snapshot.py
@@ -1,0 +1,144 @@
+"""Unit tests for MetricsSnapshot."""
+
+from datetime import UTC, datetime
+
+from git_dev_metrics.metrics import MetricsSnapshot
+from git_dev_metrics.utils import TimePeriod
+
+from .conftest import any_pr, approved_review
+
+
+def _period() -> TimePeriod:
+    return TimePeriod(
+        since=datetime(2024, 1, 1, tzinfo=UTC),
+        until=datetime(2024, 1, 31, tzinfo=UTC),
+    )
+
+
+class TestFromRepoPrs:
+    def test_should_return_empty_snapshot_for_no_prs(self):
+        snap = MetricsSnapshot.from_repo_prs({}, _period())
+
+        assert snap.devs == ()
+        assert snap.repos == ()
+        assert snap.team.pr_count == 0
+        assert snap.team.health == 0
+        assert snap.team.band == "bad"
+
+    def test_should_filter_inactive_repos(self):
+        repo_prs = {
+            "org/active": [any_pr(user={"login": "alice"})],
+            "org/empty": [],
+        }
+
+        snap = MetricsSnapshot.from_repo_prs(repo_prs, _period())
+
+        repo_names = [r.name for r in snap.repos]
+        assert "org/active" in repo_names
+        assert "org/empty" not in repo_names
+
+    def test_should_filter_bot_authors_from_devs(self):
+        repo_prs = {
+            "org/r": [
+                any_pr(user={"login": "alice"}),
+                any_pr(user={"login": "dependabot[bot]"}),
+            ]
+        }
+
+        snap = MetricsSnapshot.from_repo_prs(repo_prs, _period())
+
+        dev_names = [d.name for d in snap.devs]
+        assert "alice" in dev_names
+        assert "dependabot[bot]" not in dev_names
+
+    def test_should_sort_devs_by_health_descending(self):
+        snap = MetricsSnapshot.from_repo_prs(
+            {"org/r": [any_pr(user={"login": "alice"}), any_pr(user={"login": "bob"})]},
+            _period(),
+        )
+
+        if len(snap.devs) >= 2:
+            assert snap.devs[0].health >= snap.devs[1].health
+
+    def test_should_sort_repos_by_health_descending(self):
+        repo_prs = {
+            "org/a": [any_pr(user={"login": "alice"})],
+            "org/b": [any_pr(user={"login": "bob"})],
+        }
+
+        snap = MetricsSnapshot.from_repo_prs(repo_prs, _period())
+
+        if len(snap.repos) >= 2:
+            assert snap.repos[0].health >= snap.repos[1].health
+
+    def test_should_aggregate_team_across_all_repos(self):
+        repo_prs = {
+            "org/a": [any_pr(user={"login": "alice"})],
+            "org/b": [any_pr(user={"login": "bob"})],
+        }
+
+        snap = MetricsSnapshot.from_repo_prs(repo_prs, _period())
+
+        assert snap.team.pr_count == 2
+
+    def test_should_carry_reviewer_counts(self):
+        prs = [
+            any_pr(
+                user={"login": "alice"},
+                reviews=[approved_review(login="bob")],
+            )
+        ]
+
+        snap = MetricsSnapshot.from_repo_prs({"org/r": prs}, _period())
+
+        assert snap.reviewer_counts.get("bob") == 1
+
+
+class TestBand:
+    def test_should_band_good_at_80(self):
+        snap = MetricsSnapshot.from_repo_prs({}, _period())
+        rows = (_row_with_health(80), _row_with_health(79), _row_with_health(60))
+
+        assert rows[0].band == "good"
+        assert rows[1].band == "ok"
+        assert rows[2].band == "ok"
+        _ = snap  # snap used to exercise import path
+
+    def test_should_band_bad_below_60(self):
+        row = _row_with_health(59)
+
+        assert row.band == "bad"
+
+
+def _row_with_health(health: int):
+    from git_dev_metrics.metrics.snapshot import _to_row
+
+    return _to_row("x", {"pr_count": 1}, health)
+
+
+class TestSummary:
+    def test_should_pick_top_reviewer_with_share(self):
+        prs = [
+            any_pr(
+                user={"login": "alice"},
+                reviews=[approved_review(login="bob"), approved_review(login="carol")],
+            ),
+            any_pr(
+                number=2,
+                user={"login": "alice"},
+                reviews=[approved_review(login="bob")],
+            ),
+        ]
+
+        snap = MetricsSnapshot.from_repo_prs({"org/r": prs}, _period())
+
+        assert snap.summary.top_reviewer == "bob"
+        assert snap.summary.max_review_share == round(2 / 3 * 100)
+
+    def test_should_return_empty_top_reviewer_when_no_reviews(self):
+        snap = MetricsSnapshot.from_repo_prs(
+            {"org/r": [any_pr(user={"login": "alice"})]}, _period()
+        )
+
+        assert snap.summary.top_reviewer == ""
+        assert snap.summary.max_review_share == 0


### PR DESCRIPTION
## Problem

Metric assembly and health computation are scattered. `_build_dev_metrics` and `_build_metrics` in `analyzer.py` repeat the same nine keys. `calculate_dev_health_score(m, cohort)` is called from four sites and silently degrades if a caller forgets the cohort argument. Sort-by-health is repeated three times. The 80/60 health thresholds appear in three forms (color in `health.py`, emoji in `dev.py`, emoji in `repo.py`). Printers read `metrics[\"dev_metrics\"][dev][\"pr_count\"]` everywhere, untyped.

## Solution

New `metrics/snapshot.py`: a frozen `MetricsSnapshot` built once via `from_repo_prs(repo_prs, period)`. It owns assembly, the cohort-passing health calls, the active-repo filter, the sort, the `band` derivation, and the cross-format summary. Rows are typed `Row` dataclasses with `health` and `band` precomputed. `CONTEXT.md` introduces the domain vocabulary. Nothing is wired yet; printers and CLI still use the old path. Switching call sites and deleting the old assembly come in follow-up PRs.