### PR TITLE
Replace dict[str, Any] pipe with typed RawMetrics dataclass

### DIFF
--- a/git_dev_metrics/metrics/_dev_repo_metrics.py
+++ b/git_dev_metrics/metrics/_dev_repo_metrics.py
@@ -1,6 +1,5 @@
-from typing import Any
-
 from ..models import PullRequest
+from ._rows import RawMetrics
 from .calculator import (
     calculate_ai_percentage,
     calculate_avg_lines_per_pr,
@@ -15,36 +14,36 @@ from .calculator import (
 )
 
 
-def compute_metrics_dict(prs: list[PullRequest], days: int, reviews_given: int) -> dict[str, Any]:
-    return {
-        "cycle_time": calculate_cycle_time(prs),
-        "pr_size": calculate_pr_size(prs),
-        "avg_lines_per_pr": calculate_avg_lines_per_pr(prs),
-        "pr_count": calculate_throughput(prs),
-        "pickup_time": calculate_pickup_time(prs),
-        "review_time": calculate_review_time(prs),
-        "prs_per_week": calculate_prs_per_week(prs, days),
-        "reviews_given": reviews_given,
-        "ai_percentage": calculate_ai_percentage(prs),
-    }
+def compute_raw(prs: list[PullRequest], days: int, reviews_given: int) -> RawMetrics:
+    return RawMetrics(
+        cycle_time=calculate_cycle_time(prs),
+        pr_size=calculate_pr_size(prs),
+        avg_lines_per_pr=calculate_avg_lines_per_pr(prs),
+        pr_count=calculate_throughput(prs),
+        pickup_time=calculate_pickup_time(prs),
+        review_time=calculate_review_time(prs),
+        prs_per_week=calculate_prs_per_week(prs, days),
+        reviews_given=reviews_given,
+        ai_percentage=calculate_ai_percentage(prs),
+    )
 
 
 def compute_dev_metrics(
     all_prs: list[PullRequest], days: int, reviewer_counts: dict[str, int]
-) -> dict[str, dict[str, Any]]:
+) -> dict[str, RawMetrics]:
     return {
-        dev: compute_metrics_dict(dev_prs, days, reviewer_counts.get(dev, 0))
+        dev: compute_raw(dev_prs, days, reviewer_counts.get(dev, 0))
         for dev, dev_prs in group_prs_by_devs(all_prs).items()
     }
 
 
 def compute_repo_metrics(
     repo_prs: dict[str, list[PullRequest]], days: int
-) -> dict[str, dict[str, Any]]:
-    raws: dict[str, dict[str, Any]] = {}
+) -> dict[str, RawMetrics]:
+    raws: dict[str, RawMetrics] = {}
     for name, prs in repo_prs.items():
         reviews_given = sum(calculate_reviews_given(prs).values())
-        raw = compute_metrics_dict(prs, days, reviews_given)
-        if raw["pr_count"] > 0:
+        raw = compute_raw(prs, days, reviews_given)
+        if raw.pr_count > 0:
             raws[name] = raw
     return raws

--- a/git_dev_metrics/metrics/_health_ranking.py
+++ b/git_dev_metrics/metrics/_health_ranking.py
@@ -1,9 +1,8 @@
 from collections.abc import Callable
-from typing import Any
 
 from ..models import PullRequest
