### PR TITLE
Fix PullRequest timestamp type inconsistency

### DIFF
--- a/git_dev_metrics/cache/db.py
+++ b/git_dev_metrics/cache/db.py
@@ -67,12 +67,10 @@ def open_connection(db_path: Path | None = None) -> sqlite3.Connection:
     return conn
 
 
-def _iso(value: Any) -> str | None:
+def _iso(value: datetime | None) -> str | None:
     if value is None:
         return None
-    if isinstance(value, datetime):
-        return value.isoformat()
-    return str(value)
+    return value.isoformat()
 
 
 def _pr_row(pr: Mapping[str, Any], org: str, repo: str, year: int, month: int) -> tuple:

--- a/git_dev_metrics/cache/query.py
+++ b/git_dev_metrics/cache/query.py
@@ -1,17 +1,27 @@
 import json
 import sqlite3
 from collections import defaultdict
+from datetime import datetime
 from pathlib import Path
 
 from ..models import PullRequest, Review
 from .db import open_connection
 
 
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
 def _review(row: sqlite3.Row) -> Review:
     return {
         "user": {"login": row["user_login"] or ""},
         "state": row["state"] or "",
-        "submitted_at": row["submitted_at"] or "",
+        "submitted_at": _parse_datetime(row["submitted_at"]),
     }
 
 
@@ -21,14 +31,14 @@ def _pr(row: sqlite3.Row, reviews: list[Review]) -> PullRequest:
         "state": row["state"] or "",
         "title": row["title"] or "",
         "user": {"login": row["author_login"] or ""},
-        "created_at": row["created_at"] or "",
-        "merged_at": row["merged_at"] or "",
-        "closed_at": row["closed_at"] or "",
+        "created_at": _parse_datetime(row["created_at"]),
+        "merged_at": _parse_datetime(row["merged_at"]),
+        "closed_at": _parse_datetime(row["closed_at"]),
         "additions": row["additions"] or 0,
         "deletions": row["deletions"] or 0,
         "changed_files": row["changed_files"] or 0,
-        "first_commit_at": row["first_commit_at"],
-        "ready_for_review_at": row["ready_for_review_at"],
+        "first_commit_at": _parse_datetime(row["first_commit_at"]),
+        "ready_for_review_at": _parse_datetime(row["ready_for_review_at"]),
         "body": row["body"],
         "commit_messages": json.loads(row["commit_messages_json"] or "[]"),
         "reviews": reviews,

--- a/git_dev_metrics/github/queries.py
+++ b/git_dev_metrics/github/queries.py
@@ -82,9 +82,9 @@ def _map_pull_request(pr: dict) -> PullRequest:
 
 def _map_review(review: dict) -> Review:
     """Map GraphQL review response to internal model."""
