### PR TITLE
Type dashboard template helpers with TypedDict

### DIFF
--- a/git_dev_metrics/metrics/printer/html.py
+++ b/git_dev_metrics/metrics/printer/html.py
@@ -1,45 +1,74 @@
 from pathlib import Path
+from typing import TypedDict
 
 from ..snapshot import MetricsSnapshot
 from ._html_templates import render_template
 from .base import Printer
 
 
-def _devs_for_template(snapshot: MetricsSnapshot) -> list[dict]:
+class _DevRow(TypedDict):
+    name: str
+    health: int
+    pickup: float
+    review: float
+    cycle: float
+    size: int
+    prs: int
+    prs_week: float
+    reviews: int
+    ai: int
+
+
+class _SummaryData(TypedDict):
+    team_health: int
+    total_prs: int
+    median_lines_per_pr: float
+    median_cycle: float
+    median_pickup: float
+    median_prs_per_week: float
+    total_reviews: int
+    ai_adoption: int
+    ai_per_dev: list[int]
+    review_ratio: float
+    top_reviewer: str
+    max_review_share: int
+
+
+def _devs_for_template(snapshot: MetricsSnapshot) -> list[_DevRow]:
     return [
-        {
-            "name": row.name,
-            "health": row.health,
-            "pickup": row.pickup_time,
-            "review": row.review_time,
-            "cycle": row.cycle_time,
-            "size": int(row.pr_size),
-            "prs": row.pr_count,
-            "prs_week": row.prs_per_week,
-            "reviews": row.reviews_given,
-            "ai": int(row.ai_percentage),
-        }
+        _DevRow(
+            name=row.name,
+            health=row.health,
+            pickup=row.pickup_time,
+            review=row.review_time,
+            cycle=row.cycle_time,
+            size=int(row.pr_size),
+            prs=row.pr_count,
+            prs_week=row.prs_per_week,
+            reviews=row.reviews_given,
+            ai=int(row.ai_percentage),
+        )
         for row in snapshot.devs
     ]
 
 
-def _summary_for_template(snapshot: MetricsSnapshot) -> dict:
+def _summary_for_template(snapshot: MetricsSnapshot) -> _SummaryData:
     team = snapshot.team
     summary = snapshot.summary
-    return {
-        "team_health": team.health,
-        "total_prs": team.pr_count,
-        "median_lines_per_pr": round(team.pr_size, 1),
-        "median_cycle": round(team.cycle_time, 1),
-        "median_pickup": round(team.pickup_time, 1),
-        "median_prs_per_week": round(team.prs_per_week, 2),
-        "total_reviews": team.reviews_given,
-        "ai_adoption": round(team.ai_percentage),
-        "ai_per_dev": list(summary.ai_per_dev),
-        "review_ratio": summary.review_ratio,
-        "top_reviewer": summary.top_reviewer,
-        "max_review_share": summary.max_review_share,
-    }
+    return _SummaryData(
+        team_health=team.health,
+        total_prs=team.pr_count,
+        median_lines_per_pr=round(team.pr_size, 1),
+        median_cycle=round(team.cycle_time, 1),
+        median_pickup=round(team.pickup_time, 1),
+        median_prs_per_week=round(team.prs_per_week, 2),
+        total_reviews=team.reviews_given,
+        ai_adoption=round(team.ai_percentage),
+        ai_per_dev=list(summary.ai_per_dev),
+        review_ratio=summary.review_ratio,
+        top_reviewer=summary.top_reviewer,
+        max_review_share=summary.max_review_share,
+    )
 
 
 class FileHtmlPrinter(Printer):


### PR DESCRIPTION
## Problem

`_devs_for_template` and `_summary_for_template` returned bare `list[dict]` / `dict` — the shape was undocumented and unchecked.

## Solution

Define `_DevRow` and `_SummaryData` TypedDicts alongside the functions. Return annotated types instead of bare dicts.

## Impact

- pyright flags any field name typo or type mismatch at the construction site
- Reader sees the exact shape at a glance
- Zero runtime cost — TypedDict is a plain dict at runtime
