### PR TITLE
Switch printers and CLI to consume MetricsSnapshot

### DIFF
--- a/git_dev_metrics/cli/_metrics.py
+++ b/git_dev_metrics/cli/_metrics.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import typer
 
 from ..cache import load_all_repos_for_range
-from ..metrics.analyzer import build_combined_metrics_for_repos
+from ..metrics import MetricsSnapshot
 from ..utils.date_utils import month_iter, range_period
 from ._month_arg import parse_month_arg
 
@@ -18,18 +18,18 @@ def _slug(ym: YearMonth) -> str:
 
 def metrics_for_months(
     months: list[YearMonth], db_path: Path | None
-) -> tuple[dict, str, str] | None:
+) -> tuple[MetricsSnapshot, str, str] | None:
     repo_prs = load_all_repos_for_range(months, db_path=db_path)
     if not repo_prs:
         return None
     period = range_period(months[0], months[-1])
-    metrics = build_combined_metrics_for_repos(repo_prs, period)
+    snapshot = MetricsSnapshot.from_repo_prs(repo_prs, period)
     period_slug = f"{_slug(months[0])}-to-{_slug(months[-1])}"
     date_range = f"{period.since.strftime(_DATE_FMT)} to {period.until.strftime(_DATE_FMT)}"
-    return metrics, period_slug, date_range
+    return snapshot, period_slug, date_range
 
 
-def metrics_for_range(from_: str, to: str, db: Path | None) -> tuple[dict, str, str]:
+def metrics_for_range(from_: str, to: str, db: Path | None) -> tuple[MetricsSnapshot, str, str]:
     from_ym = parse_month_arg(from_, "--from")
     to_ym = parse_month_arg(to, "--to")
     if to_ym < from_ym:

--- a/git_dev_metrics/cli/dashboard_runner.py
+++ b/git_dev_metrics/cli/dashboard_runner.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import typer
 
+from ..metrics import MetricsSnapshot
 from ..metrics.printer.html import FileHtmlPrinter
 from ._browser import open_in_browser
 
@@ -13,9 +14,9 @@ def _default_output(period_slug: str) -> Path:
 
 
 def write_and_open_dashboard(
-    metrics: dict, period_slug: str, date_range: str, output: Path | None
+    snapshot: MetricsSnapshot, period_slug: str, date_range: str, output: Path | None
 ) -> None:
     out = (output or _default_output(period_slug)).with_suffix(".html")
-    FileHtmlPrinter(out).print_combined_metrics(metrics, period_slug, date_range)
+    FileHtmlPrinter(out).print_combined_metrics(snapshot, period_slug, date_range)
     typer.echo(f"Dashboard written to {out}.")
     open_in_browser(out)

--- a/git_dev_metrics/metrics/__init__.py
+++ b/git_dev_metrics/metrics/__init__.py
@@ -13,7 +13,8 @@ from .calculator import (
 )
 from .health import calculate_dev_health_score, calculate_health_score
 from .printer import ConsolePrinter, Printer
