### PR TITLE
Add initial ADRs for architecture decisions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: Build and Test
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/adr/**'
 
 jobs:
   test:

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,15 @@
+# {Title — noun phrase, not a question}
+
+{1–3 sentences: what's the context, what did we decide, and why. Capture the trade-off. If someone asks "why not the other thing?" the answer should be here.}
+
+## Status
+
+proposed | accepted | deprecated | superseded by ADR-NNNN
+
+## Considered Options
+
+{Optional — only when the rejected alternatives are worth remembering. Describe the option and why it was rejected.}
+
+## Consequences
+
+{Optional — only when non-obvious downstream effects need to be called out.}

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,13 +1,17 @@
 # {Title — noun phrase, not a question}
 
-{1–3 sentences: what's the context, what did we decide, and why. Capture the trade-off. If someone asks "why not the other thing?" the answer should be here.}
+## Problem
 
-*To deprecate this ADR, add a one-line note: `Deprecated by ADR-NNNN` or `Superseded by ADR-NNNN` at the top.*
+{What situation prompted this decision. What was the friction or gap.}
 
-## Considered Options
+## Options
 
-{Optional — only when the rejected alternatives are worth remembering. Describe the option and why it was rejected.}
+{Optional — alternatives considered and why they were rejected. Skip when the path was obvious.}
+
+## Solution
+
+{What we decided and why. Capture the trade-off rationale so nobody asks "why not the other thing" later.}
 
 ## Consequences
 
-{Optional — only when non-obvious downstream effects need to be called out.}
+{Downstream effects to watch for. Things that got harder, things deferred, future work unlocked.}

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -2,9 +2,7 @@
 
 {1–3 sentences: what's the context, what did we decide, and why. Capture the trade-off. If someone asks "why not the other thing?" the answer should be here.}
 
-## Status
-
-proposed | accepted | deprecated | superseded by ADR-NNNN
+*To deprecate this ADR, add a one-line note: `Deprecated by ADR-NNNN` or `Superseded by ADR-NNNN` at the top.*
 
 ## Considered Options
 

--- a/docs/adr/0001-snapshot-and-cache.md
+++ b/docs/adr/0001-snapshot-and-cache.md
@@ -1,0 +1,5 @@
+# Fetch once, snapshot and cache by month
+
+We were fetching the same PR data repeatedly — every report re-queried the GitHub API. Since PR data for a closed month is immutable, we decided to pull each month once and seal it in a local cache. The `MetricsSnapshot` is computed upfront from cached PRs and is itself frozen. Callers never re-fetch or recompute.
+
+We intentionally deferred handling partial-month data: the current month is not fetched until it's complete. A future enhancement could track which days within a month have been fetched.

--- a/docs/adr/0001-snapshot-and-cache.md
+++ b/docs/adr/0001-snapshot-and-cache.md
@@ -1,5 +1,17 @@
-# Fetch once, snapshot and cache by month
+# Snapshot and cache by month
 
-We were fetching the same PR data repeatedly — every report re-queried the GitHub API. Since PR data for a closed month is immutable, we decided to pull each month once and seal it in a local cache. The `MetricsSnapshot` is computed upfront from cached PRs and is itself frozen. Callers never re-fetch or recompute.
+## Problem
 
-We intentionally deferred handling partial-month data: the current month is not fetched until it's complete. A future enhancement could track which days within a month have been fetched.
+Every report re-queried the GitHub API for the same PR data. Building older reports re-fetched months that hadn't changed since the last run.
+
+## Options
+
+Computing metrics on every read (rejected — wasteful for sealed periods, couples reports to API availability). Fetch-once, cache-and-seal (chosen).
+
+## Solution
+
+Pull each month's PRs once and seal them in local storage as an immutable snapshot. The `MetricsSnapshot` is computed upfront from cached PRs and is itself frozen. Callers never re-fetch or recompute for sealed months.
+
+## Consequences
+
+The current month is deferred until it's complete — we never fetch a partial month. Future work could track which days within a month have been fetched for incremental pulls.

--- a/docs/adr/0002-sqlite-for-metric-storage.md
+++ b/docs/adr/0002-sqlite-for-metric-storage.md
@@ -1,0 +1,5 @@
+# SQLite for metric storage
+
+We store sealed-month data in SQLite files. The schema is simple (three tables: `prs`, `reviews`, `sealed_months`) and accessed via raw SQL with `executemany`. No ORM.
+
+SQLite was chosen for zero-setup: no server, no config, ships with Python. The schema is deliberately flat — the data shape matches GitHub's API response shape. We can evaluate other stores (Postgres, Parquet files) in the future if the project outgrows SQLite.

--- a/docs/adr/0002-sqlite-for-metric-storage.md
+++ b/docs/adr/0002-sqlite-for-metric-storage.md
@@ -1,5 +1,17 @@
 # SQLite for metric storage
 
-We store sealed-month data in SQLite files. The schema is simple (three tables: `prs`, `reviews`, `sealed_months`) and accessed via raw SQL with `executemany`. No ORM.
+## Problem
 
-SQLite was chosen for zero-setup: no server, no config, ships with Python. The schema is deliberately flat — the data shape matches GitHub's API response shape. We can evaluate other stores (Postgres, Parquet files) in the future if the project outgrows SQLite.
+Needed a local store for sealed PR data that requires zero setup and ships with the language.
+
+## Options
+
+Postgres, Parquet files, or another store (deferred — can evaluate when the project outgrows SQLite). SQLite (chosen).
+
+## Solution
+
+SQLite with three tables (`prs`, `reviews`, `sealed_months`), accessed via raw SQL with `executemany`. No ORM. The schema is deliberately flat — it mirrors the GitHub API response shape.
+
+## Consequences
+
+Schema is tightly coupled to GitHub's response shape. If we later need a different query pattern (e.g., cross-repo analytics), migration to another store is possible without changing the cache-layer interface.

--- a/docs/adr/0003-graphql-over-rest.md
+++ b/docs/adr/0003-graphql-over-rest.md
@@ -1,0 +1,5 @@
+# GraphQL over REST for GitHub data
+
+We use GitHub's GraphQL API (v4) instead of REST (v3). GraphQL lets us fetch PRs, reviews, commits, and repo metadata in a single round-trip per page, which is critical for bulk-historically analysis across many repos. REST would require N+1 requests per PR to gather reviews and commits.
+
+The trade-off is more complex query construction and a tight coupling to GitHub's GraphQL schema, but the performance gain (fewer requests, less data transferred) is worth it for the batch-analysis use case.

--- a/docs/adr/0003-graphql-over-rest.md
+++ b/docs/adr/0003-graphql-over-rest.md
@@ -1,5 +1,17 @@
 # GraphQL over REST for GitHub data
 
-We use GitHub's GraphQL API (v4) instead of REST (v3). GraphQL lets us fetch PRs, reviews, commits, and repo metadata in a single round-trip per page, which is critical for bulk-historically analysis across many repos. REST would require N+1 requests per PR to gather reviews and commits.
+## Problem
 
-The trade-off is more complex query construction and a tight coupling to GitHub's GraphQL schema, but the performance gain (fewer requests, less data transferred) is worth it for the batch-analysis use case.
+REST required N+1 requests per PR (one for the PR, one for reviews, one for commits). This made bulk historical analysis across many repos prohibitively slow.
+
+## Options
+
+REST (rejected — too chatty for batch analysis). GraphQL (chosen — fetches PRs, reviews, and commits in a single round-trip per page).
+
+## Solution
+
+Use GitHub's GraphQL API (v4). The `graphql_client` module abstracts pagination, retry, and error handling behind a small interface.
+
+## Consequences
+
+Tighter coupling to GitHub's GraphQL schema. More complex query construction. The performance gain (fewer requests, less data) is worth it for the batch-analysis use case.

--- a/docs/adr/0004-wizard-driven-cli.md
+++ b/docs/adr/0004-wizard-driven-cli.md
@@ -1,5 +1,17 @@
-# Wizard-driven CLI over pure flag-based
+# Wizard-driven CLI
 
-Commands accept simple flags (org, repo, period) and fall back to interactive prompts (wizards) when arguments are omitted. This prioritises discoverability and ease of use over scriptability — users are guided through month selection, repo picking, and report generation without memorising flags.
+## Problem
 
-We accept that this makes automated/robotic usage harder. CI pipelines or scripting use cases are a secondary concern; the primary audience is a developer running ad-hoc analysis.
+Users had to memorise flags (org, repo, period, output path) to generate any report. The learning curve was a barrier to ad-hoc analysis.
+
+## Options
+
+Pure flag-based CLI (rejected — steep learning curve, poor discoverability). Wizard-driven with flag fallback (chosen).
+
+## Solution
+
+Commands accept simple flags but fall back to interactive prompts (wizards) when arguments are omitted. Users are guided through month selection, repo picking, and report generation.
+
+## Consequences
+
+Harder for automated/CI usage — the wizard prompts expect a human at the terminal. That trade-off is accepted; the primary audience is a developer running one-off analysis.

--- a/docs/adr/0004-wizard-driven-cli.md
+++ b/docs/adr/0004-wizard-driven-cli.md
@@ -1,0 +1,5 @@
+# Wizard-driven CLI over pure flag-based
+
+Commands accept simple flags (org, repo, period) and fall back to interactive prompts (wizards) when arguments are omitted. This prioritises discoverability and ease of use over scriptability — users are guided through month selection, repo picking, and report generation without memorising flags.
+
+We accept that this makes automated/robotic usage harder. CI pipelines or scripting use cases are a secondary concern; the primary audience is a developer running ad-hoc analysis.

--- a/docs/adr/0005-file-based-reports.md
+++ b/docs/adr/0005-file-based-reports.md
@@ -1,0 +1,5 @@
+# File-based reports over web application
+
+Reports are generated as static HTML files (dashboard, trend, stale) opened in the browser. No web server, no routing, no state management.
+
+This avoids the operational complexity of hosting a web app (deployment, auth, persistence). A web application is a viable future direction if the tool grows beyond single-user analysis, but for now static files deliver the same information with zero infrastructure.

--- a/docs/adr/0005-file-based-reports.md
+++ b/docs/adr/0005-file-based-reports.md
@@ -1,5 +1,17 @@
 # File-based reports over web application
 
-Reports are generated as static HTML files (dashboard, trend, stale) opened in the browser. No web server, no routing, no state management.
+## Problem
 
-This avoids the operational complexity of hosting a web app (deployment, auth, persistence). A web application is a viable future direction if the tool grows beyond single-user analysis, but for now static files deliver the same information with zero infrastructure.
+Needed a way to deliver reports (dashboard, trend, stale PRs) without operating infrastructure.
+
+## Options
+
+Web application (deferred — adds auth, deployment, persistence, routing overhead). Static HTML files (chosen).
+
+## Solution
+
+Generate static HTML files and open them in the browser. No web server, no routing, no state management. Jinja2 templates render the snapshot data directly to HTML.
+
+## Consequences
+
+No hosting infrastructure needed. Limited to single-user read-only reports. A web application is a viable future direction if the tool grows beyond individual analysis.


### PR DESCRIPTION
## Summary

Records five architectural decisions that were implicit in the codebase:

1. **ADR-0001** — Fetch once, snapshot and cache by month
2. **ADR-0002** — SQLite for metric storage
3. **ADR-0003** — GraphQL over REST for GitHub data
4. **ADR-0004** — Wizard-driven CLI over pure flag-based
5. **ADR-0005** — File-based reports over web application

These ADRs establish a foundation for future architecture reviews and provide context for why the codebase is shaped the way it is.