-    return {  # type: ignore[return-value]
+    return {
         "user": {"login": _author_login(review.get("author"))},
-        "state": review.get("state"),
+        "state": review.get("state"),  # type: ignore[return-value]
         "submitted_at": _parse_datetime(review.get("submittedAt")),
     }
 
@@ -162,7 +162,7 @@ def _filter_and_map_pr(prs: list[dict], period: TimePeriod) -> list[PullRequest]
     for pr in prs:
         mapped = _map_pull_request(pr)
         merged_at = mapped["merged_at"]
-        if merged_at is None or merged_at < period.since or merged_at >= period.until:  # type: ignore[reportOperatorIssue]
+        if merged_at is None or merged_at < period.since or merged_at >= period.until:
             continue
 
         review_nodes = pr.get("reviews", {}).get("nodes", [])
@@ -211,7 +211,7 @@ def fetch_open_prs(token: str, org: str, repo: str, quiet: bool = False) -> list
             {
                 "number": number,
                 "title": title,
-                "created_at": pr.get("createdAt"),
+                "created_at": _parse_datetime(pr.get("createdAt")),
                 "merged_at": None,
                 "user": {"login": _author_login(pr.get("author"))},
                 "is_draft": pr.get("isDraft", False),

--- a/git_dev_metrics/metrics/calculator.py
+++ b/git_dev_metrics/metrics/calculator.py
@@ -40,15 +40,6 @@ def calculate_ai_percentage(prs: list[PullRequest]) -> float:
     return round((ai_count / len(prs)) * 100, 1)
 
 
-def _to_datetime(value: str | datetime | None) -> datetime | None:
-    """Convert string or datetime to datetime object."""
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        return value
-    return datetime.fromisoformat(value.replace("Z", "+00:00"))
-
-
 def median(values: list[float | int]) -> float:
     """Return median of a list of values."""
     if not values:
@@ -72,19 +63,18 @@ def calculate_cycle_time(prs: list[PullRequest]) -> float:
 
     cycle_times = []
     for pr in prs:
-        created = _to_datetime(pr["created_at"])
-        first_commit = _to_datetime(pr.get("first_commit_at"))
-        ready_for_review = _to_datetime(pr.get("ready_for_review_at"))
-        merged = _to_datetime(pr["merged_at"])
-
+        created = pr["created_at"]
+        merged = pr["merged_at"]
         if created is None or merged is None:
             continue
         if _first_approval_at(pr) is None:
             continue
 
-        start_time = created
+        start_time: datetime = created
+        first_commit = pr.get("first_commit_at")
         if first_commit is not None and first_commit < created:
             start_time = first_commit
+        ready_for_review = pr.get("ready_for_review_at")
         if ready_for_review is not None and ready_for_review > start_time:
             start_time = ready_for_review
 
@@ -121,7 +111,7 @@ def calculate_throughput(prs: list[PullRequest]) -> int:
 def _first_approval_at(pr: PullRequest) -> datetime | None:
     for review in pr.get("reviews", []):
         if review.get("state") == "APPROVED":
-            return _to_datetime(review.get("submitted_at"))
+            return review.get("submitted_at")
     return None
 
 
@@ -132,12 +122,12 @@ def calculate_pickup_time(prs: list[PullRequest]) -> float:
 
     pickup_times = []
     for pr in prs:
-        created = _to_datetime(pr["created_at"])
-        ready_for_review = _to_datetime(pr.get("ready_for_review_at"))
+        created = pr["created_at"]
         first_approval = _first_approval_at(pr)
-        if not (created and first_approval):
+        if created is None or first_approval is None:
             continue
-        start_time = created
+        start_time: datetime = created
+        ready_for_review = pr.get("ready_for_review_at")
         if ready_for_review is not None and ready_for_review > start_time:
             start_time = ready_for_review
         pickup_times.append((first_approval - start_time).total_seconds() / 3600)
@@ -154,7 +144,7 @@ def calculate_review_time(prs: list[PullRequest]) -> float:
 
     review_times = []
     for pr in prs:
-        merged = _to_datetime(pr["merged_at"])
+        merged = pr["merged_at"]
         first_approval = _first_approval_at(pr)
         if merged and first_approval:
             review_times.append((merged - first_approval).total_seconds() / 3600)
@@ -205,20 +195,17 @@ STALE_PR_THRESHOLD_HOURS = 24 * 7  # 7 days
 
 
 def _calculate_age_hours(
-    created_at: str | datetime, clock: Callable[[], datetime] | None = None
+    created_at: datetime | None, clock: Callable[[], datetime] | None = None
 ) -> float:
     """Calculate age in hours from created_at to now."""
     from datetime import UTC, datetime
 
     now = clock() if clock else datetime.now(UTC)
-    parsed: datetime | None = (
-        _to_datetime(created_at) if isinstance(created_at, str) else created_at
-    )
-    if parsed is None:
+    if created_at is None:
         return 0.0
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=UTC)
-    return (now - parsed).total_seconds() / 3600
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=UTC)
+    return (now - created_at).total_seconds() / 3600
 
 
 def _is_stale_pr(

--- a/git_dev_metrics/models/types.py
+++ b/git_dev_metrics/models/types.py
@@ -13,14 +13,14 @@ class GitHubUser(TypedDict):
 
 
 class PullRequestInfo(TypedDict):
-    created_at: str
-    merged_at: str
+    created_at: datetime | None
+    merged_at: datetime | None
 
 
 class Review(TypedDict):
     user: GitHubUser
     state: str
-    submitted_at: str
+    submitted_at: datetime | None
 
 
 class PullRequest(PullRequestInfo):
@@ -29,7 +29,7 @@ class PullRequest(PullRequestInfo):
     state: str
     title: str
     user: GitHubUser
-    closed_at: str
+    closed_at: datetime | None
     additions: int
     deletions: int
     changed_files: int
@@ -43,8 +43,8 @@ class PullRequest(PullRequestInfo):
 class OpenPullRequest(TypedDict):
     number: int
     title: str
-    created_at: str | None
-    merged_at: str | None
+    created_at: datetime | None
+    merged_at: datetime | None
     user: GitHubUser
     is_draft: bool
     is_approved: bool

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -15,6 +15,12 @@ def _stub_webbrowser(mocker):
     return mocker.patch("webbrowser.open", return_value=False)
 
 
+def dt(
+    *, year: int, month: int, day: int, hour: int = 0, minute: int = 0, second: int = 0
+) -> datetime:
+    return datetime(year, month, day, hour, minute, second, tzinfo=UTC)
+
+
 def _dt(s: str) -> datetime:
     return datetime.fromisoformat(s.replace("Z", "+00:00"))
 
@@ -42,9 +48,7 @@ def any_pr(**overrides: Any) -> PullRequest:
     return {**defaults, **overrides}  # type: ignore[return-value]
 
 
-def approved_review(
-    submitted_at: datetime | None = None, login: str = "reviewer"
-) -> dict:
+def approved_review(submitted_at: datetime | None = None, login: str = "reviewer") -> dict:
     """Approval review row for use in PullRequest fixtures."""
     if submitted_at is None:
         submitted_at = _dt("2024-01-01T12:00:00Z")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from typing import Any
 
 import freezegun
@@ -14,6 +15,10 @@ def _stub_webbrowser(mocker):
     return mocker.patch("webbrowser.open", return_value=False)
 
 
+def _dt(s: str) -> datetime:
+    return datetime.fromisoformat(s.replace("Z", "+00:00"))
+
+
 def any_pr(**overrides: Any) -> PullRequest:
     """Create a PullRequest with sensible defaults for testing."""
     defaults: PullRequest = {
@@ -22,9 +27,9 @@ def any_pr(**overrides: Any) -> PullRequest:
         "state": "merged",
         "title": "Test PR",
         "user": {"login": "dev1"},
-        "created_at": "2024-01-01T00:00:00Z",
-        "merged_at": "2024-01-02T00:00:00Z",
-        "closed_at": "2024-01-02T00:00:00Z",
+        "created_at": _dt("2024-01-01T00:00:00Z"),
+        "merged_at": _dt("2024-01-02T00:00:00Z"),
+        "closed_at": _dt("2024-01-02T00:00:00Z"),
         "additions": 100,
         "deletions": 50,
         "changed_files": 5,
@@ -37,6 +42,10 @@ def any_pr(**overrides: Any) -> PullRequest:
     return {**defaults, **overrides}  # type: ignore[return-value]
 
 
-def approved_review(submitted_at: str = "2024-01-01T12:00:00Z", login: str = "reviewer") -> dict:
+def approved_review(
+    submitted_at: datetime | None = None, login: str = "reviewer"
+) -> dict:
     """Approval review row for use in PullRequest fixtures."""
+    if submitted_at is None:
+        submitted_at = _dt("2024-01-01T12:00:00Z")
     return {"user": {"login": login}, "state": "APPROVED", "submitted_at": submitted_at}

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,4 +1,5 @@
 import json
+from datetime import UTC, datetime
 
 from git_dev_metrics.cache import (
     count_prs,
@@ -42,8 +43,8 @@ class TestInsertPrs:
         pr_from_mapper = {
             "number": 42,
             "title": "Real PR",
-            "created_at": "2026-04-05T08:00:00+00:00",
-            "merged_at": "2026-04-05T18:00:00+00:00",
+            "created_at": datetime(2026, 4, 5, 8, 0, tzinfo=UTC),
+            "merged_at": datetime(2026, 4, 5, 18, 0, tzinfo=UTC),
             "additions": 100,
             "deletions": 50,
             "changed_files": 5,
@@ -88,8 +89,8 @@ class TestInsertPrs:
         pr = any_pr(
             number=5,
             reviews=[
-                approved_review(login="bob", submitted_at="2026-04-02T10:00:00+00:00"),
-                approved_review(login="carol", submitted_at="2026-04-02T11:00:00+00:00"),
+                approved_review(login="bob", submitted_at=datetime(2026, 4, 2, 10, 0, tzinfo=UTC)),
+                approved_review(login="carol", submitted_at=datetime(2026, 4, 2, 11, 0, tzinfo=UTC)),
             ],
         )
 

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,5 +1,4 @@
 import json
-from datetime import UTC, datetime
 
 from git_dev_metrics.cache import (
     count_prs,
@@ -10,7 +9,7 @@ from git_dev_metrics.cache import (
     seal_month,
 )
 
-from .conftest import any_pr, approved_review
+from .conftest import any_pr, approved_review, dt
 
 
 class TestInsertPrs:
@@ -43,8 +42,8 @@ class TestInsertPrs:
         pr_from_mapper = {
             "number": 42,
             "title": "Real PR",
-            "created_at": datetime(2026, 4, 5, 8, 0, tzinfo=UTC),
-            "merged_at": datetime(2026, 4, 5, 18, 0, tzinfo=UTC),
+            "created_at": dt(year=2026, month=4, day=5, hour=8, minute=0),
+            "merged_at": dt(year=2026, month=4, day=5, hour=18, minute=0),
             "additions": 100,
             "deletions": 50,
             "changed_files": 5,
@@ -89,8 +88,12 @@ class TestInsertPrs:
         pr = any_pr(
             number=5,
             reviews=[
-                approved_review(login="bob", submitted_at=datetime(2026, 4, 2, 10, 0, tzinfo=UTC)),
-                approved_review(login="carol", submitted_at=datetime(2026, 4, 2, 11, 0, tzinfo=UTC)),
+                approved_review(
+                    login="bob", submitted_at=dt(year=2026, month=4, day=2, hour=10, minute=0)
+                ),
+                approved_review(
+                    login="carol", submitted_at=dt(year=2026, month=4, day=2, hour=11, minute=0)
+                ),
             ],
         )
 

--- a/tests/unit/test_cache_query.py
+++ b/tests/unit/test_cache_query.py
@@ -1,8 +1,6 @@
-from datetime import UTC, datetime
-
 from git_dev_metrics.cache import insert_prs, load_prs
 
-from .conftest import any_pr, approved_review
+from .conftest import any_pr, approved_review, dt
 
 
 class TestLoadPrs:
@@ -17,7 +15,11 @@ class TestLoadPrs:
                 deletions=7,
                 changed_files=3,
                 commit_messages=["feat: a", "fix: b"],
-                reviews=[approved_review(login="bob", submitted_at=datetime(2026, 4, 2, 9, 0, tzinfo=UTC))],
+                reviews=[
+                    approved_review(
+                        login="bob", submitted_at=dt(year=2026, month=4, day=2, hour=9, minute=0)
+                    )
+                ],
             ),
             any_pr(id=2, number=12, user={"login": "carol"}, commit_messages=[], reviews=[]),
         ]

--- a/tests/unit/test_cache_query.py
+++ b/tests/unit/test_cache_query.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime
+
 from git_dev_metrics.cache import insert_prs, load_prs
 
 from .conftest import any_pr, approved_review
@@ -15,7 +17,7 @@ class TestLoadPrs:
                 deletions=7,
                 changed_files=3,
                 commit_messages=["feat: a", "fix: b"],
-                reviews=[approved_review(login="bob", submitted_at="2026-04-02T09:00:00+00:00")],
+                reviews=[approved_review(login="bob", submitted_at=datetime(2026, 4, 2, 9, 0, tzinfo=UTC))],
             ),
             any_pr(id=2, number=12, user={"login": "carol"}, commit_messages=[], reviews=[]),
         ]

--- a/tests/unit/test_dashboard_command.py
+++ b/tests/unit/test_dashboard_command.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime
+
 from typer.testing import CliRunner
 
 from git_dev_metrics.cache import insert_prs, seal_month
@@ -12,23 +14,26 @@ def _seed_two_repos_apr(db_path) -> None:
     repo_a = [
         any_pr(
             number=11, user={"login": "alice"}, additions=120, deletions=30, changed_files=4,
-            created_at="2026-04-02T09:00:00Z", merged_at="2026-04-03T10:00:00Z",
-            closed_at="2026-04-03T10:00:00Z",
-            reviews=[approved_review(login="bob", submitted_at="2026-04-02T15:00:00Z")],
+            created_at=datetime(2026, 4, 2, 9, 0, tzinfo=UTC),
+            merged_at=datetime(2026, 4, 3, 10, 0, tzinfo=UTC),
+            closed_at=datetime(2026, 4, 3, 10, 0, tzinfo=UTC),
+            reviews=[approved_review(login="bob", submitted_at=datetime(2026, 4, 2, 15, 0, tzinfo=UTC))],
         ),
         any_pr(
             number=12, user={"login": "bob"}, additions=60, deletions=20, changed_files=3,
-            created_at="2026-04-10T09:00:00Z", merged_at="2026-04-11T11:00:00Z",
-            closed_at="2026-04-11T11:00:00Z",
-            reviews=[approved_review(login="alice", submitted_at="2026-04-10T18:00:00Z")],
+            created_at=datetime(2026, 4, 10, 9, 0, tzinfo=UTC),
+            merged_at=datetime(2026, 4, 11, 11, 0, tzinfo=UTC),
+            closed_at=datetime(2026, 4, 11, 11, 0, tzinfo=UTC),
+            reviews=[approved_review(login="alice", submitted_at=datetime(2026, 4, 10, 18, 0, tzinfo=UTC))],
         ),
     ]
     repo_b = [
         any_pr(
             number=21, user={"login": "alice"}, additions=40, deletions=10, changed_files=2,
-            created_at="2026-04-15T09:00:00Z", merged_at="2026-04-16T13:00:00Z",
-            closed_at="2026-04-16T13:00:00Z",
-            reviews=[approved_review(login="bob", submitted_at="2026-04-15T17:00:00Z")],
+            created_at=datetime(2026, 4, 15, 9, 0, tzinfo=UTC),
+            merged_at=datetime(2026, 4, 16, 13, 0, tzinfo=UTC),
+            closed_at=datetime(2026, 4, 16, 13, 0, tzinfo=UTC),
+            reviews=[approved_review(login="bob", submitted_at=datetime(2026, 4, 15, 17, 0, tzinfo=UTC))],
         ),
     ]
     insert_prs(repo_a, "myorg", "repoA", 2026, 4, db_path=db_path)

--- a/tests/unit/test_dashboard_command.py
+++ b/tests/unit/test_dashboard_command.py
@@ -1,11 +1,9 @@
-from datetime import UTC, datetime
-
 from typer.testing import CliRunner
 
 from git_dev_metrics.cache import insert_prs, seal_month
 from git_dev_metrics.cli.app import app
 
-from .conftest import any_pr, approved_review
+from .conftest import any_pr, approved_review, dt
 
 runner = CliRunner()
 
@@ -13,27 +11,51 @@ runner = CliRunner()
 def _seed_two_repos_apr(db_path) -> None:
     repo_a = [
         any_pr(
-            number=11, user={"login": "alice"}, additions=120, deletions=30, changed_files=4,
-            created_at=datetime(2026, 4, 2, 9, 0, tzinfo=UTC),
-            merged_at=datetime(2026, 4, 3, 10, 0, tzinfo=UTC),
-            closed_at=datetime(2026, 4, 3, 10, 0, tzinfo=UTC),
-            reviews=[approved_review(login="bob", submitted_at=datetime(2026, 4, 2, 15, 0, tzinfo=UTC))],
+            number=11,
+            user={"login": "alice"},
+            additions=120,
+            deletions=30,
+            changed_files=4,
+            created_at=dt(year=2026, month=4, day=2, hour=9, minute=0),
+            merged_at=dt(year=2026, month=4, day=3, hour=10, minute=0),
+            closed_at=dt(year=2026, month=4, day=3, hour=10, minute=0),
+            reviews=[
+                approved_review(
+                    login="bob", submitted_at=dt(year=2026, month=4, day=2, hour=15, minute=0)
+                )
+            ],
         ),
         any_pr(
-            number=12, user={"login": "bob"}, additions=60, deletions=20, changed_files=3,
-            created_at=datetime(2026, 4, 10, 9, 0, tzinfo=UTC),
-            merged_at=datetime(2026, 4, 11, 11, 0, tzinfo=UTC),
-            closed_at=datetime(2026, 4, 11, 11, 0, tzinfo=UTC),
-            reviews=[approved_review(login="alice", submitted_at=datetime(2026, 4, 10, 18, 0, tzinfo=UTC))],
+            number=12,
+            user={"login": "bob"},
+            additions=60,
+            deletions=20,
+            changed_files=3,
+            created_at=dt(year=2026, month=4, day=10, hour=9, minute=0),
+            merged_at=dt(year=2026, month=4, day=11, hour=11, minute=0),
+            closed_at=dt(year=2026, month=4, day=11, hour=11, minute=0),
+            reviews=[
+                approved_review(
+                    login="alice", submitted_at=dt(year=2026, month=4, day=10, hour=18, minute=0)
+                )
+            ],
         ),
     ]
     repo_b = [
         any_pr(
-            number=21, user={"login": "alice"}, additions=40, deletions=10, changed_files=2,
-            created_at=datetime(2026, 4, 15, 9, 0, tzinfo=UTC),
-            merged_at=datetime(2026, 4, 16, 13, 0, tzinfo=UTC),
-            closed_at=datetime(2026, 4, 16, 13, 0, tzinfo=UTC),
-            reviews=[approved_review(login="bob", submitted_at=datetime(2026, 4, 15, 17, 0, tzinfo=UTC))],
+            number=21,
+            user={"login": "alice"},
+            additions=40,
+            deletions=10,
+            changed_files=2,
+            created_at=dt(year=2026, month=4, day=15, hour=9, minute=0),
+            merged_at=dt(year=2026, month=4, day=16, hour=13, minute=0),
+            closed_at=dt(year=2026, month=4, day=16, hour=13, minute=0),
+            reviews=[
+                approved_review(
+                    login="bob", submitted_at=dt(year=2026, month=4, day=15, hour=17, minute=0)
+                )
+            ],
         ),
     ]
     insert_prs(repo_a, "myorg", "repoA", 2026, 4, db_path=db_path)
@@ -53,8 +75,15 @@ class TestDashboardFlagMode:
         result = runner.invoke(
             app,
             [
-                "dashboard", "--from", "2026-04", "--to", "2026-04",
-                "--output", str(out), "--db", str(db_path),
+                "dashboard",
+                "--from",
+                "2026-04",
+                "--to",
+                "2026-04",
+                "--output",
+                str(out),
+                "--db",
+                str(db_path),
             ],
         )
 
@@ -87,9 +116,7 @@ class TestDashboardFlagMode:
         assert matches
         _stub_webbrowser.assert_called_once_with(matches[0].resolve().as_uri())
 
-    def test_should_force_html_suffix_when_user_passes_non_html(
-        self, tmp_path, _stub_webbrowser
-    ):
+    def test_should_force_html_suffix_when_user_passes_non_html(self, tmp_path, _stub_webbrowser):
         # Arrange
         db_path = tmp_path / "cache.db"
         _seed_two_repos_apr(db_path)
@@ -99,8 +126,15 @@ class TestDashboardFlagMode:
         result = runner.invoke(
             app,
             [
-                "dashboard", "--from", "2026-04", "--to", "2026-04",
-                "--output", str(out), "--db", str(db_path),
+                "dashboard",
+                "--from",
+                "2026-04",
+                "--to",
+                "2026-04",
+                "--output",
+                str(out),
+                "--db",
+                str(db_path),
             ],
         )
 

--- a/tests/unit/test_dashboard_wizard.py
+++ b/tests/unit/test_dashboard_wizard.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime
+
 import pytest
 import typer
 
@@ -15,9 +17,9 @@ def _seed_feb_mar_apr(db_path) -> None:
                     any_pr(
                         number=year * 100 + month, user={"login": "alice"},
                         additions=20, deletions=5, changed_files=2,
-                        created_at=f"2026-{month:02d}-{day:02d}T08:00:00Z",
-                        merged_at=f"2026-{month:02d}-{day:02d}T16:00:00Z",
-                        closed_at=f"2026-{month:02d}-{day:02d}T16:00:00Z",
+                        created_at=datetime(year, month, day, 8, 0, tzinfo=UTC),
+                        merged_at=datetime(year, month, day, 16, 0, tzinfo=UTC),
+                        closed_at=datetime(year, month, day, 16, 0, tzinfo=UTC),
                         reviews=[approved_review(login="bob")],
                     )
                 ],

--- a/tests/unit/test_dashboard_wizard.py
+++ b/tests/unit/test_dashboard_wizard.py
@@ -1,12 +1,10 @@
-from datetime import UTC, datetime
-
 import pytest
 import typer
 
 from git_dev_metrics.cache import insert_prs, seal_month
 from git_dev_metrics.cli.dashboard_wizard import dashboard_wizard
 
-from .conftest import any_pr, approved_review
+from .conftest import any_pr, approved_review, dt
 
 
 def _seed_feb_mar_apr(db_path) -> None:
@@ -15,23 +13,28 @@ def _seed_feb_mar_apr(db_path) -> None:
             insert_prs(
                 [
                     any_pr(
-                        number=year * 100 + month, user={"login": "alice"},
-                        additions=20, deletions=5, changed_files=2,
-                        created_at=datetime(year, month, day, 8, 0, tzinfo=UTC),
-                        merged_at=datetime(year, month, day, 16, 0, tzinfo=UTC),
-                        closed_at=datetime(year, month, day, 16, 0, tzinfo=UTC),
+                        number=year * 100 + month,
+                        user={"login": "alice"},
+                        additions=20,
+                        deletions=5,
+                        changed_files=2,
+                        created_at=dt(year=year, month=month, day=day, hour=8, minute=0),
+                        merged_at=dt(year=year, month=month, day=day, hour=16, minute=0),
+                        closed_at=dt(year=year, month=month, day=day, hour=16, minute=0),
                         reviews=[approved_review(login="bob")],
                     )
                 ],
-                org, repo, year, month, db_path=db_path,
+                org,
+                repo,
+                year,
+                month,
+                db_path=db_path,
             )
             seal_month(org, repo, year, month, db_path=db_path)
 
 
 class TestDashboardWizardRenders:
-    def test_should_render_html_and_open_browser(
-        self, tmp_path, monkeypatch, _stub_webbrowser
-    ):
+    def test_should_render_html_and_open_browser(self, tmp_path, monkeypatch, _stub_webbrowser):
         # Arrange
         db_path = tmp_path / "cache.db"
         _seed_feb_mar_apr(db_path)

--- a/tests/unit/test_github.py
+++ b/tests/unit/test_github.py
@@ -1,5 +1,4 @@
 import re
-from datetime import UTC, datetime
 
 import responses
 from pytest import raises
@@ -13,6 +12,8 @@ from git_dev_metrics.github import (
 from git_dev_metrics.github.graphql_client import execute_paginated_query, get_client
 from git_dev_metrics.github.graphql_queries import REPO_METRICS_QUERY
 from git_dev_metrics.utils import TimePeriod
+
+from .conftest import dt
 
 
 class TestFetchRepositories:
@@ -81,7 +82,7 @@ class TestFetchRepositories:
             status=200,
         )
         period = TimePeriod(
-            since=datetime(2024, 1, 1, tzinfo=UTC), until=datetime(2024, 2, 1, tzinfo=UTC)
+            since=dt(year=2024, month=1, day=1), until=dt(year=2024, month=2, day=1)
         )
 
         result = fetch_pull_requests("fake-token", "facebook", "react", period)
@@ -102,7 +103,7 @@ class TestFetchRepositories:
             status=200,
         )
         period = TimePeriod(
-            since=datetime(2024, 3, 1, tzinfo=UTC), until=datetime(2024, 4, 1, tzinfo=UTC)
+            since=dt(year=2024, month=3, day=1), until=dt(year=2024, month=4, day=1)
         )
 
         result = fetch_pull_requests("fake-token", "facebook", "react", period)
