### PR TITLE
Move DevMonthDict TypedDict alongside DevMonthRow in trend_calculator.py

### DIFF
--- a/git_dev_metrics/metrics/printer/trend.py
+++ b/git_dev_metrics/metrics/printer/trend.py
@@ -2,31 +2,21 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import TypedDict
 
-from ..trend_calculator import TrendDataset
+from ..trend_calculator import DevMonthDict, TrendDataset
 from ._html_templates import render_template
-
-
-class _DevMonthDict(TypedDict):
-    month_label: str
-    month_key: str
-    pr_count: int
-    cycle_hours: float
-    ai_pct: float
 
 
 class _TrendData(TypedDict):
     months: list[str]
     devs: list[str]
-    rows: dict[str, list[_DevMonthDict]]
+    rows: dict[str, list[DevMonthDict]]
 
 
 def _to_dict(dataset: TrendDataset) -> _TrendData:
     return _TrendData(
         months=dataset.months,
         devs=dataset.devs,
-        rows={
-            dev: [_DevMonthDict(**asdict(r)) for r in rows] for dev, rows in dataset.rows.items()
-        },
+        rows={dev: [DevMonthDict(**asdict(r)) for r in rows] for dev, rows in dataset.rows.items()},
     )
 
 

--- a/git_dev_metrics/metrics/trend_calculator.py
+++ b/git_dev_metrics/metrics/trend_calculator.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
+from typing import TypedDict
 
 from ..constants import is_bot_login
 from ..models import PullRequest
@@ -8,6 +9,14 @@ from .calculator import calculate_ai_percentage, calculate_cycle_time
 
 @dataclass(frozen=True)
 class DevMonthRow:
+    month_label: str
+    month_key: str
+    pr_count: int
+    cycle_hours: float
+    ai_pct: float
+
+
+class DevMonthDict(TypedDict):
     month_label: str
     month_key: str
     pr_count: int


### PR DESCRIPTION
## Problem

`_DevMonthDict` in `printer/trend.py` was an exact mirror of `DevMonthRow` in `trend_calculator.py` — two definitions that must stay in sync, 30 lines apart.

## Solution

Define `DevMonthDict` TypedDict in `trend_calculator.py` directly alongside `DevMonthRow`. `printer/trend.py` imports it instead of redefining.

## Impact

- Single source of truth for the row shape
- Adding a field to `DevMonthRow` shows `DevMonthDict` right below — can't miss it
- No `**asdict()` dance needed (though we keep it for the JSON boundary)