-from .snapshot import Band, MetricsSnapshot, Row, Summary
+from .snapshot import Band, MetricsSnapshot, Row, Summary, band_color
+from .summary import build_summary
 
 __all__ = [
     "build_combined_metrics_for_repos",
@@ -34,4 +35,6 @@ __all__ = [
     "MetricsSnapshot",
     "Row",
     "Summary",
+    "band_color",
+    "build_summary",
 ]

--- a/git_dev_metrics/metrics/printer/base.py
+++ b/git_dev_metrics/metrics/printer/base.py
@@ -1,10 +1,14 @@
 from abc import ABC, abstractmethod
 
+from ..snapshot import MetricsSnapshot
+
 
 class Printer(ABC):
     """Abstract base class for printing combined metrics."""
 
     @abstractmethod
-    def print_combined_metrics(self, metrics: dict, period: str, date_range: str) -> None:
+    def print_combined_metrics(
+        self, snapshot: MetricsSnapshot, period: str, date_range: str
+    ) -> None:
         """Print both repo and dev metrics."""
         ...

--- a/git_dev_metrics/metrics/printer/dev.py
+++ b/git_dev_metrics/metrics/printer/dev.py
@@ -1,4 +1,4 @@
-from ..health import calculate_dev_health_score, format_health, get_health_color
+from ..snapshot import MetricsSnapshot, band_color
 
 DEV_COLUMNS = [
     "Dev",
@@ -19,7 +19,7 @@ class ConsoleDevPrinter:
     """Print dev metrics to console using Rich."""
 
     def print_combined_metrics(
-        self, metrics: dict, period: str, date_range: str | None = None
+        self, snapshot: MetricsSnapshot, period: str, date_range: str | None = None
     ) -> None:
         from rich.console import Console
         from rich.table import Table
@@ -32,29 +32,20 @@ class ConsoleDevPrinter:
         for col in DEV_COLUMNS:
             table.add_column(col)
 
-        all_dev_metrics = list(metrics["dev_metrics"].values())
-
-        sorted_devs = []
-        for dev, m in metrics["dev_metrics"].items():
-            health = calculate_dev_health_score(m, all_dev_metrics)
-            sorted_devs.append((dev, m, health))
-
-        sorted_devs.sort(key=lambda x: x[2], reverse=True)
-
-        for dev, m, health in sorted_devs:
-            color = get_health_color(health)
+        for row in snapshot.devs:
+            color = band_color(row.band)
             table.add_row(
-                dev,
-                f"[{color}]{format_health(health)}[/{color}]",
-                f"{m['pickup_time']:.2f}",
-                f"{m['review_time']:.2f}",
-                f"{m['cycle_time']:.2f}",
-                f"{m['pr_size']:.1f}",
-                f"{m.get('avg_lines_per_pr', 0):.1f}",
-                f"{m['pr_count']:.0f}",
-                f"{m['prs_per_week']:.2f}",
-                f"{m['reviews_given']:.0f}",
-                f"{m['ai_percentage']:.0f}%",
+                row.name,
+                f"[{color}]{row.health}[/{color}]",
+                f"{row.pickup_time:.2f}",
+                f"{row.review_time:.2f}",
+                f"{row.cycle_time:.2f}",
+                f"{row.pr_size:.1f}",
+                f"{row.avg_lines_per_pr:.1f}",
+                f"{row.pr_count:.0f}",
+                f"{row.prs_per_week:.2f}",
+                f"{row.reviews_given:.0f}",
+                f"{row.ai_percentage:.0f}%",
             )
 
         console.print(table)

--- a/git_dev_metrics/metrics/printer/html.py
+++ b/git_dev_metrics/metrics/printer/html.py
@@ -2,8 +2,7 @@ from pathlib import Path
 
 from jinja2 import Environment, PackageLoader, select_autoescape
 
-from ..health import calculate_dev_health_score
-from ..summary import build_summary
+from ..snapshot import MetricsSnapshot
 from .base import Printer
 
 _ENV: Environment | None = None
@@ -19,27 +18,41 @@ def _get_env() -> Environment:
     return _ENV
 
 
-def _build_devs_list(metrics: dict) -> list[dict]:
-    """Flatten dev_metrics into the row shape the dashboard template expects."""
-    all_dev_metrics = list(metrics["dev_metrics"].values())
-    devs = []
-    for dev, m in metrics["dev_metrics"].items():
-        health = calculate_dev_health_score(m, all_dev_metrics)
-        devs.append(
-            {
-                "name": dev,
-                "health": health,
-                "pickup": m.get("pickup_time", 0),
-                "review": m.get("review_time", 0),
-                "cycle": m.get("cycle_time", 0),
-                "size": int(m.get("pr_size", 0)),
-                "prs": int(m.get("pr_count", 0)),
-                "prs_week": m.get("prs_per_week", 0),
-                "reviews": int(m.get("reviews_given", 0)),
-                "ai": int(m.get("ai_percentage", 0)),
-            }
-        )
-    return devs
+def _devs_for_template(snapshot: MetricsSnapshot) -> list[dict]:
+    return [
+        {
+            "name": row.name,
+            "health": row.health,
+            "pickup": row.pickup_time,
+            "review": row.review_time,
+            "cycle": row.cycle_time,
+            "size": int(row.pr_size),
+            "prs": row.pr_count,
+            "prs_week": row.prs_per_week,
+            "reviews": row.reviews_given,
+            "ai": int(row.ai_percentage),
+        }
+        for row in snapshot.devs
+    ]
+
+
+def _summary_for_template(snapshot: MetricsSnapshot) -> dict:
+    team = snapshot.team
+    summary = snapshot.summary
+    return {
+        "team_health": team.health,
+        "total_prs": team.pr_count,
+        "median_lines_per_pr": round(team.pr_size, 1),
+        "median_cycle": round(team.cycle_time, 1),
+        "median_pickup": round(team.pickup_time, 1),
+        "median_prs_per_week": round(team.prs_per_week, 2),
+        "total_reviews": team.reviews_given,
+        "ai_adoption": round(team.ai_percentage),
+        "ai_per_dev": list(summary.ai_per_dev),
+        "review_ratio": summary.review_ratio,
+        "top_reviewer": summary.top_reviewer,
+        "max_review_share": summary.max_review_share,
+    }
 
 
 class FileHtmlPrinter(Printer):
@@ -48,14 +61,18 @@ class FileHtmlPrinter(Printer):
     def __init__(self, output_path: Path) -> None:
         self._output_path = output_path
 
-    def print_combined_metrics(self, metrics: dict, period: str, date_range: str) -> None:
+    def print_combined_metrics(
+        self, snapshot: MetricsSnapshot, period: str, date_range: str
+    ) -> None:
         env = _get_env()
         template = env.get_template("dashboard.html")
 
-        devs = _build_devs_list(metrics)
-        summary = build_summary(metrics)
-
-        html = template.render(devs=devs, summary=summary, period=period, date_range=date_range)
+        html = template.render(
+            devs=_devs_for_template(snapshot),
+            summary=_summary_for_template(snapshot),
+            period=period,
+            date_range=date_range,
+        )
 
         html_path = self._output_path.with_suffix(".html")
         html_path.parent.mkdir(parents=True, exist_ok=True)

--- a/git_dev_metrics/metrics/printer/printers.py
+++ b/git_dev_metrics/metrics/printer/printers.py
@@ -1,4 +1,4 @@
-from ..summary import build_summary
+from ..snapshot import MetricsSnapshot
 from .base import Printer
 from .dev import ConsoleDevPrinter
 
@@ -9,25 +9,28 @@ class ConsolePrinter(Printer):
     def __init__(self) -> None:
         self._dev_printer = ConsoleDevPrinter()
 
-    def print_combined_metrics(self, metrics: dict, period: str, date_range: str) -> None:
+    def print_combined_metrics(
+        self, snapshot: MetricsSnapshot, period: str, date_range: str
+    ) -> None:
         from rich.console import Console
         from rich.table import Table
 
         console = Console()
 
-        summary = build_summary(metrics)
+        team = snapshot.team
+        summary = snapshot.summary
         cells = [
-            ("Team Health", str(summary["team_health"])),
-            ("Total PRs", str(summary["total_prs"])),
-            ("Median Lines/PR", str(summary["median_lines_per_pr"])),
-            ("Median Cycle (h)", str(summary["median_cycle"])),
-            ("Median Pickup (h)", str(summary["median_pickup"])),
-            ("PRs/Week per Dev", str(summary["median_prs_per_week"])),
-            ("Total Reviews", str(summary["total_reviews"])),
-            ("AI Adoption", f"{summary['ai_adoption']}%"),
-            ("Review Ratio", f"{summary['review_ratio']}x"),
-            ("Top Reviewer", summary["top_reviewer"] or "—"),
-            ("Max Review Share", f"{summary['max_review_share']}%"),
+            ("Team Health", str(team.health)),
+            ("Total PRs", str(team.pr_count)),
+            ("Median Lines/PR", str(round(team.pr_size, 1))),
+            ("Median Cycle (h)", str(round(team.cycle_time, 1))),
+            ("Median Pickup (h)", str(round(team.pickup_time, 1))),
+            ("PRs/Week per Dev", str(round(team.prs_per_week, 2))),
+            ("Total Reviews", str(team.reviews_given)),
+            ("AI Adoption", f"{round(team.ai_percentage)}%"),
+            ("Review Ratio", f"{summary.review_ratio}x"),
+            ("Top Reviewer", summary.top_reviewer or "—"),
+            ("Max Review Share", f"{summary.max_review_share}%"),
         ]
 
         console.print()
@@ -45,7 +48,7 @@ class ConsolePrinter(Printer):
             console.print(table)
         console.print()
 
-        self._dev_printer.print_combined_metrics(metrics, period, date_range)
+        self._dev_printer.print_combined_metrics(snapshot, period, date_range)
 
 
 __all__ = ["ConsolePrinter", "Printer"]

--- a/git_dev_metrics/metrics/snapshot.py
+++ b/git_dev_metrics/metrics/snapshot.py
@@ -27,6 +27,13 @@ from .health import calculate_dev_health_score, calculate_health_score
 
 Band = Literal["good", "ok", "bad"]
 
+_BAND_COLOR: dict[Band, str] = {"good": "green", "ok": "yellow", "bad": "red"}
+
+
+def band_color(band: Band) -> str:
+    return _BAND_COLOR[band]
+
+
 _PER_DEV_AGGREGATED_KEYS = (
     "cycle_time",
     "pickup_time",
@@ -209,4 +216,4 @@ def _build_summary(
     )
 
 
-__all__ = ["Band", "MetricsSnapshot", "Row", "Summary"]
+__all__ = ["Band", "MetricsSnapshot", "Row", "Summary", "band_color"]


### PR DESCRIPTION
## Problem

`cli/_metrics.py`, `ConsolePrinter`, `ConsoleDevPrinter`, and `FileHtmlPrinter` all spoke the old `dict` shape: each printer re-imported `calculate_dev_health_score` (with the easy-to-forget cohort argument), re-sorted devs by health, and re-keyed magic strings like `metrics[\"dev_metrics\"][dev][\"pr_count\"]`. The 80/60 thresholds appeared in two forms.

## Solution

`metrics_for_range` now returns a `MetricsSnapshot`. The base `Printer`, the two console printers, and the HTML printer take a snapshot and read typed `Row` fields; sorts, health, band, and active-repo filtering live behind the snapshot's seam. A small `band_color(band)` mapping replaces inline 80/60 colour thresholds in `ConsoleDevPrinter`. The dashboard template is unchanged: `FileHtmlPrinter` builds the existing `summary` / `devs` dicts from the snapshot, so the template stays a thin renderer. `analyzer.py` and `summary.py` are still imported via `metrics/__init__.py` for now; the follow-up PR deletes them.