@@ -147,9 +148,7 @@ class TestFetchReviews:
             "facebook",
             "react",
             [1],
-            TimePeriod(
-                since=datetime(2024, 1, 1, tzinfo=UTC), until=datetime(2024, 2, 1, tzinfo=UTC)
-            ),
+            TimePeriod(since=dt(year=2024, month=1, day=1), until=dt(year=2024, month=2, day=1)),
         )
 
         assert len(result) == 1
@@ -185,9 +184,7 @@ class TestFetchReviews:
             "facebook",
             "react",
             [1],
-            TimePeriod(
-                since=datetime(2024, 1, 1, tzinfo=UTC), until=datetime(2024, 2, 1, tzinfo=UTC)
-            ),
+            TimePeriod(since=dt(year=2024, month=1, day=1), until=dt(year=2024, month=2, day=1)),
         )
 
         assert 1 in result
@@ -200,9 +197,7 @@ class TestFetchReviews:
             "facebook",
             "react",
             [],
-            TimePeriod(
-                since=datetime(2024, 1, 1, tzinfo=UTC), until=datetime(2024, 2, 1, tzinfo=UTC)
-            ),
+            TimePeriod(since=dt(year=2024, month=1, day=1), until=dt(year=2024, month=2, day=1)),
         )
 
         assert result == {}

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,6 +1,5 @@
 """Unit tests for reports.py functions."""
 
-from datetime import UTC, datetime
 from typing import cast
 
 from git_dev_metrics.metrics import (
@@ -17,7 +16,7 @@ from git_dev_metrics.models import OpenPullRequest
 from git_dev_metrics.utils import TimePeriod
 from git_dev_metrics.utils import period_days as _period_days
 
-from .conftest import any_pr, approved_review
+from .conftest import any_pr, approved_review, dt
 
 
 class TestMedian:
@@ -55,9 +54,9 @@ class TestCalculateCycleTime:
     def test_should_return_correct_cycle_time_for_single_pr(self):
         prs = [
             any_pr(
-                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
-                merged_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
-                reviews=[approved_review(datetime(2024, 1, 1, 6, 0, tzinfo=UTC))],
+                created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
+                merged_at=dt(year=2024, month=1, day=2, hour=0, minute=0),
+                reviews=[approved_review(dt(year=2024, month=1, day=1, hour=6, minute=0))],
             )
         ]
 
@@ -68,14 +67,14 @@ class TestCalculateCycleTime:
     def test_should_return_average_cycle_time_for_multiple_prs(self):
         prs = [
             any_pr(
-                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
-                merged_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
-                reviews=[approved_review(datetime(2024, 1, 1, 6, 0, tzinfo=UTC))],
+                created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
+                merged_at=dt(year=2024, month=1, day=2, hour=0, minute=0),
+                reviews=[approved_review(dt(year=2024, month=1, day=1, hour=6, minute=0))],
             ),
             any_pr(
-                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
-                merged_at=datetime(2024, 1, 3, 0, 0, tzinfo=UTC),
-                reviews=[approved_review(datetime(2024, 1, 1, 6, 0, tzinfo=UTC))],
+                created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
+                merged_at=dt(year=2024, month=1, day=3, hour=0, minute=0),
+                reviews=[approved_review(dt(year=2024, month=1, day=1, hour=6, minute=0))],
             ),
         ]
 
@@ -86,9 +85,9 @@ class TestCalculateCycleTime:
     def test_should_handle_prs_with_different_time_zones(self):
         prs = [
             any_pr(
-                created_at=datetime(2024, 1, 1, 12, 0, tzinfo=UTC),
-                merged_at=datetime(2024, 1, 2, 12, 0, tzinfo=UTC),
-                reviews=[approved_review(datetime(2024, 1, 1, 18, 0, tzinfo=UTC))],
+                created_at=dt(year=2024, month=1, day=1, hour=12, minute=0),
+                merged_at=dt(year=2024, month=1, day=2, hour=12, minute=0),
+                reviews=[approved_review(dt(year=2024, month=1, day=1, hour=18, minute=0))],
             ),
         ]
 
@@ -99,10 +98,10 @@ class TestCalculateCycleTime:
     def test_should_use_first_commit_when_older_than_created_at(self):
         prs = [
             any_pr(
-                created_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
-                merged_at=datetime(2024, 1, 3, 0, 0, tzinfo=UTC),
-                first_commit_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
-                reviews=[approved_review(datetime(2024, 1, 2, 12, 0, tzinfo=UTC))],
+                created_at=dt(year=2024, month=1, day=2, hour=0, minute=0),
+                merged_at=dt(year=2024, month=1, day=3, hour=0, minute=0),
+                first_commit_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
+                reviews=[approved_review(dt(year=2024, month=1, day=2, hour=12, minute=0))],
             ),
         ]
 
@@ -113,10 +112,10 @@ class TestCalculateCycleTime:
     def test_should_use_created_at_when_older_than_first_commit(self):
         prs = [
             any_pr(
-                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
-                merged_at=datetime(2024, 1, 3, 0, 0, tzinfo=UTC),
-                first_commit_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
-                reviews=[approved_review(datetime(2024, 1, 2, 12, 0, tzinfo=UTC))],
+                created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
+                merged_at=dt(year=2024, month=1, day=3, hour=0, minute=0),
+                first_commit_at=dt(year=2024, month=1, day=2, hour=0, minute=0),
+                reviews=[approved_review(dt(year=2024, month=1, day=2, hour=12, minute=0))],
             ),
         ]
 
@@ -127,10 +126,10 @@ class TestCalculateCycleTime:
     def test_should_use_created_at_when_first_commit_is_none(self):
         prs = [
             any_pr(
-                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
-                merged_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
+                created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
+                merged_at=dt(year=2024, month=1, day=2, hour=0, minute=0),
                 first_commit_at=None,
-                reviews=[approved_review(datetime(2024, 1, 1, 6, 0, tzinfo=UTC))],
+                reviews=[approved_review(dt(year=2024, month=1, day=1, hour=6, minute=0))],
             ),
         ]
 
@@ -141,10 +140,10 @@ class TestCalculateCycleTime:
     def test_should_exclude_draft_window_using_ready_for_review_at(self):
         prs = [
             any_pr(
-                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
-                ready_for_review_at=datetime(2024, 1, 4, 0, 0, tzinfo=UTC),
-                merged_at=datetime(2024, 1, 5, 0, 0, tzinfo=UTC),
-                reviews=[approved_review(datetime(2024, 1, 4, 12, 0, tzinfo=UTC))],
+                created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
+                ready_for_review_at=dt(year=2024, month=1, day=4, hour=0, minute=0),
+                merged_at=dt(year=2024, month=1, day=5, hour=0, minute=0),
+                reviews=[approved_review(dt(year=2024, month=1, day=4, hour=12, minute=0))],
             ),
         ]
 
@@ -155,11 +154,11 @@ class TestCalculateCycleTime:
     def test_should_ignore_ready_for_review_when_before_start_time(self):
         prs = [
             any_pr(
-                created_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
-                first_commit_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
-                ready_for_review_at=datetime(2023, 12, 31, 0, 0, tzinfo=UTC),
-                merged_at=datetime(2024, 1, 3, 0, 0, tzinfo=UTC),
-                reviews=[approved_review(datetime(2024, 1, 2, 12, 0, tzinfo=UTC))],
+                created_at=dt(year=2024, month=1, day=2, hour=0, minute=0),
+                first_commit_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
+                ready_for_review_at=dt(year=2023, month=12, day=31, hour=0, minute=0),
+                merged_at=dt(year=2024, month=1, day=3, hour=0, minute=0),
+                reviews=[approved_review(dt(year=2024, month=1, day=2, hour=12, minute=0))],
             ),
         ]
 
@@ -170,8 +169,8 @@ class TestCalculateCycleTime:
     def test_should_skip_prs_without_approval(self):
         prs = [
             any_pr(
-                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
-                merged_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
+                created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
+                merged_at=dt(year=2024, month=1, day=2, hour=0, minute=0),
                 reviews=[],
             ),
         ]
@@ -270,8 +269,8 @@ class TestCalculatePickupTime:
         prs = [
             any_pr(
                 number=1,
-                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
-                merged_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
+                created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
+                merged_at=dt(year=2024, month=1, day=2, hour=0, minute=0),
                 reviews=[],
             )
         ]
@@ -282,13 +281,13 @@ class TestCalculatePickupTime:
         prs = [
             any_pr(
                 number=1,
-                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
-                merged_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
+                created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
+                merged_at=dt(year=2024, month=1, day=2, hour=0, minute=0),
                 reviews=[
                     {
                         "user": {"login": "reviewer"},
                         "state": "COMMENTED",
-                        "submitted_at": datetime(2024, 1, 1, 12, 0, tzinfo=UTC),
+                        "submitted_at": dt(year=2024, month=1, day=1, hour=12, minute=0),
                     }
                 ],
             )
@@ -300,13 +299,13 @@ class TestCalculatePickupTime:
         prs = [
             any_pr(
                 number=1,
-                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
-                merged_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
+                created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
+                merged_at=dt(year=2024, month=1, day=2, hour=0, minute=0),
                 reviews=[
                     {
                         "user": {"login": "reviewer"},
                         "state": "APPROVED",
-                        "submitted_at": datetime(2024, 1, 1, 12, 0, tzinfo=UTC),
+                        "submitted_at": dt(year=2024, month=1, day=1, hour=12, minute=0),
                     }
                 ],
             )
@@ -318,10 +317,10 @@ class TestCalculatePickupTime:
         prs = [
             any_pr(
                 number=1,
-                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
-                ready_for_review_at=datetime(2024, 1, 4, 0, 0, tzinfo=UTC),
-                merged_at=datetime(2024, 1, 5, 0, 0, tzinfo=UTC),
-                reviews=[approved_review(datetime(2024, 1, 4, 6, 0, tzinfo=UTC))],
+                created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
+                ready_for_review_at=dt(year=2024, month=1, day=4, hour=0, minute=0),
+                merged_at=dt(year=2024, month=1, day=5, hour=0, minute=0),
+                reviews=[approved_review(dt(year=2024, month=1, day=4, hour=6, minute=0))],
             )
         ]
         result = calculate_pickup_time(prs)
@@ -339,13 +338,13 @@ class TestCalculateReviewTime:
         prs = [
             any_pr(
                 number=1,
-                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
-                merged_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
+                created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
+                merged_at=dt(year=2024, month=1, day=2, hour=0, minute=0),
                 reviews=[
                     {
                         "user": {"login": "reviewer"},
                         "state": "COMMENTED",
-                        "submitted_at": datetime(2024, 1, 1, 12, 0, tzinfo=UTC),
+                        "submitted_at": dt(year=2024, month=1, day=1, hour=12, minute=0),
                     }
                 ],
             )
@@ -357,13 +356,13 @@ class TestCalculateReviewTime:
         prs = [
             any_pr(
                 number=1,
-                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
-                merged_at=datetime(2024, 1, 3, 0, 0, tzinfo=UTC),
+                created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
+                merged_at=dt(year=2024, month=1, day=3, hour=0, minute=0),
                 reviews=[
                     {
                         "user": {"login": "reviewer"},
                         "state": "APPROVED",
-                        "submitted_at": datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
+                        "submitted_at": dt(year=2024, month=1, day=2, hour=0, minute=0),
                     }
                 ],
             )
@@ -400,37 +399,37 @@ class TestPeriodDays:
 
     def test_should_return_28_for_february_non_leap(self):
         period = TimePeriod(
-            since=datetime(2026, 2, 1, tzinfo=UTC),
-            until=datetime(2026, 3, 1, tzinfo=UTC),
+            since=dt(year=2026, month=2, day=1),
+            until=dt(year=2026, month=3, day=1),
         )
 
         assert _period_days(period) == 28
 
     def test_should_return_29_for_february_leap(self):
         period = TimePeriod(
-            since=datetime(2024, 2, 1, tzinfo=UTC),
-            until=datetime(2024, 3, 1, tzinfo=UTC),
+            since=dt(year=2024, month=2, day=1),
+            until=dt(year=2024, month=3, day=1),
         )
 
         assert _period_days(period) == 29
 
     def test_should_return_31_for_thirty_one_day_month(self):
         period = TimePeriod(
-            since=datetime(2026, 3, 1, tzinfo=UTC),
-            until=datetime(2026, 4, 1, tzinfo=UTC),
+            since=dt(year=2026, month=3, day=1),
+            until=dt(year=2026, month=4, day=1),
         )
 
         assert _period_days(period) == 31
 
     def test_should_return_exact_days_for_sliding_window(self):
-        until = datetime(2026, 5, 8, 12, 0, tzinfo=UTC)
-        since = datetime(2026, 4, 8, 12, 0, tzinfo=UTC)
+        until = dt(year=2026, month=5, day=8, hour=12, minute=0)
+        since = dt(year=2026, month=4, day=8, hour=12, minute=0)
         period = TimePeriod(since=since, until=until)
 
         assert _period_days(period) == 30
 
     def test_should_clamp_to_one_for_zero_span(self):
-        instant = datetime(2026, 5, 8, tzinfo=UTC)
+        instant = dt(year=2026, month=5, day=8)
         period = TimePeriod(since=instant, until=instant)
 
         assert _period_days(period) == 1
@@ -441,8 +440,8 @@ class TestCalculatePrsPerWeekUsesActualSpan:
 
     def test_should_match_calendar_month_length_for_february(self):
         period = TimePeriod(
-            since=datetime(2026, 2, 1, tzinfo=UTC),
-            until=datetime(2026, 3, 1, tzinfo=UTC),
+            since=dt(year=2026, month=2, day=1),
+            until=dt(year=2026, month=3, day=1),
         )
         prs = [any_pr(id=i, number=i) for i in range(1, 5)]
 
@@ -473,7 +472,7 @@ class TestCalculateReviewsGiven:
                     {
                         "user": {"login": "bob"},
                         "state": "APPROVED",
-                        "submitted_at": datetime(2024, 1, 1, 1, 0, tzinfo=UTC),
+                        "submitted_at": dt(year=2024, month=1, day=1, hour=1, minute=0),
                     },
                 ],
             ),
@@ -485,7 +484,7 @@ class TestCalculateReviewsGiven:
                     {
                         "user": {"login": "alice"},
                         "state": "APPROVED",
-                        "submitted_at": datetime(2024, 1, 1, 2, 0, tzinfo=UTC),
+                        "submitted_at": dt(year=2024, month=1, day=1, hour=2, minute=0),
                     },
                 ],
             ),
@@ -506,7 +505,7 @@ class TestCalculateReviewsGiven:
                     {
                         "user": {"login": "external-reviewer"},
                         "state": "APPROVED",
-                        "submitted_at": datetime(2024, 1, 1, 1, 0, tzinfo=UTC),
+                        "submitted_at": dt(year=2024, month=1, day=1, hour=1, minute=0),
                     },
                 ],
             ),
