### PR TITLE
Replace bare dict stale-PR pipe with typed StalePr dataclass

### DIFF
--- a/git_dev_metrics/cli/commands/stale.py
+++ b/git_dev_metrics/cli/commands/stale.py
@@ -5,6 +5,7 @@ import typer
 
 from ...cache import list_synced_months
 from ...github import fetch_open_prs, get_github_token
+from ...metrics._rows import StalePr
 from ...metrics.calculator import get_stale_prs
 from ...metrics.printer.stale import FileStaleHtmlPrinter
 from .._browser import open_in_browser
@@ -19,18 +20,17 @@ def stale(
     output: Path | None = typer.Option(None, "--output", help="Output HTML path"),
     db: Path | None = typer.Option(None, "--db", help="Override cache database path"),
 ) -> None:
-    """Render an HTML view of open PRs older than 7 days, across every synced repo."""
     repos = sorted({(org, repo) for org, repo, *_ in list_synced_months(db_path=db)})
     if not repos:
         typer.secho("No repos in cache — run pull first.", fg=typer.colors.RED, err=True)
         raise typer.Exit(code=1)
 
     token = get_github_token()
-    all_stale: list[dict] = []
+    all_stale: list[StalePr] = []
     for org, repo in repos:
         opens = fetch_open_prs(token, org, repo, quiet=True)
         all_stale.extend(get_stale_prs(opens, f"{org}/{repo}"))
-    all_stale.sort(key=lambda x: x["age_hours"], reverse=True)
+    all_stale.sort(key=lambda x: x.age_hours, reverse=True)
 
     out = (output or _default_output()).with_suffix(".html")
     FileStaleHtmlPrinter(out).render(all_stale)

--- a/git_dev_metrics/metrics/_rows.py
+++ b/git_dev_metrics/metrics/_rows.py
@@ -45,6 +45,19 @@ class Row:
 
 
 @dataclass(frozen=True)
+class StalePr:
+    number: int
+    title: str
+    author: str | None
+    repo: str
+    age_hours: float
+    age_days: float
+    is_draft: bool
+    is_approved: bool
+    url: str
+
+
+@dataclass(frozen=True)
 class Summary:
     ai_per_dev: tuple[int, ...]
     review_ratio: float

--- a/git_dev_metrics/metrics/calculator.py
+++ b/git_dev_metrics/metrics/calculator.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 from ..constants import is_bot_login
 from ..models import OpenPullRequest, PullRequest
+from ._rows import StalePr
 
 AI_TRAILER_PATTERNS = [
     r"Co-Authored-By:",
@@ -210,39 +211,37 @@ def _calculate_age_hours(
 
 def _is_stale_pr(
     pr: OpenPullRequest, repo: str, clock: Callable[[], datetime] | None = None
-) -> dict | None:
-    """Check if PR is stale and return data if so."""
+) -> StalePr | None:
     created = pr.get("created_at")
     if created is None:
         return None
 
     age_hours = _calculate_age_hours(created, clock)
     if age_hours > STALE_PR_THRESHOLD_HOURS:
-        return {
-            "number": pr.get("number"),
-            "title": pr.get("title"),
-            "author": pr.get("user", {}).get("login"),
-            "repo": repo,
-            "age_hours": round(age_hours, 1),
-            "age_days": round(age_hours / 24, 1),
-            "is_draft": pr.get("is_draft", False),
-            "is_approved": pr.get("is_approved", False),
-            "url": f"https://github.com/{repo}/pull/{pr.get('number')}",
-        }
+        number = pr.get("number")
+        return StalePr(
+            number=number if number is not None else 0,
+            title=pr.get("title") or "",
+            author=pr.get("user", {}).get("login"),
+            repo=repo,
+            age_hours=round(age_hours, 1),
+            age_days=round(age_hours / 24, 1),
+            is_draft=pr.get("is_draft", False),
+            is_approved=pr.get("is_approved", False),
+            url=f"https://github.com/{repo}/pull/{number}",
+        )
     return None
 
 
 def get_stale_prs(
     prs: list[OpenPullRequest], repo: str = "", clock: Callable[[], datetime] | None = None
-) -> list[dict]:
-    """Return list of stale PRs (> 7 days old), sorted by age (oldest first)."""
+) -> list[StalePr]:
     stale = [p for p in (_is_stale_pr(pr, repo, clock) for pr in prs) if p]
-    stale.sort(key=lambda x: x["age_hours"], reverse=True)
+    stale.sort(key=lambda x: x.age_hours, reverse=True)
     return stale
 
 
-def summarize_stale_prs(stale_prs: list[dict]) -> tuple[int, float]:
-    """Total count and mean age in days for the stale-PR list."""
+def summarize_stale_prs(stale_prs: list[StalePr]) -> tuple[int, float]:
     total = len(stale_prs)
