### PR TITLE
Move compute_team_row from _health_ranking.py to snapshot.py

### DIFF
--- a/git_dev_metrics/metrics/_health_ranking.py
+++ b/git_dev_metrics/metrics/_health_ranking.py
@@ -1,19 +1,7 @@
 from collections.abc import Callable
 
-from ..models import PullRequest
-from ._dev_repo_metrics import compute_raw
 from ._raw_metrics import RawMetrics
 from ._rows import Band, Row
-from .calculator import median
-
-_PER_DEV_AGGREGATED_KEYS = (
-    "cycle_time",
-    "pickup_time",
-    "review_time",
-    "pr_size",
-    "avg_lines_per_pr",
-    "prs_per_week",
-)
 
 
 def band_from_health(health: int) -> Band:
@@ -49,29 +37,3 @@ def rank_rows(
     rows = [raw_to_row(name, m, health_fn(m, cohort)) for name, m in raws.items()]
     rows.sort(key=lambda r: r.health, reverse=True)
     return tuple(rows)
-
-
-def compute_team_row(
-    all_prs: list[PullRequest],
-    days: int,
-    dev_raws: dict[str, RawMetrics],
-    devs: tuple[Row, ...],
-    reviewer_counts: dict[str, int],
-) -> Row:
-    team_raw = compute_raw(all_prs, days, sum(reviewer_counts.values()))
-    aggregated = {
-        key: round(median([getattr(m, key) for m in dev_raws.values() if getattr(m, key, None)]), 2)
-        for key in _PER_DEV_AGGREGATED_KEYS
-    }
-    ai_values = [m.ai_percentage for m in dev_raws.values()]
-    aggregated["ai_percentage"] = round(sum(ai_values) / len(ai_values), 1) if ai_values else 0.0
-    team_health = round(sum(r.health for r in devs) / len(devs)) if devs else 0
-    return raw_to_row(
-        "team",
-        RawMetrics(
-            **aggregated,
-            pr_count=team_raw.pr_count,
-            reviews_given=team_raw.reviews_given,
-        ),
-        team_health,
-    )

--- a/git_dev_metrics/metrics/snapshot.py
+++ b/git_dev_metrics/metrics/snapshot.py
@@ -8,11 +8,47 @@ from dataclasses import dataclass
 
 from ..models import PullRequest
 from ..utils import TimePeriod, period_days
-from ._dev_repo_metrics import compute_dev_metrics, compute_repo_metrics
-from ._health_ranking import band_from_health, compute_team_row, rank_rows
+from ._dev_repo_metrics import compute_dev_metrics, compute_raw, compute_repo_metrics
+from ._health_ranking import band_from_health, rank_rows, raw_to_row
+from ._raw_metrics import RawMetrics
 from ._rows import Row, Summary
-from .calculator import calculate_reviews_given
+from .calculator import calculate_reviews_given, median
 from .health import calculate_dev_health_score, calculate_health_score
+
+_PER_DEV_AGGREGATED_KEYS = (
+    "cycle_time",
+    "pickup_time",
+    "review_time",
+    "pr_size",
+    "avg_lines_per_pr",
+    "prs_per_week",
+)
+
+
+def compute_team_row(
+    all_prs: list[PullRequest],
+    days: int,
+    dev_raws: dict[str, RawMetrics],
+    devs: tuple[Row, ...],
+    reviewer_counts: dict[str, int],
+) -> Row:
+    team_raw = compute_raw(all_prs, days, sum(reviewer_counts.values()))
+    aggregated = {
+        key: round(median([getattr(m, key) for m in dev_raws.values() if getattr(m, key, None)]), 2)
+        for key in _PER_DEV_AGGREGATED_KEYS
+    }
+    ai_values = [m.ai_percentage for m in dev_raws.values()]
+    aggregated["ai_percentage"] = round(sum(ai_values) / len(ai_values), 1) if ai_values else 0.0
+    team_health = round(sum(r.health for r in devs) / len(devs)) if devs else 0
+    return raw_to_row(
+        "team",
+        RawMetrics(
+            **aggregated,
+            pr_count=team_raw.pr_count,
+            reviews_given=team_raw.reviews_given,
+        ),
+        team_health,
+    )
 
 
 @dataclass(frozen=True)
@@ -80,4 +116,5 @@ __all__ = [
     "MetricsSnapshot",
     "band_from_health",
     "build_summary",
+    "compute_team_row",
 ]


### PR DESCRIPTION
## Problem

`_health_ranking` imported `compute_raw` from sibling private module `_dev_repo_metrics` to build the team row. Cross-private-module dependency violated the `_`-prefix convention — `_health_ranking` was doing orchestration alongside mapping.

## Solution

Move `compute_team_row` into `snapshot.py` where orchestration belongs. `_health_ranking` is now pure mapping: `band_from_health`, `raw_to_row`, `rank_rows` — no side effects, no cross-module computation imports.

## Impact

- `_health_ranking` no longer imports from `_dev_repo_metrics` or `calculator`
- Dependency flow is now unidirectional: `snapshot` → `_dev_repo_metrics` + `_health_ranking`
- `compute_team_row` lives next to its only caller (`MetricsSnapshot.from_repo_prs`)