@@ -527,17 +526,17 @@ class TestCalculateReviewsGiven:
                     {
                         "user": {"login": "bob"},
                         "state": "COMMENTED",
-                        "submitted_at": datetime(2024, 1, 1, 1, 0, tzinfo=UTC),
+                        "submitted_at": dt(year=2024, month=1, day=1, hour=1, minute=0),
                     },
                     {
                         "user": {"login": "bob"},
                         "state": "CHANGES_REQUESTED",
-                        "submitted_at": datetime(2024, 1, 1, 2, 0, tzinfo=UTC),
+                        "submitted_at": dt(year=2024, month=1, day=1, hour=2, minute=0),
                     },
                     {
                         "user": {"login": "bob"},
                         "state": "APPROVED",
-                        "submitted_at": datetime(2024, 1, 1, 3, 0, tzinfo=UTC),
+                        "submitted_at": dt(year=2024, month=1, day=1, hour=3, minute=0),
                     },
                 ],
             ),
@@ -562,7 +561,7 @@ class TestCalculateReviewsGiven:
                     {
                         "user": {"login": "alice"},
                         "state": "APPROVED",
-                        "submitted_at": datetime(2024, 1, 1, 1, 0, tzinfo=UTC),
+                        "submitted_at": dt(year=2024, month=1, day=1, hour=1, minute=0),
                     },
                 ],
             ),
@@ -587,7 +586,7 @@ class TestCalculateReviewsGiven:
                     {
                         "user": {"login": "patches-bot"},
                         "state": "APPROVED",
-                        "submitted_at": datetime(2024, 1, 1, 1, 0, tzinfo=UTC),
+                        "submitted_at": dt(year=2024, month=1, day=1, hour=1, minute=0),
                     },
                 ],
             )
@@ -611,13 +610,13 @@ class TestCalculateReviewsGiven:
                 id=10,
                 number=1,
                 user={"login": "alice"},
-                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
-                merged_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
+                created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
+                merged_at=dt(year=2024, month=1, day=2, hour=0, minute=0),
                 reviews=[
                     {
                         "user": {"login": "bob"},
                         "state": "APPROVED",
-                        "submitted_at": datetime(2024, 1, 1, 2, 0, tzinfo=UTC),
+                        "submitted_at": dt(year=2024, month=1, day=1, hour=2, minute=0),
                     }
                 ],
             ),
@@ -625,13 +624,13 @@ class TestCalculateReviewsGiven:
                 id=20,
                 number=1,
                 user={"login": "carol"},
-                created_at=datetime(2024, 2, 1, 0, 0, tzinfo=UTC),
-                merged_at=datetime(2024, 2, 2, 0, 0, tzinfo=UTC),
+                created_at=dt(year=2024, month=2, day=1, hour=0, minute=0),
+                merged_at=dt(year=2024, month=2, day=2, hour=0, minute=0),
                 reviews=[
                     {
                         "user": {"login": "dave"},
                         "state": "APPROVED",
-                        "submitted_at": datetime(2024, 2, 1, 5, 0, tzinfo=UTC),
+                        "submitted_at": dt(year=2024, month=2, day=1, hour=5, minute=0),
                     }
                 ],
             ),
@@ -903,5 +902,3 @@ class TestCalculateAiPercentage:
         ]
         result = calculate_ai_percentage(prs)
         assert result == 50.0
-
-

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -55,9 +55,9 @@ class TestCalculateCycleTime:
     def test_should_return_correct_cycle_time_for_single_pr(self):
         prs = [
             any_pr(
-                created_at="2024-01-01T00:00:00Z",
-                merged_at="2024-01-02T00:00:00Z",
-                reviews=[approved_review("2024-01-01T06:00:00Z")],
+                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
+                merged_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
+                reviews=[approved_review(datetime(2024, 1, 1, 6, 0, tzinfo=UTC))],
             )
         ]
 
@@ -68,14 +68,14 @@ class TestCalculateCycleTime:
     def test_should_return_average_cycle_time_for_multiple_prs(self):
         prs = [
             any_pr(
-                created_at="2024-01-01T00:00:00Z",
-                merged_at="2024-01-02T00:00:00Z",
-                reviews=[approved_review("2024-01-01T06:00:00Z")],
+                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
+                merged_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
+                reviews=[approved_review(datetime(2024, 1, 1, 6, 0, tzinfo=UTC))],
             ),
             any_pr(
-                created_at="2024-01-01T00:00:00Z",
-                merged_at="2024-01-03T00:00:00Z",
-                reviews=[approved_review("2024-01-01T06:00:00Z")],
+                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
+                merged_at=datetime(2024, 1, 3, 0, 0, tzinfo=UTC),
+                reviews=[approved_review(datetime(2024, 1, 1, 6, 0, tzinfo=UTC))],
             ),
         ]
 
@@ -86,9 +86,9 @@ class TestCalculateCycleTime:
     def test_should_handle_prs_with_different_time_zones(self):
         prs = [
             any_pr(
-                created_at="2024-01-01T12:00:00Z",
-                merged_at="2024-01-02T12:00:00Z",
-                reviews=[approved_review("2024-01-01T18:00:00Z")],
+                created_at=datetime(2024, 1, 1, 12, 0, tzinfo=UTC),
+                merged_at=datetime(2024, 1, 2, 12, 0, tzinfo=UTC),
+                reviews=[approved_review(datetime(2024, 1, 1, 18, 0, tzinfo=UTC))],
             ),
         ]
 
@@ -99,10 +99,10 @@ class TestCalculateCycleTime:
     def test_should_use_first_commit_when_older_than_created_at(self):
         prs = [
             any_pr(
-                created_at="2024-01-02T00:00:00Z",
-                merged_at="2024-01-03T00:00:00Z",
-                first_commit_at="2024-01-01T00:00:00Z",
-                reviews=[approved_review("2024-01-02T12:00:00Z")],
+                created_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
+                merged_at=datetime(2024, 1, 3, 0, 0, tzinfo=UTC),
+                first_commit_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
+                reviews=[approved_review(datetime(2024, 1, 2, 12, 0, tzinfo=UTC))],
             ),
         ]
 
@@ -113,10 +113,10 @@ class TestCalculateCycleTime:
     def test_should_use_created_at_when_older_than_first_commit(self):
         prs = [
             any_pr(
-                created_at="2024-01-01T00:00:00Z",
-                merged_at="2024-01-03T00:00:00Z",
-                first_commit_at="2024-01-02T00:00:00Z",
-                reviews=[approved_review("2024-01-02T12:00:00Z")],
+                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
+                merged_at=datetime(2024, 1, 3, 0, 0, tzinfo=UTC),
+                first_commit_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
+                reviews=[approved_review(datetime(2024, 1, 2, 12, 0, tzinfo=UTC))],
             ),
         ]
 
@@ -127,10 +127,10 @@ class TestCalculateCycleTime:
     def test_should_use_created_at_when_first_commit_is_none(self):
         prs = [
             any_pr(
-                created_at="2024-01-01T00:00:00Z",
-                merged_at="2024-01-02T00:00:00Z",
+                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
+                merged_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
                 first_commit_at=None,
-                reviews=[approved_review("2024-01-01T06:00:00Z")],
+                reviews=[approved_review(datetime(2024, 1, 1, 6, 0, tzinfo=UTC))],
             ),
         ]
 
@@ -141,10 +141,10 @@ class TestCalculateCycleTime:
     def test_should_exclude_draft_window_using_ready_for_review_at(self):
         prs = [
             any_pr(
-                created_at="2024-01-01T00:00:00Z",
-                ready_for_review_at="2024-01-04T00:00:00Z",
-                merged_at="2024-01-05T00:00:00Z",
-                reviews=[approved_review("2024-01-04T12:00:00Z")],
+                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
+                ready_for_review_at=datetime(2024, 1, 4, 0, 0, tzinfo=UTC),
+                merged_at=datetime(2024, 1, 5, 0, 0, tzinfo=UTC),
+                reviews=[approved_review(datetime(2024, 1, 4, 12, 0, tzinfo=UTC))],
             ),
         ]
 
@@ -155,11 +155,11 @@ class TestCalculateCycleTime:
     def test_should_ignore_ready_for_review_when_before_start_time(self):
         prs = [
             any_pr(
-                created_at="2024-01-02T00:00:00Z",
-                first_commit_at="2024-01-01T00:00:00Z",
-                ready_for_review_at="2023-12-31T00:00:00Z",
-                merged_at="2024-01-03T00:00:00Z",
-                reviews=[approved_review("2024-01-02T12:00:00Z")],
+                created_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
+                first_commit_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
+                ready_for_review_at=datetime(2023, 12, 31, 0, 0, tzinfo=UTC),
+                merged_at=datetime(2024, 1, 3, 0, 0, tzinfo=UTC),
+                reviews=[approved_review(datetime(2024, 1, 2, 12, 0, tzinfo=UTC))],
             ),
         ]
 
@@ -170,8 +170,8 @@ class TestCalculateCycleTime:
     def test_should_skip_prs_without_approval(self):
         prs = [
             any_pr(
-                created_at="2024-01-01T00:00:00Z",
-                merged_at="2024-01-02T00:00:00Z",
+                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
+                merged_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
                 reviews=[],
             ),
         ]
@@ -270,8 +270,8 @@ class TestCalculatePickupTime:
         prs = [
             any_pr(
                 number=1,
-                created_at="2024-01-01T00:00:00Z",
-                merged_at="2024-01-02T00:00:00Z",
+                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
+                merged_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
                 reviews=[],
             )
         ]
