### PR TITLE
Split _rows.py into _raw_metrics.py and _stale_pr.py

### DIFF
--- a/git_dev_metrics/cli/commands/stale.py
+++ b/git_dev_metrics/cli/commands/stale.py
@@ -5,7 +5,7 @@ import typer
 
 from ...cache import list_synced_months
 from ...github import fetch_open_prs, get_github_token
-from ...metrics._rows import StalePr
+from ...metrics._stale_pr import StalePr
 from ...metrics.calculator import get_stale_prs
 from ...metrics.printer.stale import FileStaleHtmlPrinter
 from .._browser import open_in_browser

--- a/git_dev_metrics/metrics/_dev_repo_metrics.py
+++ b/git_dev_metrics/metrics/_dev_repo_metrics.py
@@ -1,5 +1,5 @@
 from ..models import PullRequest
-from ._rows import RawMetrics
+from ._raw_metrics import RawMetrics
 from .calculator import (
     calculate_ai_percentage,
     calculate_avg_lines_per_pr,

--- a/git_dev_metrics/metrics/_health_ranking.py
+++ b/git_dev_metrics/metrics/_health_ranking.py
@@ -2,7 +2,8 @@ from collections.abc import Callable
 
 from ..models import PullRequest
 from ._dev_repo_metrics import compute_raw
-from ._rows import Band, RawMetrics, Row
+from ._raw_metrics import RawMetrics
+from ._rows import Band, Row
 from .calculator import median
 
 _PER_DEV_AGGREGATED_KEYS = (

--- a/git_dev_metrics/metrics/_raw_metrics.py
+++ b/git_dev_metrics/metrics/_raw_metrics.py
@@ -1,0 +1,16 @@
+"""Typed raw metrics from the compute pipeline before health scoring."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RawMetrics:
+    cycle_time: float
+    pickup_time: float
+    review_time: float
+    pr_size: float
+    avg_lines_per_pr: float
+    pr_count: int
+    prs_per_week: float
+    reviews_given: int
+    ai_percentage: float

--- a/git_dev_metrics/metrics/_rows.py
+++ b/git_dev_metrics/metrics/_rows.py
@@ -16,19 +16,6 @@ def band_color(band: Band) -> str:
 
 
 @dataclass(frozen=True)
-class RawMetrics:
-    cycle_time: float
-    pickup_time: float
-    review_time: float
-    pr_size: float
-    avg_lines_per_pr: float
-    pr_count: int
-    prs_per_week: float
-    reviews_given: int
-    ai_percentage: float
-
-
-@dataclass(frozen=True)
 class Row:
     name: str
     pr_count: int
@@ -42,19 +29,6 @@ class Row:
     ai_percentage: float
     health: int
     band: Band
-
-
-@dataclass(frozen=True)
-class StalePr:
-    number: int
-    title: str
-    author: str | None
-    repo: str
-    age_hours: float
-    age_days: float
-    is_draft: bool
-    is_approved: bool
-    url: str
 
 
 @dataclass(frozen=True)

--- a/git_dev_metrics/metrics/_stale_pr.py
+++ b/git_dev_metrics/metrics/_stale_pr.py
@@ -1,0 +1,16 @@
+"""Typed stale-PR data from the stale-pr detection pipeline."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class StalePr:
+    number: int
+    title: str
+    author: str | None
+    repo: str
+    age_hours: float
+    age_days: float
+    is_draft: bool
+    is_approved: bool
+    url: str

--- a/git_dev_metrics/metrics/calculator.py
+++ b/git_dev_metrics/metrics/calculator.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from ..constants import is_bot_login
 from ..models import OpenPullRequest, PullRequest
-from ._rows import StalePr
+from ._stale_pr import StalePr
 
 AI_TRAILER_PATTERNS = [
     r"Co-Authored-By:",

--- a/git_dev_metrics/metrics/health.py
+++ b/git_dev_metrics/metrics/health.py
@@ -1,4 +1,4 @@
-from ._rows import RawMetrics
+from ._raw_metrics import RawMetrics
 
 TEAM_WEIGHTS = {
     "throughput": 0.25,

--- a/git_dev_metrics/metrics/printer/stale.py
+++ b/git_dev_metrics/metrics/printer/stale.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from .._rows import StalePr
+from .._stale_pr import StalePr
 from ..calculator import summarize_stale_prs
 from ._html_templates import render_template
 

--- a/tests/unit/metrics/test_health.py
+++ b/tests/unit/metrics/test_health.py
@@ -1,4 +1,4 @@
-from git_dev_metrics.metrics._rows import RawMetrics
+from git_dev_metrics.metrics._raw_metrics import RawMetrics
 from git_dev_metrics.metrics.health import (
     _citizenship_score,
     _throughput_score,

--- a/tests/unit/metrics/test_health_ranking.py
+++ b/tests/unit/metrics/test_health_ranking.py
@@ -3,7 +3,7 @@ from git_dev_metrics.metrics._health_ranking import (
     rank_rows,
     raw_to_row,
 )
-from git_dev_metrics.metrics._rows import RawMetrics
+from git_dev_metrics.metrics._raw_metrics import RawMetrics
 
 
 class TestBandFromHealth:

--- a/tests/unit/metrics/test_metrics.py
+++ b/tests/unit/metrics/test_metrics.py
@@ -777,7 +777,7 @@ class TestSummarizeStalePrs:
         assert summarize_stale_prs([]) == (0, 0.0)
 
     def test_should_compute_count_and_mean_age(self):
-        from git_dev_metrics.metrics._rows import StalePr
+        from git_dev_metrics.metrics._stale_pr import StalePr
         from git_dev_metrics.metrics.calculator import summarize_stale_prs
 
         prs = [

--- a/tests/unit/metrics/test_snapshot.py
+++ b/tests/unit/metrics/test_snapshot.py
@@ -16,7 +16,7 @@ def _period() -> TimePeriod:
 
 def _row_with_health(health: int):
     from git_dev_metrics.metrics._health_ranking import raw_to_row as _raw_to_row
-    from git_dev_metrics.metrics._rows import RawMetrics
+    from git_dev_metrics.metrics._raw_metrics import RawMetrics
 
     return _raw_to_row(
         "x",


### PR DESCRIPTION
## Problem

`_rows.py` was accumulating unrelated type definitions — `RawMetrics` (compute pipe), `StalePr` (stale PR detection), `Row`/`Summary`/`Band` (display/shared). Different consumers, different lifecycles, same file.

## Solution

Split by lifecycle:

| File | Types | Used by |
|------|-------|---------|
| `_rows.py` | `Row`, `Summary`, `Band`, `band_color` | Snapshot, health ranking, printers |
| `_raw_metrics.py` | `RawMetrics` | Compute pipeline, health scoring |
| `_stale_pr.py` | `StalePr` | Stale PR detection, CLI, printer |

## Impact

- Each file has a single clear responsibility
- Changing compute field names touches only `_raw_metrics.py`, not `_rows.py`
- Adding fields to `StalePr` doesn't risk `_rows.py` bloat