-from ._dev_repo_metrics import compute_metrics_dict
-from ._rows import Band, Row
+from ._dev_repo_metrics import compute_raw
+from ._rows import Band, RawMetrics, Row
 from .calculator import median
 
 _PER_DEV_AGGREGATED_KEYS = (
@@ -24,29 +23,29 @@ def band_from_health(health: int) -> Band:
     return "bad"
 
 
-def dict_to_row(name: str, m: dict[str, Any], health: int) -> Row:
+def raw_to_row(name: str, raw: RawMetrics, health: int) -> Row:
     return Row(
         name=name,
-        pr_count=int(m.get("pr_count", 0)),
-        cycle_time=float(m.get("cycle_time", 0)),
-        pickup_time=float(m.get("pickup_time", 0)),
-        review_time=float(m.get("review_time", 0)),
-        pr_size=float(m.get("pr_size", 0)),
-        avg_lines_per_pr=float(m.get("avg_lines_per_pr", 0)),
-        prs_per_week=float(m.get("prs_per_week", 0)),
-        reviews_given=int(m.get("reviews_given", 0)),
-        ai_percentage=float(m.get("ai_percentage", 0)),
+        pr_count=raw.pr_count,
+        cycle_time=raw.cycle_time,
+        pickup_time=raw.pickup_time,
+        review_time=raw.review_time,
+        pr_size=raw.pr_size,
+        avg_lines_per_pr=raw.avg_lines_per_pr,
+        prs_per_week=raw.prs_per_week,
+        reviews_given=raw.reviews_given,
+        ai_percentage=raw.ai_percentage,
         health=health,
         band=band_from_health(health),
     )
 
 
 def rank_rows(
-    raws: dict[str, dict[str, Any]],
-    health_fn: Callable[[dict[str, Any], list[dict[str, Any]]], int],
+    raws: dict[str, RawMetrics],
+    health_fn: Callable[[RawMetrics, list[RawMetrics]], int],
 ) -> tuple[Row, ...]:
     cohort = list(raws.values())
-    rows = [dict_to_row(name, m, health_fn(m, cohort)) for name, m in raws.items()]
+    rows = [raw_to_row(name, m, health_fn(m, cohort)) for name, m in raws.items()]
     rows.sort(key=lambda r: r.health, reverse=True)
     return tuple(rows)
 
@@ -54,15 +53,24 @@ def rank_rows(
 def compute_team_row(
     all_prs: list[PullRequest],
     days: int,
-    dev_raws: dict[str, dict[str, Any]],
+    dev_raws: dict[str, RawMetrics],
     devs: tuple[Row, ...],
     reviewer_counts: dict[str, int],
 ) -> Row:
-    raw = compute_metrics_dict(all_prs, days, sum(reviewer_counts.values()))
-    for key in _PER_DEV_AGGREGATED_KEYS:
-        values = [m[key] for m in dev_raws.values() if m.get(key)]
-        raw[key] = round(median(values), 2) if values else 0.0
-    ai_values = [m["ai_percentage"] for m in dev_raws.values()]
-    raw["ai_percentage"] = round(sum(ai_values) / len(ai_values), 1) if ai_values else 0.0
+    team_raw = compute_raw(all_prs, days, sum(reviewer_counts.values()))
+    aggregated = {
+        key: round(median([getattr(m, key) for m in dev_raws.values() if getattr(m, key, None)]), 2)
+        for key in _PER_DEV_AGGREGATED_KEYS
+    }
+    ai_values = [m.ai_percentage for m in dev_raws.values()]
+    aggregated["ai_percentage"] = round(sum(ai_values) / len(ai_values), 1) if ai_values else 0.0
     team_health = round(sum(r.health for r in devs) / len(devs)) if devs else 0
-    return dict_to_row("team", raw, team_health)
+    return raw_to_row(
+        "team",
+        RawMetrics(
+            **aggregated,
+            pr_count=team_raw.pr_count,
+            reviews_given=team_raw.reviews_given,
+        ),
+        team_health,
+    )

--- a/git_dev_metrics/metrics/_rows.py
+++ b/git_dev_metrics/metrics/_rows.py
@@ -16,6 +16,19 @@ def band_color(band: Band) -> str:
 
 
 @dataclass(frozen=True)
+class RawMetrics:
+    cycle_time: float
+    pickup_time: float
+    review_time: float
+    pr_size: float
+    avg_lines_per_pr: float
+    pr_count: int
+    prs_per_week: float
+    reviews_given: int
+    ai_percentage: float
+
+
+@dataclass(frozen=True)
 class Row:
     name: str
     pr_count: int

--- a/git_dev_metrics/metrics/health.py
+++ b/git_dev_metrics/metrics/health.py
@@ -1,4 +1,4 @@
-from typing import Any
+from ._rows import RawMetrics
 
 TEAM_WEIGHTS = {
     "throughput": 0.25,
@@ -48,7 +48,7 @@ def _time_score(value: float, bands: tuple[int, int, int, int]) -> float:
 def _citizenship_score(
     reviews_given: int,
     pr_count: int,
-    all_metrics: list[dict[str, Any]] | None = None,
+    all_metrics: list[RawMetrics] | None = None,
 ) -> float:
     """50% ratio + 50% absolute. Absolute scaled vs team max so prolific authors
     aren't penalized for not maintaining 2x review ratio at high PR volume."""
@@ -59,7 +59,7 @@ def _citizenship_score(
     ratio_score = min(100.0, ratio * 50)
 
     if all_metrics:
-        max_reviews = max((m.get("reviews_given", 0) for m in all_metrics), default=0)
+        max_reviews = max((m.reviews_given for m in all_metrics), default=0)
         absolute_score = (reviews_given / max_reviews * 100) if max_reviews > 0 else 0.0
     else:
         absolute_score = min(100.0, reviews_given / 100 * 100)
@@ -67,19 +67,17 @@ def _citizenship_score(
     return 0.5 * ratio_score + 0.5 * absolute_score
 
 
-def calculate_health_score(
-    metrics: dict[str, Any], all_metrics: list[dict[str, Any]] | None = None
-) -> int:
+def calculate_health_score(metrics: RawMetrics, all_metrics: list[RawMetrics] | None = None) -> int:
     """Team/repo composite 0-100. Includes pickup time (team responsiveness)."""
-    pr_count = metrics.get("pr_count", 0)
+    pr_count = metrics.pr_count
     if pr_count == 0:
         return 0
 
     components = {
-        "throughput": _throughput_score(metrics.get("prs_per_week", 0)),
-        "speed": _time_score(metrics.get("cycle_time", 0), CYCLE_BANDS),
-        "pickup": _time_score(metrics.get("pickup_time", 0), PICKUP_BANDS),
-        "citizenship": _citizenship_score(metrics.get("reviews_given", 0), pr_count, all_metrics),
+        "throughput": _throughput_score(metrics.prs_per_week),
+        "speed": _time_score(metrics.cycle_time, CYCLE_BANDS),
+        "pickup": _time_score(metrics.pickup_time, PICKUP_BANDS),
+        "citizenship": _citizenship_score(metrics.reviews_given, pr_count, all_metrics),
     }
 
     score = sum(TEAM_WEIGHTS[k] * v for k, v in components.items())
@@ -87,17 +85,17 @@ def calculate_health_score(
 
 
 def calculate_dev_health_score(
-    metrics: dict[str, Any], all_metrics: list[dict[str, Any]] | None = None
+    metrics: RawMetrics, all_metrics: list[RawMetrics] | None = None
 ) -> int:
     """Per-developer composite 0-100. Excludes pickup time (reviewer behavior, not author)."""
-    pr_count = metrics.get("pr_count", 0)
+    pr_count = metrics.pr_count
     if pr_count == 0:
         return 0
 
     components = {
-        "throughput": _throughput_score(metrics.get("prs_per_week", 0)),
-        "speed": _time_score(metrics.get("cycle_time", 0), CYCLE_BANDS),
-        "citizenship": _citizenship_score(metrics.get("reviews_given", 0), pr_count, all_metrics),
+        "throughput": _throughput_score(metrics.prs_per_week),
+        "speed": _time_score(metrics.cycle_time, CYCLE_BANDS),
+        "citizenship": _citizenship_score(metrics.reviews_given, pr_count, all_metrics),
     }
 
     score = sum(DEV_WEIGHTS[k] * v for k, v in components.items())

--- a/tests/integration/test_pull_e2e.py
+++ b/tests/integration/test_pull_e2e.py
@@ -58,8 +58,12 @@ class TestPullEndToEnd:
             _raw_pr(103, "alice", 22, [_raw_review("carol", 22), _raw_review("dave", 23)]),
         ]
         mapped = [map_pull_request(pr) for pr in raw]
-        mocker.patch("git_dev_metrics.cli.commands.pull.get_github_token", return_value="fake-token")
-        mocker.patch("git_dev_metrics.cli.runners.pull_runner.fetch_repo_metrics", return_value=mapped)
+        mocker.patch(
+            "git_dev_metrics.cli.commands.pull.get_github_token", return_value="fake-token"
+        )
+        mocker.patch(
+            "git_dev_metrics.cli.runners.pull_runner.fetch_repo_metrics", return_value=mapped
+        )
 
         # Act
         result = runner.invoke(
@@ -95,8 +99,12 @@ class TestPullEndToEnd:
             _raw_pr(202, "bob", 9, [_raw_review("alice", 9)]),
         ]
         mapped = [map_pull_request(pr) for pr in raw]
-        mocker.patch("git_dev_metrics.cli.commands.pull.get_github_token", return_value="fake-token")
-        mocker.patch("git_dev_metrics.cli.runners.pull_runner.fetch_repo_metrics", return_value=mapped)
+        mocker.patch(
+            "git_dev_metrics.cli.commands.pull.get_github_token", return_value="fake-token"
+        )
+        mocker.patch(
+            "git_dev_metrics.cli.runners.pull_runner.fetch_repo_metrics", return_value=mapped
+        )
         mocker.patch("git_dev_metrics.cli._browser.webbrowser.open", return_value=False)
         dashboard_out = tmp_path / "r.html"
 
@@ -161,8 +169,12 @@ class TestPullEndToEnd:
             "timelineItems": {"nodes": []},
         }
         mapped = [map_pull_request(minimal)]
-        mocker.patch("git_dev_metrics.cli.commands.pull.get_github_token", return_value="fake-token")
-        mocker.patch("git_dev_metrics.cli.runners.pull_runner.fetch_repo_metrics", return_value=mapped)
+        mocker.patch(
+            "git_dev_metrics.cli.commands.pull.get_github_token", return_value="fake-token"
+        )
+        mocker.patch(
+            "git_dev_metrics.cli.runners.pull_runner.fetch_repo_metrics", return_value=mapped
+        )
 
         # Act
         result = runner.invoke(

--- a/tests/unit/cli/test_pull_command.py
+++ b/tests/unit/cli/test_pull_command.py
@@ -30,7 +30,9 @@ class TestPull:
     def test_should_write_prs_and_seal_month(self, tmp_path, mocker):
         db_path = tmp_path / "cache.db"
         prs = _ten_prs_for_april()
-        mocker.patch("git_dev_metrics.cli.commands.pull.get_github_token", return_value="fake-token")
+        mocker.patch(
+            "git_dev_metrics.cli.commands.pull.get_github_token", return_value="fake-token"
+        )
         mocker.patch("git_dev_metrics.cli.runners.pull_runner.fetch_repo_metrics", return_value=prs)
 
         result = runner.invoke(
@@ -61,8 +63,12 @@ class TestPull:
     @freeze_time("2026-05-12")
     def test_should_refuse_incomplete_current_month(self, tmp_path, mocker):
         db_path = tmp_path / "cache.db"
-        mocker.patch("git_dev_metrics.cli.commands.pull.get_github_token", return_value="fake-token")
-        fetch = mocker.patch("git_dev_metrics.cli.runners.pull_runner.fetch_repo_metrics", return_value=[])
+        mocker.patch(
+            "git_dev_metrics.cli.commands.pull.get_github_token", return_value="fake-token"
+        )
+        fetch = mocker.patch(
+            "git_dev_metrics.cli.runners.pull_runner.fetch_repo_metrics", return_value=[]
+        )
 
         result = runner.invoke(
             app,
@@ -97,8 +103,12 @@ class TestPull:
     def test_should_refuse_already_sealed_month(self, tmp_path, mocker):
         db_path = tmp_path / "cache.db"
         seal_month("myorg", "myrepo", 2026, 4, db_path=db_path)
-        mocker.patch("git_dev_metrics.cli.commands.pull.get_github_token", return_value="fake-token")
-        fetch = mocker.patch("git_dev_metrics.cli.runners.pull_runner.fetch_repo_metrics", return_value=[])
+        mocker.patch(
+            "git_dev_metrics.cli.commands.pull.get_github_token", return_value="fake-token"
+        )
+        fetch = mocker.patch(
+            "git_dev_metrics.cli.runners.pull_runner.fetch_repo_metrics", return_value=[]
+        )
 
         result = runner.invoke(
             app,

--- a/tests/unit/cli/test_stale_command.py
+++ b/tests/unit/cli/test_stale_command.py
@@ -40,7 +40,9 @@ class TestStale:
                 ]  # ~41d
             return [_open_pr(2, "bob", dt(year=2026, month=5, day=1, hour=8, minute=0))]  # ~11d
 
-        mocker.patch("git_dev_metrics.cli.commands.stale.get_github_token", return_value="fake-token")
+        mocker.patch(
+            "git_dev_metrics.cli.commands.stale.get_github_token", return_value="fake-token"
+        )
         mocker.patch("git_dev_metrics.cli.commands.stale.fetch_open_prs", side_effect=fake_open_prs)
         out = tmp_path / "stale.html"
 
@@ -63,7 +65,9 @@ class TestStale:
         db_path = tmp_path / "cache.db"
         seal_month("myorg", "repoA", 2026, 4, db_path=db_path)
 
-        mocker.patch("git_dev_metrics.cli.commands.stale.get_github_token", return_value="fake-token")
+        mocker.patch(
+            "git_dev_metrics.cli.commands.stale.get_github_token", return_value="fake-token"
+        )
         mocker.patch(
             "git_dev_metrics.cli.commands.stale.fetch_open_prs",
             return_value=[
@@ -89,7 +93,9 @@ class TestStale:
         db_path = tmp_path / "cache.db"
         seal_month("myorg", "repoA", 2026, 4, db_path=db_path)
 
-        mocker.patch("git_dev_metrics.cli.commands.stale.get_github_token", return_value="fake-token")
+        mocker.patch(
+            "git_dev_metrics.cli.commands.stale.get_github_token", return_value="fake-token"
+        )
         mocker.patch(
             "git_dev_metrics.cli.commands.stale.fetch_open_prs",
             return_value=[
@@ -123,7 +129,9 @@ class TestStale:
         seal_month("myorg", "repoA", 2026, 4, db_path=db_path)
         monkeypatch.chdir(tmp_path)
 
-        mocker.patch("git_dev_metrics.cli.commands.stale.get_github_token", return_value="fake-token")
+        mocker.patch(
+            "git_dev_metrics.cli.commands.stale.get_github_token", return_value="fake-token"
+        )
         mocker.patch(
             "git_dev_metrics.cli.commands.stale.fetch_open_prs",
             return_value=[_open_pr(1, "alice", dt(year=2026, month=4, day=1, hour=8, minute=0))],

--- a/tests/unit/metrics/test_dev_repo_metrics.py
+++ b/tests/unit/metrics/test_dev_repo_metrics.py
@@ -1,9 +1,9 @@
-from git_dev_metrics.metrics._dev_repo_metrics import compute_metrics_dict
+from git_dev_metrics.metrics._dev_repo_metrics import compute_raw
 
 from ..conftest import any_pr, approved_review, dt
 
 
-class TestComputeMetricsDict:
+class TestComputeRaw:
     def test_should_calculate_all_metrics(self) -> None:
         prs = [
             any_pr(
@@ -14,7 +14,7 @@ class TestComputeMetricsDict:
                 reviews=[approved_review(dt(year=2024, month=1, day=1, hour=6, minute=0))],
             )
         ]
-        result = compute_metrics_dict(prs, 31, 3)
-        assert result["pr_count"] == 1
-        assert result["reviews_given"] == 3
-        assert result["cycle_time"] > 0
+        result = compute_raw(prs, 31, 3)
+        assert result.pr_count == 1
+        assert result.reviews_given == 3
+        assert result.cycle_time > 0

--- a/tests/unit/metrics/test_health.py
+++ b/tests/unit/metrics/test_health.py
@@ -1,3 +1,4 @@
+from git_dev_metrics.metrics._rows import RawMetrics
 from git_dev_metrics.metrics.health import (
     _citizenship_score,
     _throughput_score,
@@ -5,6 +6,20 @@ from git_dev_metrics.metrics.health import (
     calculate_dev_health_score,
     calculate_health_score,
 )
+
+
+def _raw(**overrides: float | int) -> RawMetrics:
+    return RawMetrics(
+        pr_count=int(overrides.get("pr_count", 0)),
+        prs_per_week=float(overrides.get("prs_per_week", 0)),
+        cycle_time=float(overrides.get("cycle_time", 0)),
+        pickup_time=float(overrides.get("pickup_time", 0)),
+        reviews_given=int(overrides.get("reviews_given", 0)),
+        review_time=float(overrides.get("review_time", 0)),
+        pr_size=float(overrides.get("pr_size", 0)),
+        avg_lines_per_pr=float(overrides.get("avg_lines_per_pr", 0)),
+        ai_percentage=float(overrides.get("ai_percentage", 0)),
+    )
 
 
 class TestThroughputScore:
@@ -27,7 +42,6 @@ class TestThroughputScore:
         assert _throughput_score(3) == 40
 
     def test_should_reward_extreme_volume_above_baseline(self):
-        # 12/wk should clearly beat 6/wk (was tied at 100 in old formula)
         assert _throughput_score(12) > _throughput_score(6)
 
 
@@ -64,243 +78,125 @@ class TestCitizenshipScore:
         assert _citizenship_score(0, 5) == 0
 
     def test_should_score_full_at_2x_ratio_and_full_absolute(self):
-        # Standalone (no team): 50 absolute (50/100) + 50 ratio (2x) → 75
         assert _citizenship_score(50, 25) == 75
 
     def test_should_score_top_absolute_when_team_provided(self):
-        # Top reviewer in team gets full absolute, even with low ratio
-        all_m = [{"reviews_given": 300}, {"reviews_given": 50}]
-        # ratio 300/100 = 3 → 100 ratio_score; absolute 300/300 → 100. Avg 100.
+        all_m = [_raw(reviews_given=300), _raw(reviews_given=50)]
         assert _citizenship_score(300, 100, all_m) == 100
 
     def test_should_punish_high_volume_author_with_low_relative_reviews(self):
-        # Big author, modest reviews vs team max
-        all_m = [{"reviews_given": 1000}, {"reviews_given": 100}]
-        # ratio 100/200 = 0.5 → 25; absolute 100/1000 = 10. Avg 17.5
+        all_m = [_raw(reviews_given=1000), _raw(reviews_given=100)]
         assert _citizenship_score(100, 200, all_m) == 17.5
 
     def test_should_reward_prolific_reviewer_at_top_of_team(self):
-        # Kobbi-like: high author volume + top absolute reviews
-        all_m = [{"reviews_given": 335}, {"reviews_given": 35}]
-        # ratio 335/264 = 1.27 → 63.4; absolute 335/335 → 100. Avg ~81.7
+        all_m = [_raw(reviews_given=335), _raw(reviews_given=35)]
         result = _citizenship_score(335, 264, all_m)
         assert 80 < result < 83
 
 
 class TestCalculateHealthScore:
     def test_should_return_zero_when_no_prs(self):
-        result = calculate_health_score({"pr_count": 0})
-        assert result == 0
+        assert calculate_health_score(_raw(pr_count=0)) == 0
 
     def test_should_return_100_for_elite_metrics(self):
-        # Arrange: elite throughput + excellent times + top reviewer
-        metrics = {
-            "pr_count": 30,
-            "prs_per_week": 60,
-            "cycle_time": 2,
-            "pickup_time": 1,
-            "reviews_given": 200,
-        }
-
-        # Act
-        result = calculate_health_score(metrics)
-
-        # Assert
+        result = calculate_health_score(
+            _raw(pr_count=30, prs_per_week=60, cycle_time=2, pickup_time=1, reviews_given=200)
+        )
         assert result == 100
 
     def test_should_ignore_pr_size(self):
-        # Arrange: same metrics with vastly different pr_size should score identically
-        small = {
-            "pr_count": 30,
-            "prs_per_week": 60,
-            "cycle_time": 2,
-            "pickup_time": 1,
-            "reviews_given": 200,
-            "pr_size": 50,
-        }
-        huge = {**small, "pr_size": 10000, "avg_lines_per_pr": 5000}
-
-        # Act / Assert
+        small = _raw(
+            pr_count=30, prs_per_week=60, cycle_time=2, pickup_time=1, reviews_given=200, pr_size=50
+        )
+        huge = _raw(
+            pr_count=30,
+            prs_per_week=60,
+            cycle_time=2,
+            pickup_time=1,
+            reviews_given=200,
+            pr_size=10000,
+            avg_lines_per_pr=5000,
+        )
         assert calculate_health_score(small) == calculate_health_score(huge)
 
     def test_should_penalize_slow_cycle_time(self):
-        # Arrange
-        metrics = {
-            "pr_count": 30,
-            "prs_per_week": 60,
-            "cycle_time": 200,
-            "pickup_time": 1,
-            "reviews_given": 200,
-        }
-
-        # Act
-        result = calculate_health_score(metrics)
-
-        # Assert: speed drops 100→20, costs 0.20*80 = 16 points. 100-16 = 84
+        result = calculate_health_score(
+            _raw(pr_count=30, prs_per_week=60, cycle_time=200, pickup_time=1, reviews_given=200)
+        )
         assert result == 84
 
     def test_should_penalize_slow_pickup(self):
-        # Arrange
-        metrics = {
-            "pr_count": 30,
-            "prs_per_week": 60,
-            "cycle_time": 2,
-            "pickup_time": 100,
-            "reviews_given": 200,
-        }
-
-        # Act
-        result = calculate_health_score(metrics)
-
-        # Assert
+        result = calculate_health_score(
+            _raw(pr_count=30, prs_per_week=60, cycle_time=2, pickup_time=100, reviews_given=200)
+        )
         assert result == 84
 
     def test_should_penalize_low_throughput(self):
-        # Arrange
-        metrics = {
-            "pr_count": 1,
-            "prs_per_week": 1,
-            "cycle_time": 2,
-            "pickup_time": 1,
-            "reviews_given": 100,
-        }
-
-        # Act
-        result = calculate_health_score(metrics)
-
-        # Assert: throughput 13.3 (1/6*80), citizenship 100 (top abs + top ratio).
-        # 0.25*13.3 + 0.20*100 + 0.20*100 + 0.35*100 = 78.33 → 78
+        result = calculate_health_score(
+            _raw(pr_count=1, prs_per_week=1, cycle_time=2, pickup_time=1, reviews_given=100)
+        )
         assert result == 78
 
     def test_should_penalize_low_citizenship(self):
-        # Arrange
-        metrics = {
-            "pr_count": 10,
-            "prs_per_week": 60,
-            "cycle_time": 2,
-            "pickup_time": 1,
-            "reviews_given": 0,
-        }
-
-        # Act
-        result = calculate_health_score(metrics)
-
-        # Assert: citizenship 0 (no reviews). 0.25*100 + 0.20*100 + 0.20*100 + 0.35*0 = 65
+        result = calculate_health_score(
+            _raw(pr_count=10, prs_per_week=60, cycle_time=2, pickup_time=1, reviews_given=0)
+        )
         assert result == 65
 
     def test_should_handle_negative_pickup_time_as_no_signal(self):
-        # Arrange
-        metrics = {
-            "pr_count": 30,
-            "prs_per_week": 60,
-            "cycle_time": 2,
-            "pickup_time": -440,
-            "reviews_given": 200,
-        }
-
-        # Act
-        result = calculate_health_score(metrics)
-
-        # Assert
+        result = calculate_health_score(
+            _raw(pr_count=30, prs_per_week=60, cycle_time=2, pickup_time=-440, reviews_given=200)
+        )
         assert result == 100
 
     def test_should_floor_at_zero(self):
-        # Arrange
-        metrics = {
-            "pr_count": 1,
-            "prs_per_week": 0,
-            "cycle_time": 200,
-            "pickup_time": 100,
-            "reviews_given": 0,
-        }
-
-        # Act
-        result = calculate_health_score(metrics)
-
-        # Assert: all components 0/20/20/0. 0.25*0 + 0.20*20 + 0.20*20 + 0.35*0 = 8
+        result = calculate_health_score(
+            _raw(pr_count=1, prs_per_week=0, cycle_time=200, pickup_time=100, reviews_given=0)
+        )
         assert result == 8
 
     def test_should_handle_missing_metrics(self):
-        result = calculate_health_score({})
-        assert result == 0
+        assert calculate_health_score(_raw(pr_count=0)) == 0
 
     def test_should_use_team_max_for_relative_citizenship(self):
-        # Arrange: top reviewer in team gets max citizenship even with modest ratio
-        prolific = {
-            "pr_count": 264,
-            "prs_per_week": 60,
-            "cycle_time": 2,
-            "pickup_time": 3,
-            "reviews_given": 335,
-        }
-        small = {
-            "pr_count": 23,
-            "prs_per_week": 5,
-            "cycle_time": 2,
-            "pickup_time": 1,
-            "reviews_given": 35,
-        }
+        prolific = _raw(
+            pr_count=264, prs_per_week=60, cycle_time=2, pickup_time=3, reviews_given=335
+        )
+        small = _raw(pr_count=23, prs_per_week=5, cycle_time=2, pickup_time=1, reviews_given=35)
         all_m = [prolific, small]
 
-        # Act
         prolific_score = calculate_health_score(prolific, all_m)
         small_score = calculate_health_score(small, all_m)
-
-        # Assert: prolific (top reviewer + top throughput) should beat small dev
         assert prolific_score > small_score
 
 
 class TestCalculateDevHealthScore:
     def test_should_return_zero_when_no_prs(self):
-        assert calculate_dev_health_score({"pr_count": 0}) == 0
+        assert calculate_dev_health_score(_raw(pr_count=0)) == 0
 
     def test_should_ignore_pickup_time(self):
-        # Arrange: same metrics with vastly different pickup should score identically
-        fast_pickup = {
-            "pr_count": 30,
-            "prs_per_week": 60,
-            "cycle_time": 2,
-            "pickup_time": 1,
-            "reviews_given": 200,
-        }
-        slow_pickup = {**fast_pickup, "pickup_time": 100}
-
-        # Act / Assert
+        fast_pickup = _raw(
+            pr_count=30, prs_per_week=60, cycle_time=2, pickup_time=1, reviews_given=200
+        )
+        slow_pickup = _raw(
+            pr_count=30, prs_per_week=60, cycle_time=2, pickup_time=100, reviews_given=200
+        )
         assert calculate_dev_health_score(fast_pickup) == calculate_dev_health_score(slow_pickup)
 
     def test_should_return_100_for_elite_metrics(self):
-        # Arrange: elite throughput + excellent cycle + top reviewer
-        metrics = {
-            "pr_count": 30,
-            "prs_per_week": 60,
-            "cycle_time": 2,
-            "reviews_given": 200,
-        }
-
-        # Act
-        result = calculate_dev_health_score(metrics)
-
-        # Assert
+        result = calculate_dev_health_score(
+            _raw(pr_count=30, prs_per_week=60, cycle_time=2, reviews_given=200)
+        )
         assert result == 100
 
     def test_should_weight_cycle_more_than_team_score(self):
-        # Same slow-cycle metrics; dev formula penalizes cycle harder (30% vs 20%)
-        slow = {
-            "pr_count": 30,
-            "prs_per_week": 60,
-            "cycle_time": 200,
-            "pickup_time": 1,
-            "reviews_given": 200,
-        }
-        # dev score: throughput 100, speed 20, citizenship 100. 0.25*100+0.30*20+0.45*100 = 76
+        slow = _raw(pr_count=30, prs_per_week=60, cycle_time=200, pickup_time=1, reviews_given=200)
         assert calculate_dev_health_score(slow) == 76
 
     def test_should_weight_citizenship_at_45_percent(self):
-        # No reviews → citizenship 0; everything else 100. 0.25*100 + 0.30*100 + 0.45*0 = 55
-        metrics = {
-            "pr_count": 10,
-            "prs_per_week": 60,
-            "cycle_time": 2,
-            "reviews_given": 0,
-        }
-        assert calculate_dev_health_score(metrics) == 55
+        assert (
+            calculate_dev_health_score(
+                _raw(pr_count=10, prs_per_week=60, cycle_time=2, reviews_given=0)
+            )
+            == 55
+        )

--- a/tests/unit/metrics/test_health.py
+++ b/tests/unit/metrics/test_health.py
@@ -5,6 +5,8 @@ from git_dev_metrics.metrics.health import (
     _time_score,
     calculate_dev_health_score,
     calculate_health_score,
+    format_health,
+    get_health_color,
 )
 
 
@@ -200,3 +202,22 @@ class TestCalculateDevHealthScore:
             )
             == 55
         )
+
+
+class TestFormatHealth:
+    def test_should_return_string(self) -> None:
+        assert format_health(85) == "85"
+
+
+class TestGetHealthColor:
+    def test_should_return_green_at_80(self) -> None:
+        assert get_health_color(80) == "green"
+        assert get_health_color(100) == "green"
+
+    def test_should_return_yellow_between_60_and_79(self) -> None:
+        assert get_health_color(60) == "yellow"
+        assert get_health_color(79) == "yellow"
+
+    def test_should_return_red_below_60(self) -> None:
+        assert get_health_color(0) == "red"
+        assert get_health_color(59) == "red"

--- a/tests/unit/metrics/test_health_ranking.py
+++ b/tests/unit/metrics/test_health_ranking.py
@@ -1,8 +1,9 @@
 from git_dev_metrics.metrics._health_ranking import (
     band_from_health,
-    dict_to_row,
     rank_rows,
+    raw_to_row,
 )
+from git_dev_metrics.metrics._rows import RawMetrics
 
 
 class TestBandFromHealth:
@@ -19,36 +20,64 @@ class TestBandFromHealth:
         assert band_from_health(59) == "bad"
 
 
-class TestDictToRow:
+class TestRawToRow:
     def test_should_build_row_with_health_and_band(self) -> None:
-        row = dict_to_row("alice", {"pr_count": 5, "cycle_time": 12.5}, 85)
+        row = raw_to_row(
+            "alice",
+            RawMetrics(
+                pr_count=5,
+                cycle_time=12.5,
+                pickup_time=0,
+                review_time=0,
+                pr_size=0,
+                avg_lines_per_pr=0,
+                prs_per_week=0,
+                reviews_given=0,
+                ai_percentage=0,
+            ),
+            85,
+        )
         assert row.name == "alice"
         assert row.pr_count == 5
         assert row.cycle_time == 12.5
         assert row.health == 85
         assert row.band == "good"
 
-    def test_should_default_missing_fields(self) -> None:
-        row = dict_to_row("bob", {}, 0)
+    def test_should_default_zero_fields(self) -> None:
+        row = raw_to_row(
+            "bob",
+            RawMetrics(
+                pr_count=0,
+                cycle_time=0,
+                pickup_time=0,
+                review_time=0,
+                pr_size=0,
+                avg_lines_per_pr=0,
+                prs_per_week=0,
+                reviews_given=0,
+                ai_percentage=0,
+            ),
+            0,
+        )
         assert row.pr_count == 0
         assert row.cycle_time == 0.0
         assert row.reviews_given == 0
         assert row.band == "bad"
 
-    def test_should_cast_types(self) -> None:
-        row = dict_to_row(
+    def test_should_build_full_row(self) -> None:
+        row = raw_to_row(
             "carol",
-            {
-                "pr_count": "3",
-                "cycle_time": "10.5",
-                "pickup_time": "2.0",
-                "review_time": "5.0",
-                "pr_size": "50",
-                "avg_lines_per_pr": "100.0",
-                "prs_per_week": "1.5",
-                "reviews_given": "7",
-                "ai_percentage": "40.0",
-            },
+            RawMetrics(
+                pr_count=3,
+                cycle_time=10.5,
+                pickup_time=2.0,
+                review_time=5.0,
+                pr_size=50,
+                avg_lines_per_pr=100.0,
+                prs_per_week=1.5,
+                reviews_given=7,
+                ai_percentage=40.0,
+            ),
             75,
         )
         assert row.pr_count == 3
@@ -65,8 +94,42 @@ class TestDictToRow:
 
 class TestRankRows:
     def test_should_sort_by_health_descending(self) -> None:
-        raws = {"a": {"pr_count": 1}, "b": {"pr_count": 3}, "c": {"pr_count": 2}}
-        result = rank_rows(raws, lambda m, _: m["pr_count"] * 10)
+        raws = {
+            "a": RawMetrics(
+                pr_count=1,
+                cycle_time=0,
+                pickup_time=0,
+                review_time=0,
+                pr_size=0,
+                avg_lines_per_pr=0,
+                prs_per_week=0,
+                reviews_given=0,
+                ai_percentage=0,
+            ),
+            "b": RawMetrics(
+                pr_count=3,
+                cycle_time=0,
+                pickup_time=0,
+                review_time=0,
+                pr_size=0,
+                avg_lines_per_pr=0,
+                prs_per_week=0,
+                reviews_given=0,
+                ai_percentage=0,
+            ),
+            "c": RawMetrics(
+                pr_count=2,
+                cycle_time=0,
+                pickup_time=0,
+                review_time=0,
+                pr_size=0,
+                avg_lines_per_pr=0,
+                prs_per_week=0,
+                reviews_given=0,
+                ai_percentage=0,
+            ),
+        }
+        result = rank_rows(raws, lambda m, _: m.pr_count * 10)
         assert [r.name for r in result] == ["b", "c", "a"]
         assert result[0].health == 30
         assert result[2].health == 10

--- a/tests/unit/metrics/test_snapshot.py
+++ b/tests/unit/metrics/test_snapshot.py
@@ -15,9 +15,24 @@ def _period() -> TimePeriod:
 
 
 def _row_with_health(health: int):
-    from git_dev_metrics.metrics._health_ranking import dict_to_row as _dict_to_row
+    from git_dev_metrics.metrics._health_ranking import raw_to_row as _raw_to_row
+    from git_dev_metrics.metrics._rows import RawMetrics
 
-    return _dict_to_row("x", {"pr_count": 1}, health)
+    return _raw_to_row(
+        "x",
+        RawMetrics(
+            pr_count=1,
+            cycle_time=0,
+            pickup_time=0,
+            review_time=0,
+            pr_size=0,
+            avg_lines_per_pr=0,
+            prs_per_week=0,
+            reviews_given=0,
+            ai_percentage=0,
+        ),
+        health,
+    )
 
 
 class TestFromRepoPrs:


### PR DESCRIPTION
## Problem

The compute pipeline used bare `dict[str, Any]` to pass raw metrics between layers. Three copies of the field list existed (`compute_metrics_dict` return keys, `dict_to_row` mappings, `_PER_DEV_AGGREGATED_KEYS`) — none checked at compile time. `m.get("key", 0)` silently masked rename bugs because all calculator functions return 0 for empty input.

## Solution

Replace the dict pipe with a typed `RawMetrics` dataclass — a single source of truth for field mapping enforced at compile time.

- Add `RawMetrics` frozen dataclass to `_rows.py` (9 typed fields)
- Rename `compute_metrics_dict` → `compute_raw`, returns `RawMetrics`
- Replace `dict_to_row` with `raw_to_row`
- Update `rank_rows` callback to `Callable[[RawMetrics, list[RawMetrics]], int]`
- Health score functions accept `RawMetrics`, use attribute access

## Example

```python
# Before: untyped dict, field names in 3 places
def compute_metrics_dict(prs, days, reviews) -> dict[str, Any]:
    return {"cycle_time": ..., "pr_count": ..., ...}

def dict_to_row(m: dict[str, Any], health) -> Row:
    return Row(cycle_time=m.get("cycle_time", 0), ...)

# After: typed dataclass, single definition
def compute_raw(prs, days, reviews) -> RawMetrics:
    return RawMetrics(cycle_time=..., pr_count=..., ...)

def raw_to_row(raw: RawMetrics, health) -> Row:
    return Row(cycle_time=raw.cycle_time, ...)
```

## Impact

- pyright catches field name mismatches at compile time
- No silent `.get("key", 0)` defaults
- Single field contract in `RawMetrics` — remove `_PER_DEV_AGGREGATED_KEYS`
- Health functions no longer need to handle missing keys