@@ -282,13 +282,13 @@ class TestCalculatePickupTime:
         prs = [
             any_pr(
                 number=1,
-                created_at="2024-01-01T00:00:00Z",
-                merged_at="2024-01-02T00:00:00Z",
+                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
+                merged_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
                 reviews=[
                     {
                         "user": {"login": "reviewer"},
                         "state": "COMMENTED",
-                        "submitted_at": "2024-01-01T12:00:00Z",
+                        "submitted_at": datetime(2024, 1, 1, 12, 0, tzinfo=UTC),
                     }
                 ],
             )
@@ -300,13 +300,13 @@ class TestCalculatePickupTime:
         prs = [
             any_pr(
                 number=1,
-                created_at="2024-01-01T00:00:00Z",
-                merged_at="2024-01-02T00:00:00Z",
+                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
+                merged_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
                 reviews=[
                     {
                         "user": {"login": "reviewer"},
                         "state": "APPROVED",
-                        "submitted_at": "2024-01-01T12:00:00Z",
+                        "submitted_at": datetime(2024, 1, 1, 12, 0, tzinfo=UTC),
                     }
                 ],
             )
@@ -318,10 +318,10 @@ class TestCalculatePickupTime:
         prs = [
             any_pr(
                 number=1,
-                created_at="2024-01-01T00:00:00Z",
-                ready_for_review_at="2024-01-04T00:00:00Z",
-                merged_at="2024-01-05T00:00:00Z",
-                reviews=[approved_review("2024-01-04T06:00:00Z")],
+                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
+                ready_for_review_at=datetime(2024, 1, 4, 0, 0, tzinfo=UTC),
+                merged_at=datetime(2024, 1, 5, 0, 0, tzinfo=UTC),
+                reviews=[approved_review(datetime(2024, 1, 4, 6, 0, tzinfo=UTC))],
             )
         ]
         result = calculate_pickup_time(prs)
@@ -339,13 +339,13 @@ class TestCalculateReviewTime:
         prs = [
             any_pr(
                 number=1,
-                created_at="2024-01-01T00:00:00Z",
-                merged_at="2024-01-02T00:00:00Z",
+                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
+                merged_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
                 reviews=[
                     {
                         "user": {"login": "reviewer"},
                         "state": "COMMENTED",
-                        "submitted_at": "2024-01-01T12:00:00Z",
+                        "submitted_at": datetime(2024, 1, 1, 12, 0, tzinfo=UTC),
                     }
                 ],
             )
@@ -357,13 +357,13 @@ class TestCalculateReviewTime:
         prs = [
             any_pr(
                 number=1,
-                created_at="2024-01-01T00:00:00Z",
-                merged_at="2024-01-03T00:00:00Z",
+                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
+                merged_at=datetime(2024, 1, 3, 0, 0, tzinfo=UTC),
                 reviews=[
                     {
                         "user": {"login": "reviewer"},
                         "state": "APPROVED",
-                        "submitted_at": "2024-01-02T00:00:00Z",
+                        "submitted_at": datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
                     }
                 ],
             )
@@ -473,7 +473,7 @@ class TestCalculateReviewsGiven:
                     {
                         "user": {"login": "bob"},
                         "state": "APPROVED",
-                        "submitted_at": "2024-01-01T01:00:00Z",
+                        "submitted_at": datetime(2024, 1, 1, 1, 0, tzinfo=UTC),
                     },
                 ],
             ),
@@ -485,7 +485,7 @@ class TestCalculateReviewsGiven:
                     {
                         "user": {"login": "alice"},
                         "state": "APPROVED",
-                        "submitted_at": "2024-01-01T02:00:00Z",
+                        "submitted_at": datetime(2024, 1, 1, 2, 0, tzinfo=UTC),
                     },
                 ],
             ),
@@ -506,7 +506,7 @@ class TestCalculateReviewsGiven:
                     {
                         "user": {"login": "external-reviewer"},
                         "state": "APPROVED",
-                        "submitted_at": "2024-01-01T01:00:00Z",
+                        "submitted_at": datetime(2024, 1, 1, 1, 0, tzinfo=UTC),
                     },
                 ],
             ),
@@ -527,17 +527,17 @@ class TestCalculateReviewsGiven:
                     {
                         "user": {"login": "bob"},
                         "state": "COMMENTED",
-                        "submitted_at": "2024-01-01T01:00:00Z",
+                        "submitted_at": datetime(2024, 1, 1, 1, 0, tzinfo=UTC),
                     },
                     {
                         "user": {"login": "bob"},
                         "state": "CHANGES_REQUESTED",
-                        "submitted_at": "2024-01-01T02:00:00Z",
+                        "submitted_at": datetime(2024, 1, 1, 2, 0, tzinfo=UTC),
                     },
                     {
                         "user": {"login": "bob"},
                         "state": "APPROVED",
-                        "submitted_at": "2024-01-01T03:00:00Z",
+                        "submitted_at": datetime(2024, 1, 1, 3, 0, tzinfo=UTC),
                     },
                 ],
             ),
@@ -562,7 +562,7 @@ class TestCalculateReviewsGiven:
                     {
                         "user": {"login": "alice"},
                         "state": "APPROVED",
-                        "submitted_at": "2024-01-01T01:00:00Z",
+                        "submitted_at": datetime(2024, 1, 1, 1, 0, tzinfo=UTC),
                     },
                 ],
             ),
@@ -587,7 +587,7 @@ class TestCalculateReviewsGiven:
                     {
                         "user": {"login": "patches-bot"},
                         "state": "APPROVED",
-                        "submitted_at": "2024-01-01T01:00:00Z",
+                        "submitted_at": datetime(2024, 1, 1, 1, 0, tzinfo=UTC),
                     },
                 ],
             )
@@ -611,13 +611,13 @@ class TestCalculateReviewsGiven:
                 id=10,
                 number=1,
                 user={"login": "alice"},
-                created_at="2024-01-01T00:00:00Z",
-                merged_at="2024-01-02T00:00:00Z",
+                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
+                merged_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
                 reviews=[
                     {
                         "user": {"login": "bob"},
                         "state": "APPROVED",
-                        "submitted_at": "2024-01-01T02:00:00Z",
+                        "submitted_at": datetime(2024, 1, 1, 2, 0, tzinfo=UTC),
                     }
                 ],
             ),
@@ -625,13 +625,13 @@ class TestCalculateReviewsGiven:
                 id=20,
                 number=1,
                 user={"login": "carol"},
-                created_at="2024-02-01T00:00:00Z",
-                merged_at="2024-02-02T00:00:00Z",
+                created_at=datetime(2024, 2, 1, 0, 0, tzinfo=UTC),
+                merged_at=datetime(2024, 2, 2, 0, 0, tzinfo=UTC),
                 reviews=[
                     {
                         "user": {"login": "dave"},
                         "state": "APPROVED",
-                        "submitted_at": "2024-02-01T05:00:00Z",
+                        "submitted_at": datetime(2024, 2, 1, 5, 0, tzinfo=UTC),
                     }
                 ],
             ),
@@ -708,7 +708,7 @@ class TestGetStalePrs:
                 {
                     "number": 1,
                     "title": "Fresh PR",
-                    "created_at": (now - timedelta(days=1)).isoformat(),
+                    "created_at": now - timedelta(days=1),
                     "merged_at": None,
                     "user": {"login": "alice"},
                 },
@@ -729,7 +729,7 @@ class TestGetStalePrs:
                 {
                     "number": 1,
                     "title": "Stale PR",
-                    "created_at": (now - timedelta(days=10)).isoformat(),
+                    "created_at": now - timedelta(days=10),
                     "merged_at": None,
                     "user": {"login": "alice"},
                 },
@@ -754,14 +754,14 @@ class TestGetStalePrs:
                 {
                     "number": 1,
                     "title": "Newer stale",
-                    "created_at": (now - timedelta(days=8)).isoformat(),
+                    "created_at": now - timedelta(days=8),
                     "merged_at": None,
                     "user": {"login": "alice"},
                 },
                 {
                     "number": 2,
                     "title": "Older stale",
-                    "created_at": (now - timedelta(days=15)).isoformat(),
+                    "created_at": now - timedelta(days=15),
                     "merged_at": None,
                     "user": {"login": "bob"},
                 },

--- a/tests/unit/test_pull_command.py
+++ b/tests/unit/test_pull_command.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime
+
 from freezegun import freeze_time
 from typer.testing import CliRunner
 
@@ -17,8 +19,8 @@ def _ten_prs_for_april() -> list:
             id=100 + i,
             number=200 + i,
             user={"login": logins[i]},
-            created_at=f"2026-04-{day:02d}T08:00:00Z",
-            merged_at=f"2026-04-{day:02d}T18:00:00Z",
+            created_at=datetime(2026, 4, day, 8, 0, tzinfo=UTC),
+            merged_at=datetime(2026, 4, day, 18, 0, tzinfo=UTC),
             reviews=[approved_review(login="reviewer-1")] if i % 3 == 0 else [],
         )
         for i, day in enumerate(days)

--- a/tests/unit/test_pull_command.py
+++ b/tests/unit/test_pull_command.py
@@ -1,12 +1,10 @@
-from datetime import UTC, datetime
-
 from freezegun import freeze_time
 from typer.testing import CliRunner
 
 from git_dev_metrics.cache import count_prs, seal_month
 from git_dev_metrics.cli.app import app
 
-from .conftest import any_pr, approved_review
+from .conftest import any_pr, approved_review, dt
 
 runner = CliRunner()
 
@@ -19,8 +17,8 @@ def _ten_prs_for_april() -> list:
             id=100 + i,
             number=200 + i,
             user={"login": logins[i]},
-            created_at=datetime(2026, 4, day, 8, 0, tzinfo=UTC),
-            merged_at=datetime(2026, 4, day, 18, 0, tzinfo=UTC),
+            created_at=dt(year=2026, month=4, day=day, hour=8, minute=0),
+            merged_at=dt(year=2026, month=4, day=day, hour=18, minute=0),
             reviews=[approved_review(login="reviewer-1")] if i % 3 == 0 else [],
         )
         for i, day in enumerate(days)

--- a/tests/unit/test_pull_wizard.py
+++ b/tests/unit/test_pull_wizard.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import datetime
 from unittest.mock import Mock
 
 import pytest
@@ -8,7 +8,7 @@ from git_dev_metrics.cache import count_prs, is_sealed, seal_month
 from git_dev_metrics.cli.pull_wizard import pull_wizard
 from git_dev_metrics.models import Repository
 
-from .conftest import any_pr, approved_review
+from .conftest import any_pr, approved_review, dt
 
 
 def _three_prs(prefix: int) -> list:
@@ -17,8 +17,8 @@ def _three_prs(prefix: int) -> list:
             id=prefix + i,
             number=prefix + i,
             user={"login": f"dev-{i}"},
-            created_at=datetime(2026, 4, day, 8, 0, tzinfo=UTC),
-            merged_at=datetime(2026, 4, day, 16, 0, tzinfo=UTC),
+            created_at=dt(year=2026, month=4, day=day, hour=8, minute=0),
+            merged_at=dt(year=2026, month=4, day=day, hour=16, minute=0),
             reviews=[approved_review(login="reviewer")],
         )
         for i, day in enumerate((5, 12, 22))
@@ -36,9 +36,9 @@ class TestPullWizardMultiRepo:
         mocker.patch("git_dev_metrics.cli.pull_wizard.load_last_org", return_value=None)
         mocker.patch("git_dev_metrics.cli.pull_wizard.save_last_org")
         repos = [
-            _repo("myorg/repoA", private=False, pushed=datetime(2026, 4, 20, tzinfo=UTC)),
-            _repo("myorg/oldrepo", private=False, pushed=datetime(2025, 1, 1, tzinfo=UTC)),
-            _repo("myorg/repoB", private=True, pushed=datetime(2026, 4, 25, tzinfo=UTC)),
+            _repo("myorg/repoA", private=False, pushed=dt(year=2026, month=4, day=20)),
+            _repo("myorg/oldrepo", private=False, pushed=dt(year=2025, month=1, day=1)),
+            _repo("myorg/repoB", private=True, pushed=dt(year=2026, month=4, day=25)),
         ]
         captured_options: list[dict[str, str]] = []
 
@@ -54,7 +54,7 @@ class TestPullWizardMultiRepo:
             ask_org=lambda _last: "myorg",
             ask_month=lambda _choices: "2026-04",
             ask_repos=ask_repos,
-            clock=lambda: datetime(2026, 5, 12, tzinfo=UTC),
+            clock=lambda: dt(year=2026, month=5, day=12),
             fetch=fetch,
             fetch_repos=lambda _token, _org: repos,
             get_token=lambda: "fake",
@@ -82,8 +82,8 @@ class TestPullWizardSkipsSealedInBatch:
         mocker.patch("git_dev_metrics.cli.pull_wizard.load_last_org", return_value=None)
         mocker.patch("git_dev_metrics.cli.pull_wizard.save_last_org")
         repos = [
-            _repo("myorg/repoA", private=False, pushed=datetime(2026, 4, 20, tzinfo=UTC)),
-            _repo("myorg/repoB", private=False, pushed=datetime(2026, 4, 20, tzinfo=UTC)),
+            _repo("myorg/repoA", private=False, pushed=dt(year=2026, month=4, day=20)),
+            _repo("myorg/repoB", private=False, pushed=dt(year=2026, month=4, day=20)),
         ]
         fetch = Mock(return_value=_three_prs(200))
 
