### PR TITLE
Type trend template helper with TypedDict

### DIFF
--- a/git_dev_metrics/metrics/printer/trend.py
+++ b/git_dev_metrics/metrics/printer/trend.py
@@ -1,16 +1,33 @@
 from dataclasses import asdict
 from pathlib import Path
+from typing import TypedDict
 
 from ..trend_calculator import TrendDataset
 from ._html_templates import render_template
 
 
-def _to_dict(dataset: TrendDataset) -> dict:
-    return {
-        "months": dataset.months,
-        "devs": dataset.devs,
-        "rows": {dev: [asdict(r) for r in rows] for dev, rows in dataset.rows.items()},
-    }
+class _DevMonthDict(TypedDict):
+    month_label: str
+    month_key: str
+    pr_count: int
+    cycle_hours: float
+    ai_pct: float
+
+
+class _TrendData(TypedDict):
+    months: list[str]
+    devs: list[str]
+    rows: dict[str, list[_DevMonthDict]]
+
+
+def _to_dict(dataset: TrendDataset) -> _TrendData:
+    return _TrendData(
+        months=dataset.months,
+        devs=dataset.devs,
+        rows={
+            dev: [_DevMonthDict(**asdict(r)) for r in rows] for dev, rows in dataset.rows.items()
+        },
+    )
 
 
 class FileTrendPrinter:


### PR DESCRIPTION
## Problem

`_to_dict` returned bare `dict` — the shape was undocumented and unchecked.

## Solution

Define `_TrendData` and `_DevMonthDict` TypedDicts alongside the function. Return annotated types.

## Impact

- pyright flags any field name typo or type mismatch
- Reader sees the exact shape at a glance
