### PR TITLE
Extract shared _snapshot_runner formatting helpers

### DIFF
--- a/git_dev_metrics/cli/commands/dashboard.py
+++ b/git_dev_metrics/cli/commands/dashboard.py
@@ -39,7 +39,4 @@ def dashboard(
         )
         raise typer.Exit(code=1)
 
-    period_slug = f"{from_}-to-{to}"
-    since = snapshot.period.since.strftime("%Y-%m-%d")
-    until = snapshot.period.until.strftime("%Y-%m-%d")
-    write_and_open_dashboard(snapshot, period_slug, f"{since} to {until}", output)
+    write_and_open_dashboard(snapshot, output, flag_from=from_, flag_to=to)

--- a/git_dev_metrics/cli/commands/summary.py
+++ b/git_dev_metrics/cli/commands/summary.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import typer
 
 from ...metrics.loader import InvalidRangeError, load_snapshot_for_range
-from ...metrics.printer import ConsolePrinter
+from ..runners.summary_runner import print_console_summary
 from ..wizards.summary_wizard import summary_wizard
 
 
@@ -38,7 +38,4 @@ def summary(
         )
         raise typer.Exit(code=1)
 
-    period_slug = f"{from_}-to-{to}"
-    since = snapshot.period.since.strftime("%Y-%m-%d")
-    until = snapshot.period.until.strftime("%Y-%m-%d")
-    ConsolePrinter().print_combined_metrics(snapshot, period_slug, f"{since} to {until}")
+    print_console_summary(snapshot, flag_from=from_, flag_to=to)

--- a/git_dev_metrics/cli/runners/_snapshot_runner.py
+++ b/git_dev_metrics/cli/runners/_snapshot_runner.py
@@ -1,0 +1,20 @@
+from ...metrics import MetricsSnapshot
+
+YearMonth = tuple[int, int]
+
+
+def format_period_slug(
+    selected: list[YearMonth] | None = None,
+    flag_from: str | None = None,
+    flag_to: str | None = None,
+) -> str:
+    if selected:
+        first, last = selected[0], selected[-1]
+        return f"{first[0]:04d}-{first[1]:02d}-to-{last[0]:04d}-{last[1]:02d}"
+    return f"{flag_from}-to-{flag_to}"
+
+
+def format_date_range(snapshot: MetricsSnapshot) -> str:
+    since = snapshot.period.since.strftime("%Y-%m-%d")
+    until = snapshot.period.until.strftime("%Y-%m-%d")
+    return f"{since} to {until}"

--- a/git_dev_metrics/cli/runners/dashboard_runner.py
+++ b/git_dev_metrics/cli/runners/dashboard_runner.py
@@ -6,6 +6,7 @@ import typer
 from ...metrics import MetricsSnapshot
 from ...metrics.printer.html import FileHtmlPrinter
 from .._browser import open_in_browser
+from ._snapshot_runner import YearMonth, format_date_range, format_period_slug
 
 
 def _default_output(period_slug: str) -> Path:
@@ -14,9 +15,15 @@ def _default_output(period_slug: str) -> Path:
 
 
 def write_and_open_dashboard(
-    snapshot: MetricsSnapshot, period_slug: str, date_range: str, output: Path | None
+    snapshot: MetricsSnapshot,
+    output: Path | None,
+    *,
+    selected: list[YearMonth] | None = None,
+    flag_from: str | None = None,
+    flag_to: str | None = None,
 ) -> None:
+    period_slug = format_period_slug(selected=selected, flag_from=flag_from, flag_to=flag_to)
     out = (output or _default_output(period_slug)).with_suffix(".html")
-    FileHtmlPrinter(out).print_combined_metrics(snapshot, period_slug, date_range)
+    FileHtmlPrinter(out).print_combined_metrics(snapshot, period_slug, format_date_range(snapshot))
     typer.echo(f"Dashboard written to {out}.")
     open_in_browser(out)

--- a/git_dev_metrics/cli/runners/summary_runner.py
+++ b/git_dev_metrics/cli/runners/summary_runner.py
@@ -1,0 +1,14 @@
+from ...metrics import MetricsSnapshot
+from ...metrics.printer import ConsolePrinter
+from ._snapshot_runner import YearMonth, format_date_range, format_period_slug
+
+
+def print_console_summary(
+    snapshot: MetricsSnapshot,
+    *,
+    selected: list[YearMonth] | None = None,
+    flag_from: str | None = None,
+    flag_to: str | None = None,
+) -> None:
+    period_slug = format_period_slug(selected=selected, flag_from=flag_from, flag_to=flag_to)
+    ConsolePrinter().print_combined_metrics(snapshot, period_slug, format_date_range(snapshot))

--- a/git_dev_metrics/cli/wizards/dashboard_wizard.py
+++ b/git_dev_metrics/cli/wizards/dashboard_wizard.py
@@ -21,8 +21,4 @@ def dashboard_wizard(
     if snapshot is None:
         typer.secho("No PRs in selected months.", fg=typer.colors.RED, err=True)
         raise typer.Exit(code=1)
-    first, last = selected[0], selected[-1]
-    period_slug = f"{first[0]:04d}-{first[1]:02d}-to-{last[0]:04d}-{last[1]:02d}"
-    since = snapshot.period.since.strftime("%Y-%m-%d")
-    until = snapshot.period.until.strftime("%Y-%m-%d")
-    write_and_open_dashboard(snapshot, period_slug, f"{since} to {until}", output=None)
+    write_and_open_dashboard(snapshot, output=None, selected=selected)

--- a/git_dev_metrics/cli/wizards/summary_wizard.py
+++ b/git_dev_metrics/cli/wizards/summary_wizard.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import typer
 
 from ...metrics.loader import load_snapshot_for_months
-from ...metrics.printer import ConsolePrinter
+from ..runners.summary_runner import print_console_summary
 from ._wizard import _prompt_months, pick_months
 
 YearMonth = tuple[int, int]
@@ -21,8 +21,4 @@ def summary_wizard(
     if snapshot is None:
         typer.secho("No PRs in selected months.", fg=typer.colors.RED, err=True)
         raise typer.Exit(code=1)
-    first, last = selected[0], selected[-1]
-    period_slug = f"{first[0]:04d}-{first[1]:02d}-to-{last[0]:04d}-{last[1]:02d}"
-    since = snapshot.period.since.strftime("%Y-%m-%d")
-    until = snapshot.period.until.strftime("%Y-%m-%d")
-    ConsolePrinter().print_combined_metrics(snapshot, period_slug, f"{since} to {until}")
+    print_console_summary(snapshot, selected=selected)


### PR DESCRIPTION
Problem: period_slug and date_range formatting was duplicated across 4 callers (summary command, summary wizard, dashboard command, dashboard wizard) — same logic, 4 copies.

Solution: Extract _snapshot_runner.py with two shared helpers:
- format_period_slug() — handles both input shapes (tuple from wizard vs string from CLI flag)
- format_date_range() — formats snapshot.period.since/until as "YYYY-MM-DD to YYYY-MM-DD"

Both summary_runner and dashboard_runner now accept selected or flag_from/flag_to and call the shared helpers internally. The 4 callers pass raw inputs and let the runner own formatting.

Benefits: Adding a third snapshot-based command (e.g. export --json) means one runner file, no formatting code. The formatting logic is localised — change slug format once, not 4 times.

Builds on the pattern from #131 (adds the missing runner) but goes further by centralising formatting across all snapshot-view commands.