### PR TITLE
Extract GraphQL mapping layer into public module with tests

### DIFF
--- a/git_dev_metrics/github/__init__.py
+++ b/git_dev_metrics/github/__init__.py
@@ -1,5 +1,12 @@
 """Github auth and data fetching."""
 
+from ._response_mapper import (
+    map_author_login,
+    map_datetime,
+    map_pull_request,
+    map_repository,
+    map_review,
+)
 from .auth import get_github_token
 from .exceptions import (
     GitHubAPIError,
@@ -24,6 +31,7 @@ __all__ = [
     "GitHubAPIError",
     "GitHubRateLimitError",
     "GitHubNotFoundError",
+    "map_author_login",
     "get_github_token",
     "fetch_repositories",
     "fetch_org_repositories",
@@ -32,5 +40,9 @@ __all__ = [
     "fetch_repo_metrics",
     "fetch_open_prs",
     "load_last_org",
+    "map_pull_request",
+    "map_repository",
+    "map_review",
+    "map_datetime",
     "save_last_org",
 ]

--- a/git_dev_metrics/github/_response_mapper.py
+++ b/git_dev_metrics/github/_response_mapper.py
@@ -1,0 +1,70 @@
+from datetime import datetime
+
+from ..models import PullRequest, Repository, Review
+
+
+def map_datetime(dt_str: str | None) -> datetime | None:
+    """Parse ISO datetime string to datetime object."""
+    if not dt_str:
+        return None
+    try:
+        return datetime.fromisoformat(dt_str.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def map_author_login(author: dict | None) -> str:
+    """Extract login from author dict, defaulting to 'unknown'."""
+    return (author or {}).get("login") or "unknown"
+
+
+def map_repository(repo: dict) -> Repository:
+    """Map GraphQL repository response to internal model."""
+    return {
+        "full_name": repo.get("nameWithOwner"),  # type: ignore[return-value]
+        "private": repo.get("isPrivate", False),
+        "last_pushed": map_datetime(repo.get("pushedAt")),
+    }
+
+
+def map_pull_request(pr: dict) -> PullRequest:
+    """Map GraphQL PR response to internal model."""
+    commits = pr.get("commits", {}).get("nodes", [])
+    first_commit_date = None
+    if commits:
+        commit_data = commits[-1].get("commit", {})
+        committed_at = commit_data.get("committedDate")
+        first_commit_date = map_datetime(committed_at)
+
+    commit_messages = [msg for c in commits if (msg := (c.get("commit") or {}).get("message"))]
+
+    timeline_nodes = (pr.get("timelineItems") or {}).get("nodes") or []
+    ready_for_review = next(
+        (map_datetime(n.get("createdAt")) for n in timeline_nodes if n.get("createdAt")),
+        None,
+    )
+
+    return {  # type: ignore[return-value]
+        "number": pr.get("number"),
+        "title": pr.get("title"),
+        "created_at": map_datetime(pr.get("createdAt")),
+        "merged_at": map_datetime(pr.get("mergedAt")),
+        "additions": pr.get("additions", 0),
+        "deletions": pr.get("deletions", 0),
+        "changed_files": pr.get("changedFiles", 0),
+        "user": {"login": map_author_login(pr.get("author"))},
+        "first_commit_at": first_commit_date,
+        "ready_for_review_at": ready_for_review,
+        "body": pr.get("body"),
+        "commit_messages": commit_messages,
+        "reviews": [],
+    }
+
+
+def map_review(review: dict) -> Review:
+    """Map GraphQL review response to internal model."""
+    return {
+        "user": {"login": map_author_login(review.get("author"))},
+        "state": review.get("state"),  # type: ignore[return-value]
+        "submitted_at": map_datetime(review.get("submittedAt")),
+    }

--- a/git_dev_metrics/github/queries.py
+++ b/git_dev_metrics/github/queries.py
@@ -1,7 +1,12 @@
-from datetime import datetime
-
 from ..models import OpenPullRequest, PullRequest, Repository, Review
 from ..utils import TimePeriod
+from ._response_mapper import (
+    map_author_login,
+    map_datetime,
+    map_pull_request,
+    map_repository,
+    map_review,
+)
 from .graphql_client import execute_paginated_query, get_client
 from .graphql_queries import (
     OPEN_PRS_QUERY,
@@ -22,73 +27,6 @@ def _build_merged_prs_query(org: str, repo: str, period: TimePeriod) -> str:
     return f"repo:{org}/{repo} is:pr merged:{since}..{until}"
 
 
-def _author_login(author: dict | None) -> str:
-    """Extract login from author dict, default to 'unknown' if missing."""
-    return (author or {}).get("login") or "unknown"
-
-
-def _parse_datetime(dt_str: str | None) -> datetime | None:
-    """Parse ISO datetime string to datetime object."""
-    if not dt_str:
-        return None
-    try:
-        return datetime.fromisoformat(dt_str.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-
-
-def _map_repository(repo: dict) -> Repository:
-    """Map GraphQL repository response to internal model."""
-    return {
-        "full_name": repo.get("nameWithOwner"),  # type: ignore[return-value]
-        "private": repo.get("isPrivate", False),
-        "last_pushed": _parse_datetime(repo.get("pushedAt")),
-    }
-
-
-def _map_pull_request(pr: dict) -> PullRequest:
-    """Map GraphQL PR response to internal model."""
-    commits = pr.get("commits", {}).get("nodes", [])
-    first_commit_date = None
-    if commits:
-        commit_data = commits[-1].get("commit", {})
-        committed_at = commit_data.get("committedDate")
-        first_commit_date = _parse_datetime(committed_at)
-
-    commit_messages = [msg for c in commits if (msg := (c.get("commit") or {}).get("message"))]
-
-    timeline_nodes = (pr.get("timelineItems") or {}).get("nodes") or []
-    ready_for_review = next(
-        (_parse_datetime(n.get("createdAt")) for n in timeline_nodes if n.get("createdAt")),
-        None,
-    )
-
-    return {  # type: ignore[return-value]
-        "number": pr.get("number"),
-        "title": pr.get("title"),
-        "created_at": _parse_datetime(pr.get("createdAt")),
-        "merged_at": _parse_datetime(pr.get("mergedAt")),
-        "additions": pr.get("additions", 0),
-        "deletions": pr.get("deletions", 0),
-        "changed_files": pr.get("changedFiles", 0),
-        "user": {"login": _author_login(pr.get("author"))},
-        "first_commit_at": first_commit_date,
-        "ready_for_review_at": ready_for_review,
-        "body": pr.get("body"),
-        "commit_messages": commit_messages,
-        "reviews": [],
-    }
-
-
-def _map_review(review: dict) -> Review:
-    """Map GraphQL review response to internal model."""
-    return {
-        "user": {"login": _author_login(review.get("author"))},
-        "state": review.get("state"),  # type: ignore[return-value]
-        "submitted_at": _parse_datetime(review.get("submittedAt")),
-    }
-
-
 def fetch_repositories(token: str) -> list[Repository]:
     """Fetch all repositories accessible with the given token."""
     client = get_client(token)
@@ -96,7 +34,7 @@ def fetch_repositories(token: str) -> list[Repository]:
         client, REPOSITORIES_QUERY, {"first": PAGE_SIZE}, "viewer.repositories"
     )
 
-    return [_map_repository(repo) for repo in repos if repo.get("nameWithOwner")]
+    return [map_repository(repo) for repo in repos if repo.get("nameWithOwner")]
 
 
 def fetch_org_repositories(token: str, org: str) -> list[Repository]:
@@ -109,7 +47,7 @@ def fetch_org_repositories(token: str, org: str) -> list[Repository]:
         "organization.repositories",
     )
 
-    return [_map_repository(repo) for repo in repos if repo.get("nameWithOwner")]
+    return [map_repository(repo) for repo in repos if repo.get("nameWithOwner")]
 
 
 def fetch_pull_requests(token: str, org: str, repo: str, period: TimePeriod) -> list[PullRequest]:
@@ -124,7 +62,7 @@ def fetch_pull_requests(token: str, org: str, repo: str, period: TimePeriod) -> 
         repo_id=f"{org}/{repo}",
     )
 
-    return [_map_pull_request(pr) for pr in prs if pr.get("mergedAt")]
+    return [map_pull_request(pr) for pr in prs if pr.get("mergedAt")]
 
 
 def fetch_reviews(
@@ -150,7 +88,7 @@ def fetch_reviews(
             continue
 
         reviews = pr.get("reviews", {}).get("nodes", [])
-        reviews_by_pr[pr_number] = [_map_review(r) for r in reviews]
+        reviews_by_pr[pr_number] = [map_review(r) for r in reviews]
 
     return reviews_by_pr
 
@@ -160,13 +98,13 @@ def _filter_and_map_pr(prs: list[dict], period: TimePeriod) -> list[PullRequest]
     mapped_prs: list[PullRequest] = []
 
     for pr in prs:
-        mapped = _map_pull_request(pr)
+        mapped = map_pull_request(pr)
         merged_at = mapped["merged_at"]
         if merged_at is None or merged_at < period.since or merged_at >= period.until:
             continue
 
         review_nodes = pr.get("reviews", {}).get("nodes", [])
-        mapped["reviews"] = [_map_review(r) for r in review_nodes]
+        mapped["reviews"] = [map_review(r) for r in review_nodes]
         mapped_prs.append(mapped)
 
     return mapped_prs
@@ -211,9 +149,9 @@ def fetch_open_prs(token: str, org: str, repo: str, quiet: bool = False) -> list
             {
                 "number": number,
                 "title": title,
-                "created_at": _parse_datetime(pr.get("createdAt")),
+                "created_at": map_datetime(pr.get("createdAt")),
                 "merged_at": None,
-                "user": {"login": _author_login(pr.get("author"))},
+                "user": {"login": map_author_login(pr.get("author"))},
                 "is_draft": pr.get("isDraft", False),
                 "is_approved": is_approved,
             }

--- a/tests/integration/test_pull_e2e.py
+++ b/tests/integration/test_pull_e2e.py
@@ -1,6 +1,6 @@
 """End-to-end tests for the pull command: raw GraphQL → mapper → cache → report.
 
-These exist so a shape change in `_map_pull_request` (or anywhere it touches the
+These exist so a shape change in `map_pull_request` (or anywhere it touches the
 cache) breaks a test, not the next live `gdm pull`.
 """
 
@@ -8,7 +8,7 @@ from typer.testing import CliRunner
 
 from git_dev_metrics.cache import count_prs, is_sealed, query_prs
 from git_dev_metrics.cli.app import app
-from git_dev_metrics.github.queries import _map_pull_request
+from git_dev_metrics.github._response_mapper import map_pull_request
 
 runner = CliRunner()
 
@@ -57,7 +57,7 @@ class TestPullEndToEnd:
             _raw_pr(102, "bob", 12, []),
             _raw_pr(103, "alice", 22, [_raw_review("carol", 22), _raw_review("dave", 23)]),
         ]
-        mapped = [_map_pull_request(pr) for pr in raw]
+        mapped = [map_pull_request(pr) for pr in raw]
         mocker.patch("git_dev_metrics.cli.pull.get_github_token", return_value="fake-token")
         mocker.patch("git_dev_metrics.cli.pull_runner.fetch_repo_metrics", return_value=mapped)
 
@@ -94,7 +94,7 @@ class TestPullEndToEnd:
             _raw_pr(201, "alice", 3, [_raw_review("bob", 3)]),
             _raw_pr(202, "bob", 9, [_raw_review("alice", 9)]),
         ]
-        mapped = [_map_pull_request(pr) for pr in raw]
+        mapped = [map_pull_request(pr) for pr in raw]
         mocker.patch("git_dev_metrics.cli.pull.get_github_token", return_value="fake-token")
         mocker.patch("git_dev_metrics.cli.pull_runner.fetch_repo_metrics", return_value=mapped)
         mocker.patch("git_dev_metrics.cli._browser.webbrowser.open", return_value=False)
@@ -104,16 +104,29 @@ class TestPullEndToEnd:
         pull_result = runner.invoke(
             app,
             [
-                "pull", "--month", "2026-04",
-                "--org", "myorg", "--repo", "myrepo",
-                "--db", str(db_path),
+                "pull",
+                "--month",
+                "2026-04",
+                "--org",
+                "myorg",
+                "--repo",
+                "myrepo",
+                "--db",
+                str(db_path),
             ],
         )
         dashboard_result = runner.invoke(
             app,
             [
-                "dashboard", "--from", "2026-04", "--to", "2026-04",
-                "--db", str(db_path), "--output", str(dashboard_out),
+                "dashboard",
+                "--from",
+                "2026-04",
+                "--to",
+                "2026-04",
+                "--db",
+                str(db_path),
+                "--output",
+                str(dashboard_out),
             ],
         )
         clear_result = runner.invoke(app, ["clear", "--db", str(db_path), "--yes"])
@@ -147,7 +160,7 @@ class TestPullEndToEnd:
             "reviews": {"nodes": []},
             "timelineItems": {"nodes": []},
         }
-        mapped = [_map_pull_request(minimal)]
+        mapped = [map_pull_request(minimal)]
         mocker.patch("git_dev_metrics.cli.pull.get_github_token", return_value="fake-token")
         mocker.patch("git_dev_metrics.cli.pull_runner.fetch_repo_metrics", return_value=mapped)
 

--- a/tests/unit/test_github_response_mapper.py
+++ b/tests/unit/test_github_response_mapper.py
@@ -1,0 +1,189 @@
+from datetime import UTC, datetime
+
+from git_dev_metrics.github._response_mapper import (
+    map_author_login,
+    map_datetime,
+    map_pull_request,
+    map_repository,
+    map_review,
+)
+
+from .conftest import dt
+
+
+class TestMapDatetime:
+    def test_should_parse_iso_string(self) -> None:
+        result = map_datetime("2024-01-01T12:00:00Z")
+        assert result == datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+    def test_should_return_none_for_none(self) -> None:
+        assert map_datetime(None) is None
+
+    def test_should_return_none_for_empty_string(self) -> None:
+        assert map_datetime("") is None
+
+    def test_should_return_none_for_invalid_string(self) -> None:
+        assert map_datetime("not-a-date") is None
+
+
+class TestMapAuthorLogin:
+    def test_should_return_login_for_known_author(self) -> None:
+        assert map_author_login({"login": "alice"}) == "alice"
+
+    def test_should_return_unknown_for_none(self) -> None:
+        assert map_author_login(None) == "unknown"
+
+    def test_should_return_unknown_for_empty_dict(self) -> None:
+        assert map_author_login({}) == "unknown"
+
+    def test_should_return_unknown_for_missing_login(self) -> None:
+        assert map_author_login({"name": "bob"}) == "unknown"
+
+
+class TestMapRepository:
+    def test_should_map_full_repo(self) -> None:
+        raw = {
+            "nameWithOwner": "myorg/myrepo",
+            "isPrivate": True,
+            "pushedAt": "2024-06-15T10:00:00Z",
+        }
+        result = map_repository(raw)
+        assert result == {
+            "full_name": "myorg/myrepo",
+            "private": True,
+            "last_pushed": dt(year=2024, month=6, day=15, hour=10),
+        }
+
+    def test_should_map_public_repo_without_push(self) -> None:
+        raw = {"nameWithOwner": "myorg/other", "isPrivate": False, "pushedAt": None}
+        result = map_repository(raw)
+        assert result == {
+            "full_name": "myorg/other",
+            "private": False,
+            "last_pushed": None,
+        }
+
+
+class TestMapPullRequest:
+    def test_should_map_full_pr_with_reviews(self) -> None:
+        raw = {
+            "number": 42,
+            "title": "Fix the thing",
+            "createdAt": "2024-01-01T08:00:00Z",
+            "mergedAt": "2024-01-02T16:00:00Z",
+            "additions": 100,
+            "deletions": 50,
+            "changedFiles": 5,
+            "author": {"login": "alice"},
+            "commits": {
+                "nodes": [
+                    {"commit": {"committedDate": "2024-01-01T06:00:00Z", "message": "wip"}},
+                    {"commit": {"committedDate": "2024-01-01T07:00:00Z", "message": "fix: done"}},
+                ]
+            },
+            "reviews": {"nodes": []},
+            "timelineItems": {"nodes": []},
+        }
+        result = map_pull_request(raw)
+        assert result["number"] == 42
+        assert result["title"] == "Fix the thing"
+        assert result["user"]["login"] == "alice"
+        assert result["additions"] == 100
+        assert result["deletions"] == 50
+        assert result["changed_files"] == 5
+        assert result["created_at"] == dt(year=2024, month=1, day=1, hour=8)
+        assert result["merged_at"] == dt(year=2024, month=1, day=2, hour=16)
+        assert result["commit_messages"] == ["wip", "fix: done"]
+        assert result["reviews"] == []
+
+    def test_should_map_minimal_pr(self) -> None:
+        raw: dict = {
+            "number": 1,
+            "title": "Minimal",
+            "createdAt": "2024-01-01T00:00:00Z",
+            "mergedAt": None,
+            "additions": 0,
+            "deletions": 0,
+            "changedFiles": 0,
+            "author": None,
+            "commits": {"nodes": []},
+            "reviews": {"nodes": []},
+            "timelineItems": {"nodes": []},
+        }
+        result = map_pull_request(raw)
+        assert result["number"] == 1
+        assert result["user"]["login"] == "unknown"
+        assert result["merged_at"] is None
+        assert result["first_commit_at"] is None
+        assert result["ready_for_review_at"] is None
+        assert result["body"] is None
+        assert result["commit_messages"] == []
+
+    def test_should_extract_ready_for_review_from_timeline(self) -> None:
+        raw = {
+            "number": 2,
+            "title": "PR",
+            "createdAt": "2024-01-01T08:00:00Z",
+            "mergedAt": "2024-01-02T16:00:00Z",
+            "additions": 10,
+            "deletions": 5,
+            "changedFiles": 1,
+            "author": {"login": "bob"},
+            "commits": {"nodes": []},
+            "reviews": {"nodes": []},
+            "timelineItems": {
+                "nodes": [
+                    {"createdAt": "2024-01-01T10:00:00Z"},
+                ]
+            },
+        }
+        result = map_pull_request(raw)
+        assert result["ready_for_review_at"] == dt(year=2024, month=1, day=1, hour=10)
+
+    def test_should_use_oldest_commit_as_first_commit(self) -> None:
+        raw = {
+            "number": 3,
+            "title": "Commits",
+            "createdAt": "2024-01-03T08:00:00Z",
+            "mergedAt": "2024-01-04T16:00:00Z",
+            "additions": 10,
+            "deletions": 5,
+            "changedFiles": 1,
+            "author": {"login": "carol"},
+            "commits": {
+                "nodes": [
+                    {"commit": {"committedDate": "2024-01-03T07:00:00Z", "message": "b"}},
+                    {"commit": {"committedDate": "2024-01-02T06:00:00Z", "message": "a"}},
+                ]
+            },
+            "reviews": {"nodes": []},
+            "timelineItems": {"nodes": []},
+        }
+        result = map_pull_request(raw)
+        assert result["first_commit_at"] == dt(year=2024, month=1, day=2, hour=6)
+        assert result["commit_messages"] == ["b", "a"]
+
+
+class TestMapReview:
+    def test_should_map_approved_review(self) -> None:
+        raw = {
+            "author": {"login": "reviewer1"},
+            "state": "APPROVED",
+            "submittedAt": "2024-01-02T12:00:00Z",
+        }
+        result = map_review(raw)
+        assert result == {
+            "user": {"login": "reviewer1"},
+            "state": "APPROVED",
+            "submitted_at": dt(year=2024, month=1, day=2, hour=12),
+        }
+
+    def test_should_map_review_without_author(self) -> None:
+        raw: dict = {"author": None, "state": "COMMENTED", "submittedAt": "2024-01-02T12:00:00Z"}
+        result = map_review(raw)
+        assert result["user"]["login"] == "unknown"
+
+    def test_should_map_review_without_submitted_at(self) -> None:
+        raw: dict = {"author": {"login": "r"}, "state": "CHANGES_REQUESTED", "submittedAt": None}
+        result = map_review(raw)
+        assert result["submitted_at"] is None


### PR DESCRIPTION
## Summary

`_map_pull_request`, `_map_review`, `_map_repository`, `_parse_datetime`, and `_author_login` were private functions in `queries.py` with no direct test coverage. Extracted to `github/_response_mapper.py` as public, tested functions — renamed to `map_*` for consistency.

| Function | Old (private) | New (public) | Tests |
|---|---|---|---|
| `map_pull_request` | `_map_pull_request` | `map_pull_request` | 4 |
| `map_review` | `_map_review` | `map_review` | 3 |
| `map_repository` | `_map_repository` | `map_repository` | 2 |
| `map_datetime` | `_parse_datetime` | `map_datetime` | 4 |
| `map_author_login` | `_author_login` | `map_author_login` | 4 |

- Exported from `github/__init__.py` alongside fetch functions
- Integration test imports `map_pull_request` from public API
- 17 new unit tests, all 239 passing