@@ -93,7 +93,7 @@ class TestPullWizardSkipsSealedInBatch:
             ask_org=lambda _last: "myorg",
             ask_month=lambda _choices: "2026-04",
             ask_repos=lambda _opts: ["myorg/repoA", "myorg/repoB"],
-            clock=lambda: datetime(2026, 5, 12, tzinfo=UTC),
+            clock=lambda: dt(year=2026, month=5, day=12),
             fetch=fetch,
             fetch_repos=lambda _token, _org: repos,
             get_token=lambda: "fake",
@@ -115,7 +115,7 @@ class TestPullWizardNoActiveRepos:
         db_path = tmp_path / "cache.db"
         mocker.patch("git_dev_metrics.cli.pull_wizard.load_last_org", return_value=None)
         mocker.patch("git_dev_metrics.cli.pull_wizard.save_last_org")
-        stale_only = [_repo("myorg/old", private=False, pushed=datetime(2025, 1, 1, tzinfo=UTC))]
+        stale_only = [_repo("myorg/old", private=False, pushed=dt(year=2025, month=1, day=1))]
 
         # Act
         with pytest.raises(typer.Exit) as exc:
@@ -124,7 +124,7 @@ class TestPullWizardNoActiveRepos:
                 ask_org=lambda _last: "myorg",
                 ask_month=lambda _choices: "2026-04",
                 ask_repos=Mock(side_effect=AssertionError("should not prompt for repos")),
-                clock=lambda: datetime(2026, 5, 12, tzinfo=UTC),
+                clock=lambda: dt(year=2026, month=5, day=12),
                 fetch=Mock(side_effect=AssertionError("should not fetch metrics")),
                 fetch_repos=lambda _token, _org: stale_only,
                 get_token=lambda: "fake",
@@ -154,7 +154,7 @@ class TestPullWizardMonthChoices:
                 ask_org=lambda _last: "myorg",
                 ask_month=ask_month,
                 ask_repos=Mock(side_effect=AssertionError("should not reach repos")),
-                clock=lambda: datetime(2026, 5, 12, tzinfo=UTC),
+                clock=lambda: dt(year=2026, month=5, day=12),
                 fetch=Mock(side_effect=AssertionError("should not fetch metrics")),
                 fetch_repos=Mock(side_effect=AssertionError("should not fetch repos")),
                 get_token=lambda: "fake",

--- a/tests/unit/test_pull_wizard.py
+++ b/tests/unit/test_pull_wizard.py
@@ -17,8 +17,8 @@ def _three_prs(prefix: int) -> list:
             id=prefix + i,
             number=prefix + i,
             user={"login": f"dev-{i}"},
-            created_at=f"2026-04-{day:02d}T08:00:00Z",
-            merged_at=f"2026-04-{day:02d}T16:00:00Z",
+            created_at=datetime(2026, 4, day, 8, 0, tzinfo=UTC),
+            merged_at=datetime(2026, 4, day, 16, 0, tzinfo=UTC),
             reviews=[approved_review(login="reviewer")],
         )
         for i, day in enumerate((5, 12, 22))

--- a/tests/unit/test_snapshot.py
+++ b/tests/unit/test_snapshot.py
@@ -1,17 +1,15 @@
 """Unit tests for MetricsSnapshot."""
 
-from datetime import UTC, datetime
-
 from git_dev_metrics.metrics import MetricsSnapshot
 from git_dev_metrics.utils import TimePeriod
 
-from .conftest import any_pr, approved_review
+from .conftest import any_pr, approved_review, dt
 
 
 def _period() -> TimePeriod:
     return TimePeriod(
-        since=datetime(2024, 1, 1, tzinfo=UTC),
-        until=datetime(2024, 1, 31, tzinfo=UTC),
+        since=dt(year=2024, month=1, day=1),
+        until=dt(year=2024, month=1, day=31),
     )
 
 
@@ -151,9 +149,9 @@ class TestSummary:
                     any_pr(
                         number=f"{login}-{i}",
                         user={"login": login},
-                        created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
-                        merged_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
-                        reviews=[approved_review(datetime(2024, 1, 1, 6, 0, tzinfo=UTC))],
+                        created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
+                        merged_at=dt(year=2024, month=1, day=2, hour=0, minute=0),
+                        reviews=[approved_review(dt(year=2024, month=1, day=1, hour=6, minute=0))],
                         body="Co-Authored-By: Claude" if i < ai_count else "",
                     )
                 )
@@ -167,7 +165,11 @@ class TestSummary:
             any_pr(
                 number=i,
                 user={"login": "author"},
-                reviews=[approved_review(login=login, submitted_at=datetime(2024, 1, i, 0, 0, tzinfo=UTC))],
+                reviews=[
+                    approved_review(
+                        login=login, submitted_at=dt(year=2024, month=1, day=i, hour=0, minute=0)
+                    )
+                ],
             )
             for i, login in enumerate(["carol", "alice", "bob"], start=1)
         ]
@@ -183,9 +185,9 @@ class TestTeamAggregation:
             any_pr(
                 number=i,
                 user={"login": "kobbi"},
-                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
-                merged_at=datetime(2024, 1, 5 + i, 0, 0, tzinfo=UTC),
-                reviews=[approved_review(datetime(2024, 1, 1, 6, 0, tzinfo=UTC))],
+                created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
+                merged_at=dt(year=2024, month=1, day=5 + i, hour=0, minute=0),
+                reviews=[approved_review(dt(year=2024, month=1, day=1, hour=6, minute=0))],
             )
             for i in range(1, 4)
         ]
@@ -193,9 +195,9 @@ class TestTeamAggregation:
             any_pr(
                 number=10,
                 user={"login": "alice"},
-                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
-                merged_at=datetime(2024, 1, 1, 1, 0, tzinfo=UTC),
-                reviews=[approved_review(datetime(2024, 1, 1, 0, 30, tzinfo=UTC))],
+                created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
+                merged_at=dt(year=2024, month=1, day=1, hour=1, minute=0),
+                reviews=[approved_review(dt(year=2024, month=1, day=1, hour=0, minute=30))],
             )
         ]
 
@@ -211,10 +213,10 @@ class TestTeamAggregation:
             any_pr(
                 number=1,
                 user={"login": "dev"},
-                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
-                ready_for_review_at=datetime(2024, 1, 4, 0, 0, tzinfo=UTC),
-                merged_at=datetime(2024, 1, 5, 0, 0, tzinfo=UTC),
-                reviews=[approved_review(datetime(2024, 1, 4, 12, 0, tzinfo=UTC))],
+                created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
+                ready_for_review_at=dt(year=2024, month=1, day=4, hour=0, minute=0),
+                merged_at=dt(year=2024, month=1, day=5, hour=0, minute=0),
+                reviews=[approved_review(dt(year=2024, month=1, day=4, hour=12, minute=0))],
             )
         ]
 
@@ -230,9 +232,9 @@ class TestTeamAggregation:
                     any_pr(
                         number=f"{login}-{i}",
                         user={"login": login},
-                        created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
-                        merged_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
-                        reviews=[approved_review(datetime(2024, 1, 1, 6, 0, tzinfo=UTC))],
+                        created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
+                        merged_at=dt(year=2024, month=1, day=2, hour=0, minute=0),
+                        reviews=[approved_review(dt(year=2024, month=1, day=1, hour=6, minute=0))],
                         body="Co-Authored-By: Claude" if i < ai_count else "",
                     )
                 )

--- a/tests/unit/test_snapshot.py
+++ b/tests/unit/test_snapshot.py
@@ -151,9 +151,9 @@ class TestSummary:
                     any_pr(
                         number=f"{login}-{i}",
                         user={"login": login},
-                        created_at="2024-01-01T00:00:00Z",
-                        merged_at="2024-01-02T00:00:00Z",
-                        reviews=[approved_review("2024-01-01T06:00:00Z")],
+                        created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
+                        merged_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
+                        reviews=[approved_review(datetime(2024, 1, 1, 6, 0, tzinfo=UTC))],
                         body="Co-Authored-By: Claude" if i < ai_count else "",
                     )
                 )
@@ -167,7 +167,7 @@ class TestSummary:
             any_pr(
                 number=i,
                 user={"login": "author"},
-                reviews=[approved_review(login=login, submitted_at=f"2024-01-0{i}T00:00:00Z")],
+                reviews=[approved_review(login=login, submitted_at=datetime(2024, 1, i, 0, 0, tzinfo=UTC))],
             )
             for i, login in enumerate(["carol", "alice", "bob"], start=1)
         ]
@@ -183,9 +183,9 @@ class TestTeamAggregation:
             any_pr(
                 number=i,
                 user={"login": "kobbi"},
-                created_at="2024-01-01T00:00:00Z",
-                merged_at=f"2024-01-0{5 + i}T00:00:00Z",
-                reviews=[approved_review("2024-01-01T06:00:00Z")],
+                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
+                merged_at=datetime(2024, 1, 5 + i, 0, 0, tzinfo=UTC),
+                reviews=[approved_review(datetime(2024, 1, 1, 6, 0, tzinfo=UTC))],
             )
             for i in range(1, 4)
         ]
@@ -193,9 +193,9 @@ class TestTeamAggregation:
             any_pr(
                 number=10,
                 user={"login": "alice"},
-                created_at="2024-01-01T00:00:00Z",
-                merged_at="2024-01-01T01:00:00Z",
-                reviews=[approved_review("2024-01-01T00:30:00Z")],
+                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
+                merged_at=datetime(2024, 1, 1, 1, 0, tzinfo=UTC),
+                reviews=[approved_review(datetime(2024, 1, 1, 0, 30, tzinfo=UTC))],
             )
         ]
 
@@ -211,10 +211,10 @@ class TestTeamAggregation:
             any_pr(
                 number=1,
                 user={"login": "dev"},
-                created_at="2024-01-01T00:00:00Z",
-                ready_for_review_at="2024-01-04T00:00:00Z",
-                merged_at="2024-01-05T00:00:00Z",
-                reviews=[approved_review("2024-01-04T12:00:00Z")],
+                created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
+                ready_for_review_at=datetime(2024, 1, 4, 0, 0, tzinfo=UTC),
+                merged_at=datetime(2024, 1, 5, 0, 0, tzinfo=UTC),
+                reviews=[approved_review(datetime(2024, 1, 4, 12, 0, tzinfo=UTC))],
             )
         ]
 
@@ -230,9 +230,9 @@ class TestTeamAggregation:
                     any_pr(
                         number=f"{login}-{i}",
                         user={"login": login},
-                        created_at="2024-01-01T00:00:00Z",
-                        merged_at="2024-01-02T00:00:00Z",
-                        reviews=[approved_review("2024-01-01T06:00:00Z")],
+                        created_at=datetime(2024, 1, 1, 0, 0, tzinfo=UTC),
+                        merged_at=datetime(2024, 1, 2, 0, 0, tzinfo=UTC),
+                        reviews=[approved_review(datetime(2024, 1, 1, 6, 0, tzinfo=UTC))],
                         body="Co-Authored-By: Claude" if i < ai_count else "",
                     )
                 )

--- a/tests/unit/test_stale_command.py
+++ b/tests/unit/test_stale_command.py
@@ -1,10 +1,12 @@
-from datetime import UTC, datetime
+from datetime import datetime
 
 from freezegun import freeze_time
 from typer.testing import CliRunner
 
 from git_dev_metrics.cache import seal_month
 from git_dev_metrics.cli.app import app
+
+from .conftest import dt
 
 runner = CliRunner()
 
@@ -33,8 +35,10 @@ class TestStale:
 
         def fake_open_prs(_token, _org, repo, **_kwargs):
             if repo == "repoA":
-                return [_open_pr(1, "alice", datetime(2026, 4, 1, 8, 0, tzinfo=UTC))]  # ~41d
-            return [_open_pr(2, "bob", datetime(2026, 5, 1, 8, 0, tzinfo=UTC))]  # ~11d
+                return [
+                    _open_pr(1, "alice", dt(year=2026, month=4, day=1, hour=8, minute=0))
+                ]  # ~41d
+            return [_open_pr(2, "bob", dt(year=2026, month=5, day=1, hour=8, minute=0))]  # ~11d
 
         mocker.patch("git_dev_metrics.cli.stale.get_github_token", return_value="fake-token")
         mocker.patch("git_dev_metrics.cli.stale.fetch_open_prs", side_effect=fake_open_prs)
@@ -63,8 +67,8 @@ class TestStale:
         mocker.patch(
             "git_dev_metrics.cli.stale.fetch_open_prs",
             return_value=[
-                _open_pr(10, "young", datetime(2026, 5, 1, 8, 0, tzinfo=UTC)),  # ~11d
-                _open_pr(11, "old", datetime(2026, 4, 1, 8, 0, tzinfo=UTC)),  # ~41d
+                _open_pr(10, "young", dt(year=2026, month=5, day=1, hour=8, minute=0)),  # ~11d
+                _open_pr(11, "old", dt(year=2026, month=4, day=1, hour=8, minute=0)),  # ~41d
             ],
         )
         out = tmp_path / "stale.html"