-    avg_age = sum(pr["age_days"] for pr in stale_prs) / total if stale_prs else 0.0
+    avg_age = sum(pr.age_days for pr in stale_prs) / total if stale_prs else 0.0
     return total, round(avg_age, 1)

--- a/git_dev_metrics/metrics/printer/stale.py
+++ b/git_dev_metrics/metrics/printer/stale.py
@@ -1,16 +1,15 @@
 from pathlib import Path
 
+from .._rows import StalePr
 from ..calculator import summarize_stale_prs
 from ._html_templates import render_template
 
 
 class FileStaleHtmlPrinter:
-    """Render a self-contained stale-PR HTML view."""
-
     def __init__(self, output_path: Path) -> None:
         self._output_path = output_path
 
-    def render(self, stale_prs: list[dict]) -> None:
+    def render(self, stale_prs: list[StalePr]) -> None:
         total, avg_age = summarize_stale_prs(stale_prs)
         html = render_template("stale.html", total=total, avg_age=avg_age, prs=stale_prs)
         self._output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/metrics/test_metrics.py
+++ b/tests/unit/metrics/test_metrics.py
@@ -687,8 +687,6 @@ class TestGroupPrsByDevsBotExclusion:
 
 
 class TestGetStalePrs:
-    """Test cases for get_stale_prs function."""
-
     def test_should_return_empty_for_empty_list(self):
         from git_dev_metrics.metrics.calculator import get_stale_prs
 
@@ -736,10 +734,10 @@ class TestGetStalePrs:
         )
         result = get_stale_prs(prs, "myrepo", lambda: now)
         assert len(result) == 1
-        assert result[0]["number"] == 1
-        assert result[0]["author"] == "alice"
-        assert result[0]["repo"] == "myrepo"
-        assert result[0]["age_hours"] > 24 * 7  # More than 7 days
+        assert result[0].number == 1
+        assert result[0].author == "alice"
+        assert result[0].repo == "myrepo"
+        assert result[0].age_hours > 24 * 7
 
     def test_should_sort_by_age_oldest_first(self):
         from datetime import UTC, datetime, timedelta
@@ -767,9 +765,46 @@ class TestGetStalePrs:
             ],
         )
         result = get_stale_prs(prs, "myrepo", lambda: now)
-        assert result[0]["number"] == 2  # Older first
-        assert result[1]["number"] == 1
-        assert result[0]["repo"] == "myrepo"
+        assert result[0].number == 2
+        assert result[1].number == 1
+        assert result[0].repo == "myrepo"
+
+
+class TestSummarizeStalePrs:
+    def test_should_return_zero_for_empty_list(self):
+        from git_dev_metrics.metrics.calculator import summarize_stale_prs
+
+        assert summarize_stale_prs([]) == (0, 0.0)
+
+    def test_should_compute_count_and_mean_age(self):
+        from git_dev_metrics.metrics._rows import StalePr
+        from git_dev_metrics.metrics.calculator import summarize_stale_prs
+
+        prs = [
+            StalePr(
+                number=1,
+                title="a",
+                author="x",
+                repo="r",
+                age_hours=480,
+                age_days=20.0,
+                is_draft=False,
+                is_approved=False,
+                url="",
+            ),
+            StalePr(
+                number=2,
+                title="b",
+                author="y",
+                repo="r",
+                age_hours=240,
+                age_days=10.0,
+                is_draft=False,
+                is_approved=False,
+                url="",
+            ),
+        ]
+        assert summarize_stale_prs(prs) == (2, 15.0)
 
 
 class TestIsAiCoauthored:


### PR DESCRIPTION
## Problem

The stale-PR pipeline used bare `dict` to pass PR data from construction (`_is_stale_pr`) through filtering, sorting, and printing across 3 modules. Keys like `"age_hours"`, `"age_days"`, `"is_draft"` were hard-coded strings at every touchpoint with no type safety.

## Solution

Replace the dict pipe with a typed `StalePr` frozen dataclass.

- Add `StalePr` to `_rows.py` — 9 typed fields
- `_is_stale_pr` returns `StalePr | None` instead of `dict | None`
- `get_stale_prs` returns `list[StalePr]`, `summarize_stale_prs` accepts `list[StalePr]`
- CLI command and HTML printer use `StalePr` instead of `list[dict]`

## Example

```python
# Before: bare dict, string keys everywhere
def _is_stale_pr(...) -> dict | None:
    return {"number": ..., "age_hours": ..., ...}
def get_stale_prs(...) -> list[dict]:
    stale.sort(key=lambda x: x["age_hours"])

# After: typed dataclass
def _is_stale_pr(...) -> StalePr | None:
    return StalePr(number=..., age_hours=..., ...)
def get_stale_prs(...) -> list[StalePr]:
    stale.sort(key=lambda x: x.age_hours)
```

## Impact

- pyright catches field mismatches at compile time
- No `.get("key")` or `x["key"]` access
- Single field contract in `StalePr` — the template just works via Jinja2 attribute access
