### PR TITLE
Extract shared Row/Summary/Band types into _rows.py, fixing circular dependency

### DIFF
--- a/git_dev_metrics/metrics/__init__.py
+++ b/git_dev_metrics/metrics/__init__.py
@@ -1,5 +1,7 @@
 """Metrics"""
 
+from ._health_ranking import band_from_health
+from ._rows import Band, Row, Summary, band_color
 from .calculator import (
     calculate_avg_lines_per_pr,
     calculate_cycle_time,
@@ -13,15 +15,7 @@ from .calculator import (
 from .health import calculate_dev_health_score, calculate_health_score
 from .loader import InvalidRangeError, load_snapshot_for_months, load_snapshot_for_range
 from .printer import ConsolePrinter, Printer
-from .snapshot import (
-    Band,
-    MetricsSnapshot,
-    Row,
-    Summary,
-    band_color,
-    band_from_health,
-    build_summary,
-)
+from .snapshot import MetricsSnapshot, build_summary
 
 __all__ = [
     "Band",

--- a/git_dev_metrics/metrics/_health_ranking.py
+++ b/git_dev_metrics/metrics/_health_ranking.py
@@ -3,8 +3,8 @@ from typing import Any
 
 from ..models import PullRequest
 from ._dev_repo_metrics import compute_metrics_dict
+from ._rows import Band, Row
 from .calculator import median
-from .snapshot import Band, Row
 
 _PER_DEV_AGGREGATED_KEYS = (
     "cycle_time",

--- a/git_dev_metrics/metrics/_rows.py
+++ b/git_dev_metrics/metrics/_rows.py
@@ -1,0 +1,39 @@
+"""Shared row types used by snapshot and health ranking.
+
+Leaf module — no dependencies within the metrics package.
+"""
+
+from dataclasses import dataclass
+from typing import Literal
+
+Band = Literal["good", "ok", "bad"]
+
+_BAND_COLOR: dict[Band, str] = {"good": "green", "ok": "yellow", "bad": "red"}
+
+
+def band_color(band: Band) -> str:
+    return _BAND_COLOR[band]
+
+
+@dataclass(frozen=True)
+class Row:
+    name: str
+    pr_count: int
+    cycle_time: float
+    pickup_time: float
+    review_time: float
+    pr_size: float
+    avg_lines_per_pr: float
+    prs_per_week: float
+    reviews_given: int
+    ai_percentage: float
+    health: int
+    band: Band
+
+
+@dataclass(frozen=True)
+class Summary:
+    ai_per_dev: tuple[int, ...]
+    review_ratio: float
+    top_reviewer: str
+    max_review_share: int

--- a/git_dev_metrics/metrics/printer/dev.py
+++ b/git_dev_metrics/metrics/printer/dev.py
@@ -1,4 +1,5 @@
-from ..snapshot import MetricsSnapshot, band_color
+from .._rows import band_color
+from ..snapshot import MetricsSnapshot
 
 DEV_COLUMNS = [
     "Dev",

--- a/git_dev_metrics/metrics/snapshot.py
+++ b/git_dev_metrics/metrics/snapshot.py
@@ -5,55 +5,14 @@ they do not recompute health, bands, sort orders, or aggregations.
 """
 
 from dataclasses import dataclass
-from typing import Literal
 
 from ..models import PullRequest
 from ..utils import TimePeriod, period_days
 from ._dev_repo_metrics import compute_dev_metrics, compute_repo_metrics
+from ._health_ranking import band_from_health, compute_team_row, rank_rows
+from ._rows import Row, Summary
 from .calculator import calculate_reviews_given
 from .health import calculate_dev_health_score, calculate_health_score
-
-# Imports from _health_ranking must come after Row/Band definitions
-# to resolve circular dependency (_health_ranking imports Row/Band).
-
-Band = Literal["good", "ok", "bad"]
-
-_BAND_COLOR: dict[Band, str] = {"good": "green", "ok": "yellow", "bad": "red"}
-
-
-def band_color(band: Band) -> str:
-    return _BAND_COLOR[band]
-
-
-@dataclass(frozen=True)
-class Row:
-    name: str
-    pr_count: int
-    cycle_time: float
-    pickup_time: float
-    review_time: float
-    pr_size: float
-    avg_lines_per_pr: float
-    prs_per_week: float
-    reviews_given: int
-    ai_percentage: float
-    health: int
-    band: Band
-
-
-@dataclass(frozen=True)
-class Summary:
-    ai_per_dev: tuple[int, ...]
-    review_ratio: float
-    top_reviewer: str
-    max_review_share: int
-
-
-from ._health_ranking import (  # noqa: E402
-    band_from_health,
-    compute_team_row,
-    rank_rows,
-)
 
 
 @dataclass(frozen=True)
@@ -118,11 +77,7 @@ def build_summary(
 
 
 __all__ = [
-    "Band",
     "MetricsSnapshot",
-    "Row",
-    "Summary",
-    "band_color",
     "band_from_health",
     "build_summary",
 ]


### PR DESCRIPTION
## Summary

**Problem**: `snapshot.py` and `_health_ranking.py` shared a circular dependency. `Band`, `Row`, `Summary` were defined in `snapshot`, but `_health_ranking` imported them. Meanwhile `snapshot` imported `band_from_health`/`compute_team_row`/`rank_rows` from `_health_ranking`. The cycle was papered over with a deferred import (`noqa: E402`).

**Solution**: Extracted `Band`, `Row`, `Summary`, `band_color`, and `_BAND_COLOR` into a new leaf module `metrics/_rows.py` with zero dependencies on the rest of the metrics package (only stdlib imports). Both `snapshot.py` and `_health_ranking.py` now import from `_rows.py`.

The deferred import in `snapshot.py` is gone — all imports are at the top of the file where they belong.

**Files changed**:
- `metrics/_rows.py` — new file, leaf module
- `metrics/snapshot.py` — removed type definitions + deferred import, now imports from `_rows`
- `metrics/_health_ranking.py` — imports `Band`, `Row` from `_rows` instead of `snapshot`
- `metrics/__init__.py` — imports types from `_rows`, `band_from_health` from `_health_ranking`
- `metrics/printer/dev.py` — imports `band_color` from `_rows` instead of `snapshot`

**Benefits**:
- Eliminates the circular dependency entirely
- Clear dependency direction: `_rows` → `_health_ranking` → `snapshot`
- No more deferred import hack
- Types are in a natural home (leaf module, zero dependencies)

**Related**: candidate 2 from architecture deepening exercise.