@@ -88,7 +92,9 @@ class TestStale:
         mocker.patch("git_dev_metrics.cli.stale.get_github_token", return_value="fake-token")
         mocker.patch(
             "git_dev_metrics.cli.stale.fetch_open_prs",
-            return_value=[_open_pr(1, "alice", datetime(2026, 5, 10, 8, 0, tzinfo=UTC))],  # ~2d, fresh
+            return_value=[
+                _open_pr(1, "alice", dt(year=2026, month=5, day=10, hour=8, minute=0))
+            ],  # ~2d, fresh
         )
         out = tmp_path / "stale.html"
 
@@ -120,7 +126,7 @@ class TestStale:
         mocker.patch("git_dev_metrics.cli.stale.get_github_token", return_value="fake-token")
         mocker.patch(
             "git_dev_metrics.cli.stale.fetch_open_prs",
-            return_value=[_open_pr(1, "alice", datetime(2026, 4, 1, 8, 0, tzinfo=UTC))],
+            return_value=[_open_pr(1, "alice", dt(year=2026, month=4, day=1, hour=8, minute=0))],
         )
 
         # Act

--- a/tests/unit/test_stale_command.py
+++ b/tests/unit/test_stale_command.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime
+
 from freezegun import freeze_time
 from typer.testing import CliRunner
 
@@ -7,7 +9,7 @@ from git_dev_metrics.cli.app import app
 runner = CliRunner()
 
 
-def _open_pr(number: int, login: str, created_at: str, is_draft: bool = False) -> dict:
+def _open_pr(number: int, login: str, created_at: datetime, is_draft: bool = False) -> dict:
     return {
         "number": number,
         "title": f"PR #{number}",
@@ -31,8 +33,8 @@ class TestStale:
 
         def fake_open_prs(_token, _org, repo, **_kwargs):
             if repo == "repoA":
-                return [_open_pr(1, "alice", "2026-04-01T08:00:00Z")]  # ~41d
-            return [_open_pr(2, "bob", "2026-05-01T08:00:00Z")]  # ~11d
+                return [_open_pr(1, "alice", datetime(2026, 4, 1, 8, 0, tzinfo=UTC))]  # ~41d
+            return [_open_pr(2, "bob", datetime(2026, 5, 1, 8, 0, tzinfo=UTC))]  # ~11d
 
         mocker.patch("git_dev_metrics.cli.stale.get_github_token", return_value="fake-token")
         mocker.patch("git_dev_metrics.cli.stale.fetch_open_prs", side_effect=fake_open_prs)
@@ -61,8 +63,8 @@ class TestStale:
         mocker.patch(
             "git_dev_metrics.cli.stale.fetch_open_prs",
             return_value=[
-                _open_pr(10, "young", "2026-05-01T08:00:00Z"),  # ~11d
-                _open_pr(11, "old", "2026-04-01T08:00:00Z"),  # ~41d
+                _open_pr(10, "young", datetime(2026, 5, 1, 8, 0, tzinfo=UTC)),  # ~11d
+                _open_pr(11, "old", datetime(2026, 4, 1, 8, 0, tzinfo=UTC)),  # ~41d
             ],
         )
         out = tmp_path / "stale.html"
@@ -86,7 +88,7 @@ class TestStale:
         mocker.patch("git_dev_metrics.cli.stale.get_github_token", return_value="fake-token")
         mocker.patch(
             "git_dev_metrics.cli.stale.fetch_open_prs",
-            return_value=[_open_pr(1, "alice", "2026-05-10T08:00:00Z")],  # ~2d, fresh
+            return_value=[_open_pr(1, "alice", datetime(2026, 5, 10, 8, 0, tzinfo=UTC))],  # ~2d, fresh
         )
         out = tmp_path / "stale.html"
 
@@ -118,7 +120,7 @@ class TestStale:
         mocker.patch("git_dev_metrics.cli.stale.get_github_token", return_value="fake-token")
         mocker.patch(
             "git_dev_metrics.cli.stale.fetch_open_prs",
-            return_value=[_open_pr(1, "alice", "2026-04-01T08:00:00Z")],
+            return_value=[_open_pr(1, "alice", datetime(2026, 4, 1, 8, 0, tzinfo=UTC))],
         )
 
         # Act

--- a/tests/unit/test_summary_command.py
+++ b/tests/unit/test_summary_command.py
@@ -1,11 +1,9 @@
-from datetime import UTC, datetime
-
 from typer.testing import CliRunner
 
 from git_dev_metrics.cache import insert_prs, seal_month
 from git_dev_metrics.cli.app import app
 
-from .conftest import any_pr, approved_review
+from .conftest import any_pr, approved_review, dt
 
 runner = CliRunner()
 
@@ -14,27 +12,51 @@ def _seed_two_repos_apr(db_path) -> None:
     """3 merged PRs across 2 repos and 2 devs in April 2026."""
     repo_a = [
         any_pr(
-            number=11, user={"login": "alice"}, additions=120, deletions=30, changed_files=4,
-            created_at=datetime(2026, 4, 2, 9, 0, tzinfo=UTC),
-            merged_at=datetime(2026, 4, 3, 10, 0, tzinfo=UTC),
-            closed_at=datetime(2026, 4, 3, 10, 0, tzinfo=UTC),
-            reviews=[approved_review(login="bob", submitted_at=datetime(2026, 4, 2, 15, 0, tzinfo=UTC))],
+            number=11,
+            user={"login": "alice"},
+            additions=120,
+            deletions=30,
+            changed_files=4,
+            created_at=dt(year=2026, month=4, day=2, hour=9, minute=0),
+            merged_at=dt(year=2026, month=4, day=3, hour=10, minute=0),
+            closed_at=dt(year=2026, month=4, day=3, hour=10, minute=0),
+            reviews=[
+                approved_review(
+                    login="bob", submitted_at=dt(year=2026, month=4, day=2, hour=15, minute=0)
+                )
+            ],
         ),
         any_pr(
-            number=12, user={"login": "bob"}, additions=60, deletions=20, changed_files=3,
-            created_at=datetime(2026, 4, 10, 9, 0, tzinfo=UTC),
-            merged_at=datetime(2026, 4, 11, 11, 0, tzinfo=UTC),
-            closed_at=datetime(2026, 4, 11, 11, 0, tzinfo=UTC),
-            reviews=[approved_review(login="alice", submitted_at=datetime(2026, 4, 10, 18, 0, tzinfo=UTC))],
+            number=12,
+            user={"login": "bob"},
+            additions=60,
+            deletions=20,
+            changed_files=3,
+            created_at=dt(year=2026, month=4, day=10, hour=9, minute=0),
+            merged_at=dt(year=2026, month=4, day=11, hour=11, minute=0),
+            closed_at=dt(year=2026, month=4, day=11, hour=11, minute=0),
+            reviews=[
+                approved_review(
+                    login="alice", submitted_at=dt(year=2026, month=4, day=10, hour=18, minute=0)
+                )
+            ],
         ),
     ]
     repo_b = [
         any_pr(
-            number=21, user={"login": "alice"}, additions=40, deletions=10, changed_files=2,
-            created_at=datetime(2026, 4, 15, 9, 0, tzinfo=UTC),
-            merged_at=datetime(2026, 4, 16, 13, 0, tzinfo=UTC),
-            closed_at=datetime(2026, 4, 16, 13, 0, tzinfo=UTC),
-            reviews=[approved_review(login="bob", submitted_at=datetime(2026, 4, 15, 17, 0, tzinfo=UTC))],
+            number=21,
+            user={"login": "alice"},
+            additions=40,
+            deletions=10,
+            changed_files=2,
+            created_at=dt(year=2026, month=4, day=15, hour=9, minute=0),
+            merged_at=dt(year=2026, month=4, day=16, hour=13, minute=0),
+            closed_at=dt(year=2026, month=4, day=16, hour=13, minute=0),
+            reviews=[
+                approved_review(
+                    login="bob", submitted_at=dt(year=2026, month=4, day=15, hour=17, minute=0)
+                )
+            ],
         ),
     ]
     insert_prs(repo_a, "myorg", "repoA", 2026, 4, db_path=db_path)

--- a/tests/unit/test_summary_command.py
+++ b/tests/unit/test_summary_command.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime
+
 from typer.testing import CliRunner
 
 from git_dev_metrics.cache import insert_prs, seal_month
@@ -13,23 +15,26 @@ def _seed_two_repos_apr(db_path) -> None:
     repo_a = [
         any_pr(
             number=11, user={"login": "alice"}, additions=120, deletions=30, changed_files=4,
-            created_at="2026-04-02T09:00:00Z", merged_at="2026-04-03T10:00:00Z",
-            closed_at="2026-04-03T10:00:00Z",
-            reviews=[approved_review(login="bob", submitted_at="2026-04-02T15:00:00Z")],
+            created_at=datetime(2026, 4, 2, 9, 0, tzinfo=UTC),
+            merged_at=datetime(2026, 4, 3, 10, 0, tzinfo=UTC),
+            closed_at=datetime(2026, 4, 3, 10, 0, tzinfo=UTC),
+            reviews=[approved_review(login="bob", submitted_at=datetime(2026, 4, 2, 15, 0, tzinfo=UTC))],
         ),
         any_pr(
             number=12, user={"login": "bob"}, additions=60, deletions=20, changed_files=3,
-            created_at="2026-04-10T09:00:00Z", merged_at="2026-04-11T11:00:00Z",
-            closed_at="2026-04-11T11:00:00Z",
-            reviews=[approved_review(login="alice", submitted_at="2026-04-10T18:00:00Z")],
+            created_at=datetime(2026, 4, 10, 9, 0, tzinfo=UTC),
+            merged_at=datetime(2026, 4, 11, 11, 0, tzinfo=UTC),
+            closed_at=datetime(2026, 4, 11, 11, 0, tzinfo=UTC),
+            reviews=[approved_review(login="alice", submitted_at=datetime(2026, 4, 10, 18, 0, tzinfo=UTC))],
         ),
     ]
     repo_b = [
         any_pr(
             number=21, user={"login": "alice"}, additions=40, deletions=10, changed_files=2,
-            created_at="2026-04-15T09:00:00Z", merged_at="2026-04-16T13:00:00Z",
-            closed_at="2026-04-16T13:00:00Z",
-            reviews=[approved_review(login="bob", submitted_at="2026-04-15T17:00:00Z")],
+            created_at=datetime(2026, 4, 15, 9, 0, tzinfo=UTC),
+            merged_at=datetime(2026, 4, 16, 13, 0, tzinfo=UTC),
+            closed_at=datetime(2026, 4, 16, 13, 0, tzinfo=UTC),
+            reviews=[approved_review(login="bob", submitted_at=datetime(2026, 4, 15, 17, 0, tzinfo=UTC))],
         ),
     ]
     insert_prs(repo_a, "myorg", "repoA", 2026, 4, db_path=db_path)

--- a/tests/unit/test_summary_wizard.py
+++ b/tests/unit/test_summary_wizard.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime
+
 import pytest
 import typer
 
@@ -15,9 +17,9 @@ def _seed_feb_mar_apr(db_path) -> None:
                     any_pr(
                         number=year * 100 + month, user={"login": "alice"},
                         additions=20, deletions=5, changed_files=2,
-                        created_at=f"2026-{month:02d}-{day:02d}T08:00:00Z",
-                        merged_at=f"2026-{month:02d}-{day:02d}T16:00:00Z",
-                        closed_at=f"2026-{month:02d}-{day:02d}T16:00:00Z",
+                        created_at=datetime(year, month, day, 8, 0, tzinfo=UTC),
+                        merged_at=datetime(year, month, day, 16, 0, tzinfo=UTC),
+                        closed_at=datetime(year, month, day, 16, 0, tzinfo=UTC),
                         reviews=[approved_review(login="bob")],
                     )
                 ],

--- a/tests/unit/test_summary_wizard.py
+++ b/tests/unit/test_summary_wizard.py
@@ -1,12 +1,10 @@
-from datetime import UTC, datetime
-
 import pytest
 import typer
 
 from git_dev_metrics.cache import insert_prs, seal_month
 from git_dev_metrics.cli.summary_wizard import summary_wizard
 
-from .conftest import any_pr, approved_review
+from .conftest import any_pr, approved_review, dt
 
 
 def _seed_feb_mar_apr(db_path) -> None:
@@ -15,15 +13,22 @@ def _seed_feb_mar_apr(db_path) -> None:
             insert_prs(
                 [
                     any_pr(
-                        number=year * 100 + month, user={"login": "alice"},
-                        additions=20, deletions=5, changed_files=2,
-                        created_at=datetime(year, month, day, 8, 0, tzinfo=UTC),
-                        merged_at=datetime(year, month, day, 16, 0, tzinfo=UTC),
-                        closed_at=datetime(year, month, day, 16, 0, tzinfo=UTC),
+                        number=year * 100 + month,
+                        user={"login": "alice"},
+                        additions=20,
+                        deletions=5,
+                        changed_files=2,
+                        created_at=dt(year=year, month=month, day=day, hour=8, minute=0),
+                        merged_at=dt(year=year, month=month, day=day, hour=16, minute=0),
+                        closed_at=dt(year=year, month=month, day=day, hour=16, minute=0),
                         reviews=[approved_review(login="bob")],
                     )
                 ],
-                org, repo, year, month, db_path=db_path,
+                org,
+                repo,
+                year,
+                month,
+                db_path=db_path,
             )
             seal_month(org, repo, year, month, db_path=db_path)
 

