### PR TITLE
Extract shared Jinja2 environment into render_template

### DIFF
--- a/git_dev_metrics/metrics/printer/_html_templates.py
+++ b/git_dev_metrics/metrics/printer/_html_templates.py
@@ -1,0 +1,16 @@
+from typing import Any
+
+from jinja2 import Environment, PackageLoader, select_autoescape
+
+_ENV: Environment | None = None
+
+
+def render_template(template_name: str, **context: Any) -> str:
+    global _ENV
+    if _ENV is None:
+        _ENV = Environment(
+            loader=PackageLoader("git_dev_metrics.metrics.printer", "templates"),
+            autoescape=select_autoescape(["html", "xml"]),
+        )
+    template = _ENV.get_template(template_name)
+    return template.render(context)

--- a/git_dev_metrics/metrics/printer/html.py
+++ b/git_dev_metrics/metrics/printer/html.py
@@ -1,21 +1,8 @@
 from pathlib import Path
 
-from jinja2 import Environment, PackageLoader, select_autoescape
-
 from ..snapshot import MetricsSnapshot
+from ._html_templates import render_template
 from .base import Printer
-
-_ENV: Environment | None = None
-
-
-def _get_env() -> Environment:
-    global _ENV
-    if _ENV is None:
-        _ENV = Environment(
-            loader=PackageLoader("git_dev_metrics.metrics.printer", "templates"),
-            autoescape=select_autoescape(["html", "xml"]),
-        )
-    return _ENV
 
 
 def _devs_for_template(snapshot: MetricsSnapshot) -> list[dict]:
@@ -64,10 +51,8 @@ class FileHtmlPrinter(Printer):
     def print_combined_metrics(
         self, snapshot: MetricsSnapshot, period: str, date_range: str
     ) -> None:
-        env = _get_env()
-        template = env.get_template("dashboard.html")
-
-        html = template.render(
+        html = render_template(
+            "dashboard.html",
             devs=_devs_for_template(snapshot),
             summary=_summary_for_template(snapshot),
             period=period,

--- a/git_dev_metrics/metrics/printer/stale.py
+++ b/git_dev_metrics/metrics/printer/stale.py
@@ -1,20 +1,7 @@
 from pathlib import Path
 
-from jinja2 import Environment, PackageLoader, select_autoescape
-
 from ..calculator import summarize_stale_prs
-
-_ENV: Environment | None = None
-
-
-def _get_env() -> Environment:
-    global _ENV
-    if _ENV is None:
-        _ENV = Environment(
-            loader=PackageLoader("git_dev_metrics.metrics.printer", "templates"),
-            autoescape=select_autoescape(["html", "xml"]),
-        )
-    return _ENV
+from ._html_templates import render_template
 
 
 class FileStaleHtmlPrinter:
@@ -25,10 +12,6 @@ class FileStaleHtmlPrinter:
 
     def render(self, stale_prs: list[dict]) -> None:
         total, avg_age = summarize_stale_prs(stale_prs)
-        html = (
-            _get_env()
-            .get_template("stale.html")
-            .render(total=total, avg_age=avg_age, prs=stale_prs)
-        )
+        html = render_template("stale.html", total=total, avg_age=avg_age, prs=stale_prs)
         self._output_path.parent.mkdir(parents=True, exist_ok=True)
         self._output_path.write_text(html)

--- a/git_dev_metrics/metrics/printer/trend.py
+++ b/git_dev_metrics/metrics/printer/trend.py
@@ -1,21 +1,8 @@
 from dataclasses import asdict
 from pathlib import Path
 
-from jinja2 import Environment, PackageLoader, select_autoescape
-
 from ..trend_calculator import TrendDataset
-
-_ENV: Environment | None = None
-
-
-def _get_env() -> Environment:
-    global _ENV
-    if _ENV is None:
-        _ENV = Environment(
-            loader=PackageLoader("git_dev_metrics.metrics.printer", "templates"),
-            autoescape=select_autoescape(["html", "xml"]),
-        )
-    return _ENV
+from ._html_templates import render_template
 
 
 def _to_dict(dataset: TrendDataset) -> dict:
@@ -33,9 +20,8 @@ class FileTrendPrinter:
         self._output_path = output_path
 
     def render(self, dataset: TrendDataset) -> None:
-        template = _get_env().get_template("trend.html")
         period_range = f"{dataset.months[0]} to {dataset.months[-1]}" if dataset.months else ""
-        html = template.render(period_range=period_range, dataset=_to_dict(dataset))
+        html = render_template("trend.html", period_range=period_range, dataset=_to_dict(dataset))
         self._output_path.parent.mkdir(parents=True, exist_ok=True)
         self._output_path.write_text(html)
 


### PR DESCRIPTION
## Summary

`_get_env()` + module-level `_ENV` was duplicated identically across 3 files (stale.py, trend.py, html.py). Extracted to `_html_templates.py` as `render_template(template_name, **context)`.

- **`_html_templates.py`** — single `render_template()` hides Jinja2 completely
- **-30 lines** net removal
- **Same behaviour** — lazy-init singleton, same PackageLoader config

No test changes needed — no public API changed.