--- a/tests/unit/test_trend_calculator.py
+++ b/tests/unit/test_trend_calculator.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime
+
 from git_dev_metrics.metrics.trend_calculator import build_trend_dataset
 from git_dev_metrics.models import PullRequest
 
@@ -9,9 +11,9 @@ def _pr(pr_id: int, login: str, year: int, month: int, day: int) -> PullRequest:
         id=pr_id,
         number=pr_id,
         user={"login": login},
-        created_at=f"{year:04d}-{month:02d}-{day:02d}T08:00:00Z",
-        merged_at=f"{year:04d}-{month:02d}-{day:02d}T18:00:00Z",
-        reviews=[approved_review(submitted_at=f"{year:04d}-{month:02d}-{day:02d}T12:00:00Z")],
+        created_at=datetime(year, month, day, 8, 0, tzinfo=UTC),
+        merged_at=datetime(year, month, day, 18, 0, tzinfo=UTC),
+        reviews=[approved_review(submitted_at=datetime(year, month, day, 12, 0, tzinfo=UTC))],
     )
 
 

--- a/tests/unit/test_trend_calculator.py
+++ b/tests/unit/test_trend_calculator.py
@@ -1,9 +1,7 @@
-from datetime import UTC, datetime
-
 from git_dev_metrics.metrics.trend_calculator import build_trend_dataset
 from git_dev_metrics.models import PullRequest
 
-from .conftest import any_pr, approved_review
+from .conftest import any_pr, approved_review, dt
 
 
 def _pr(pr_id: int, login: str, year: int, month: int, day: int) -> PullRequest:
@@ -11,9 +9,11 @@ def _pr(pr_id: int, login: str, year: int, month: int, day: int) -> PullRequest:
         id=pr_id,
         number=pr_id,
         user={"login": login},
-        created_at=datetime(year, month, day, 8, 0, tzinfo=UTC),
-        merged_at=datetime(year, month, day, 18, 0, tzinfo=UTC),
-        reviews=[approved_review(submitted_at=datetime(year, month, day, 12, 0, tzinfo=UTC))],
+        created_at=dt(year=year, month=month, day=day, hour=8, minute=0),
+        merged_at=dt(year=year, month=month, day=day, hour=18, minute=0),
+        reviews=[
+            approved_review(submitted_at=dt(year=year, month=month, day=day, hour=12, minute=0))
+        ],
     )
 
 

--- a/tests/unit/test_trend_command.py
+++ b/tests/unit/test_trend_command.py
@@ -1,5 +1,6 @@
 import json
 import re
+from datetime import UTC, datetime
 
 from freezegun import freeze_time
 from typer.testing import CliRunner
@@ -19,9 +20,9 @@ def _pr(pr_id: int, login: str, year: int, month: int, day: int) -> PullRequest:
         id=pr_id,
         number=pr_id,
         user={"login": login},
-        created_at=f"{year:04d}-{month:02d}-{day:02d}T08:00:00Z",
-        merged_at=f"{year:04d}-{month:02d}-{day:02d}T18:00:00Z",
-        reviews=[approved_review(submitted_at=f"{year:04d}-{month:02d}-{day:02d}T12:00:00Z")],
+        created_at=datetime(year, month, day, 8, 0, tzinfo=UTC),
+        merged_at=datetime(year, month, day, 18, 0, tzinfo=UTC),
+        reviews=[approved_review(submitted_at=datetime(year, month, day, 12, 0, tzinfo=UTC))],
     )
 
 

--- a/tests/unit/test_trend_command.py
+++ b/tests/unit/test_trend_command.py
@@ -1,6 +1,5 @@
 import json
 import re
-from datetime import UTC, datetime
 
 from freezegun import freeze_time
 from typer.testing import CliRunner
@@ -10,7 +9,7 @@ from git_dev_metrics.cli.app import app
 from git_dev_metrics.cli.trend_wizard import trend_wizard
 from git_dev_metrics.models import PullRequest
 
-from .conftest import any_pr, approved_review
+from .conftest import any_pr, approved_review, dt
 
 runner = CliRunner()
 
@@ -20,9 +19,11 @@ def _pr(pr_id: int, login: str, year: int, month: int, day: int) -> PullRequest:
         id=pr_id,
         number=pr_id,
         user={"login": login},
-        created_at=datetime(year, month, day, 8, 0, tzinfo=UTC),
-        merged_at=datetime(year, month, day, 18, 0, tzinfo=UTC),
-        reviews=[approved_review(submitted_at=datetime(year, month, day, 12, 0, tzinfo=UTC))],
+        created_at=dt(year=year, month=month, day=day, hour=8, minute=0),
+        merged_at=dt(year=year, month=month, day=day, hour=18, minute=0),
+        reviews=[
+            approved_review(submitted_at=dt(year=year, month=month, day=day, hour=12, minute=0))
+        ],
     )
 
 
@@ -73,8 +74,15 @@ class TestTrendFiltersLeavers:
         result = runner.invoke(
             app,
             [
-                "trend", "--from", "2026-02", "--to", "2026-04",
-                "--db", str(db_path), "--output", str(out),
+                "trend",
+                "--from",
+                "2026-02",
+                "--to",
+                "2026-04",
+                "--db",
+                str(db_path),
+                "--output",
+                str(out),
             ],
         )
 
@@ -99,8 +107,15 @@ class TestTrendCanvases:
         result = runner.invoke(
             app,
             [
-                "trend", "--from", "2026-02", "--to", "2026-04",
-                "--db", str(db_path), "--output", str(out),
+                "trend",
+                "--from",
+                "2026-02",
+                "--to",
+                "2026-04",
+                "--db",
+                str(db_path),
+                "--output",
+                str(out),
             ],
         )
 
@@ -122,11 +137,19 @@ class TestTrendAggregatesAllRepos:
         db_path = tmp_path / "cache.db"
         insert_prs(
             [_pr(101, "alice", 2026, 4, 5), _pr(102, "bob", 2026, 4, 6)],
-            "myorg", "repoA", 2026, 4, db_path=db_path,
+            "myorg",
+            "repoA",
+            2026,
+            4,
+            db_path=db_path,
         )
         insert_prs(
             [_pr(201, "alice", 2026, 4, 12), _pr(202, "alice", 2026, 4, 22)],
-            "myorg", "repoB", 2026, 4, db_path=db_path,
+            "myorg",
+            "repoB",
+            2026,
+            4,
+            db_path=db_path,
         )
         seal_month("myorg", "repoA", 2026, 4, db_path=db_path)
         seal_month("myorg", "repoB", 2026, 4, db_path=db_path)
@@ -136,8 +159,15 @@ class TestTrendAggregatesAllRepos:
         result = runner.invoke(
             app,
             [
-                "trend", "--from", "2026-04", "--to", "2026-04",
-                "--db", str(db_path), "--output", str(out),
+                "trend",
+                "--from",
+                "2026-04",
+                "--to",
+                "2026-04",
+                "--db",
+                str(db_path),
+                "--output",
+                str(out),
             ],
         )
 
@@ -194,8 +224,15 @@ class TestTrendOpensBrowser:
         result = runner.invoke(
             app,
             [
-                "trend", "--from", "2026-02", "--to", "2026-04",
-                "--db", str(db_path), "--output", str(out),
+                "trend",
+                "--from",
+                "2026-02",
+                "--to",
+                "2026-04",
+                "--db",
+                str(db_path),
+                "--output",
+                str(out),
             ],
         )
 
@@ -233,8 +270,15 @@ class TestTrendNoSyncedData:
         result = runner.invoke(
             app,
             [
-                "trend", "--from", "2026-04", "--to", "2026-04",
-                "--db", str(db_path), "--output", str(out),
+                "trend",
+                "--from",
+                "2026-04",
+                "--to",
+                "2026-04",
+                "--db",
+                str(db_path),
+                "--output",
+                str(out),
             ],
         )
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,6 @@
 """Unit tests for date_utils.py functions."""
 
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 
 import pytest
 from freezegun import freeze_time
@@ -8,11 +8,13 @@ from freezegun import freeze_time
 from git_dev_metrics.utils import TimePeriod, get_last_month, parse_time_period
 from git_dev_metrics.utils.date_utils import month_range
 
+from .conftest import dt
+
 
 class TestTimePeriod:
     def test_should_construct_when_since_before_until(self):
-        since = datetime(2024, 1, 1, tzinfo=UTC)
-        until = datetime(2024, 2, 1, tzinfo=UTC)
+        since = dt(year=2024, month=1, day=1)
+        until = dt(year=2024, month=2, day=1)
 
         period = TimePeriod(since=since, until=until)
 
@@ -20,8 +22,8 @@ class TestTimePeriod:
         assert period.until == until
 
     def test_should_raise_when_since_after_until(self):
-        since = datetime(2024, 2, 1, tzinfo=UTC)
-        until = datetime(2024, 1, 1, tzinfo=UTC)
+        since = dt(year=2024, month=2, day=1)
+        until = dt(year=2024, month=1, day=1)
 
         with pytest.raises(ValueError, match="since must be before until"):
             TimePeriod(since=since, until=until)
@@ -32,8 +34,10 @@ class TestParseTimePeriod:
     def test_should_return_one_day_period_for_1d(self):
         result = parse_time_period("1d")
 
-        assert result.until == datetime(2024, 6, 15, 12, 0, 0, tzinfo=UTC)
-        assert result.since == datetime(2024, 6, 15, 12, 0, 0, tzinfo=UTC) - timedelta(days=1)
+        assert result.until == dt(year=2024, month=6, day=15, hour=12, minute=0, second=0)
+        assert result.since == dt(
+            year=2024, month=6, day=15, hour=12, minute=0, second=0
+        ) - timedelta(days=1)
 
     @freeze_time("2024-06-15 12:00:00")
     def test_should_return_seven_day_period_for_7d(self):
@@ -74,14 +78,14 @@ class TestParseTimePeriod:
     def test_should_return_calendar_month_for_year_month_string(self):
         result = parse_time_period("2026-03")
 
-        assert result.since == datetime(2026, 3, 1, tzinfo=UTC)
-        assert result.until == datetime(2026, 4, 1, tzinfo=UTC)
+        assert result.since == dt(year=2026, month=3, day=1)
+        assert result.until == dt(year=2026, month=4, day=1)
 
     def test_should_cross_year_boundary_for_december(self):
         result = parse_time_period("2025-12")
 
-        assert result.since == datetime(2025, 12, 1, tzinfo=UTC)
-        assert result.until == datetime(2026, 1, 1, tzinfo=UTC)
+        assert result.since == dt(year=2025, month=12, day=1)
+        assert result.until == dt(year=2026, month=1, day=1)
 
     def test_should_raise_for_invalid_month_in_year_month(self):
         with pytest.raises(ValueError, match="Unsupported period"):
@@ -103,19 +107,19 @@ class TestGetLastMonth:
     def test_should_return_last_month_range_mid_month(self):
         result = get_last_month()
 
-        assert result.since == datetime(2024, 5, 1, tzinfo=UTC)
-        assert result.until == datetime(2024, 6, 1, tzinfo=UTC)
+        assert result.since == dt(year=2024, month=5, day=1)
+        assert result.until == dt(year=2024, month=6, day=1)
 
     @freeze_time("2024-01-15 12:00:00")
     def test_should_cross_year_boundary(self):
         result = get_last_month()
 
-        assert result.since == datetime(2023, 12, 1, tzinfo=UTC)
-        assert result.until == datetime(2024, 1, 1, tzinfo=UTC)
+        assert result.since == dt(year=2023, month=12, day=1)
+        assert result.until == dt(year=2024, month=1, day=1)
 
     @freeze_time("2024-03-01 00:00:00")
     def test_should_handle_first_of_month(self):
         result = get_last_month()
 
-        assert result.since == datetime(2024, 2, 1, tzinfo=UTC)
-        assert result.until == datetime(2024, 3, 1, tzinfo=UTC)
+        assert result.since == dt(year=2024, month=2, day=1)
+        assert result.until == dt(year=2024, month=3, day=1)


### PR DESCRIPTION
## Summary

The `PullRequest` TypedDict declared timestamp fields (`created_at`, `merged_at`, `closed_at`) as `str`, but the GraphQL mappers produced `datetime` objects at runtime with `# type: ignore[return-value]`. This inconsistency leaked across every boundary in the system.

### What changed

- **Models** (`models/types.py`): `PullRequest.created_at`, `.merged_at`, `.closed_at`, `Review.submitted_at`, `OpenPullRequest.created_at` → `datetime | None` (consistent with `first_commit_at`, `ready_for_review_at` which were already correct)
- **Mappers** (`github/queries.py`): already produce `datetime` — just needed `# type: ignore` removed for timestamp fields
- **Cache write** (`cache/db._iso`): simplified — no more `str()` fallback for unknown types
- **Cache read** (`cache/query._pr`, `._review`): parse ISO strings to `datetime` at this one boundary, rather than making every consumer guess the type
- **Calculator** (`metrics/calculator.py`): removed `_to_datetime()` entirely — all callers receive `datetime | None` natively
- **`_calculate_age_hours`**: signature changed from `str | datetime` to `datetime | None`

### Type safety benefit

The type checker now catches timestamp type mismatches instead of being silenced by `# type: ignore`. The `_to_datetime()` adapter — which existed solely to paper over the model inconsistency — is deleted (42 lines removed).