### PR TITLE
Add cache→snapshot round-trip integration test

### DIFF
--- a/tests/integration/test_cache_to_snapshot.py
+++ b/tests/integration/test_cache_to_snapshot.py
@@ -5,11 +5,9 @@ JSON blobs) preserves enough shape that the metrics pipeline produces correct Ro
 """
 
 from datetime import UTC, datetime
-from typing import cast
 
 from git_dev_metrics.cache import insert_prs, load_all_repos_for_range, seal_month
 from git_dev_metrics.metrics.snapshot import MetricsSnapshot
-from git_dev_metrics.models import PullRequest, Review
 from git_dev_metrics.utils.date_utils import month_range
 
 
@@ -22,7 +20,7 @@ def _pr(
     changed_files: int = 5,
     reviews: list[dict] | None = None,
     state: str = "merged",
-) -> PullRequest:
+) -> dict:
     return {
         "id": number,
         "number": number,
@@ -39,7 +37,7 @@ def _pr(
         "ready_for_review_at": datetime(2026, 4, merged_day, 7, 0, 0, tzinfo=UTC),
         "body": f"Body for #{number}",
         "commit_messages": [f"feat: change for #{number}"],
-        "reviews": cast("list[Review]", reviews or []),
+        "reviews": reviews or [],
     }
 
 
@@ -53,8 +51,8 @@ def _review(login: str, day: int) -> dict:
 
 class TestCacheToSnapshotRoundTrip:
     def test_should_compute_row_values_after_cache_round_trip(self, tmp_path):
+        # Arrange
         db_path = tmp_path / "cache.db"
-
         prs_repo1 = [
             _pr(101, "alice", 5, reviews=[_review("bob", 5)]),
             _pr(102, "bob", 12),
@@ -68,9 +66,11 @@ class TestCacheToSnapshotRoundTrip:
         insert_prs(prs_repo2, "myorg", "repo2", 2026, 4, db_path=db_path)
         seal_month("myorg", "repo2", 2026, 4, db_path=db_path)
 
+        # Act
         repo_prs = load_all_repos_for_range([(2026, 4)], db_path=db_path)
         snapshot = MetricsSnapshot.from_repo_prs(repo_prs, month_range(2026, 4))
 
+        # Assert
         dev_rows = {r.name: r for r in snapshot.devs}
         assert set(dev_rows) == {"alice", "bob"}
         assert dev_rows["alice"].pr_count == 2

--- a/tests/integration/test_cache_to_snapshot.py
+++ b/tests/integration/test_cache_to_snapshot.py
@@ -1,0 +1,84 @@
+"""Round-trip integration: PullRequest dicts → cache → load → MetricsSnapshot → Row.
+
+Asserts the cache serialization round-trip (datetimes ↔ ISO strings, reviews ↔ DB rows,
+JSON blobs) preserves enough shape that the metrics pipeline produces correct Rows.
+"""
+
+from datetime import UTC, datetime
+from typing import cast
+
+from git_dev_metrics.cache import insert_prs, load_all_repos_for_range, seal_month
+from git_dev_metrics.metrics.snapshot import MetricsSnapshot
+from git_dev_metrics.models import PullRequest, Review
+from git_dev_metrics.utils.date_utils import month_range
+
+
+def _pr(
+    number: int,
+    login: str,
+    merged_day: int,
+    additions: int = 100,
+    deletions: int = 50,
+    changed_files: int = 5,
+    reviews: list[dict] | None = None,
+    state: str = "merged",
+) -> PullRequest:
+    return {
+        "id": number,
+        "number": number,
+        "state": state,
+        "title": f"PR #{number}",
+        "user": {"login": login},
+        "created_at": datetime(2026, 4, merged_day, 8, 0, 0, tzinfo=UTC),
+        "merged_at": datetime(2026, 4, merged_day, 18, 0, 0, tzinfo=UTC),
+        "closed_at": datetime(2026, 4, merged_day, 18, 0, 0, tzinfo=UTC),
+        "additions": additions,
+        "deletions": deletions,
+        "changed_files": changed_files,
+        "first_commit_at": datetime(2026, 4, merged_day, 6, 0, 0, tzinfo=UTC),
+        "ready_for_review_at": datetime(2026, 4, merged_day, 7, 0, 0, tzinfo=UTC),
+        "body": f"Body for #{number}",
+        "commit_messages": [f"feat: change for #{number}"],
+        "reviews": cast("list[Review]", reviews or []),
+    }
+
+
+def _review(login: str, day: int) -> dict:
+    return {
+        "user": {"login": login},
+        "state": "APPROVED",
+        "submitted_at": datetime(2026, 4, day, 12, 0, 0, tzinfo=UTC),
+    }
+
+
+class TestCacheToSnapshotRoundTrip:
+    def test_should_compute_row_values_after_cache_round_trip(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+
+        prs_repo1 = [
+            _pr(101, "alice", 5, reviews=[_review("bob", 5)]),
+            _pr(102, "bob", 12),
+        ]
+        prs_repo2 = [
+            _pr(103, "alice", 20, additions=50, deletions=25, changed_files=3),
+        ]
+
+        insert_prs(prs_repo1, "myorg", "repo1", 2026, 4, db_path=db_path)
+        seal_month("myorg", "repo1", 2026, 4, db_path=db_path)
+        insert_prs(prs_repo2, "myorg", "repo2", 2026, 4, db_path=db_path)
+        seal_month("myorg", "repo2", 2026, 4, db_path=db_path)
+
+        repo_prs = load_all_repos_for_range([(2026, 4)], db_path=db_path)
+        snapshot = MetricsSnapshot.from_repo_prs(repo_prs, month_range(2026, 4))
+
+        dev_rows = {r.name: r for r in snapshot.devs}
+        assert set(dev_rows) == {"alice", "bob"}
+        assert dev_rows["alice"].pr_count == 2
+        assert dev_rows["alice"].reviews_given == 0
+        assert dev_rows["bob"].pr_count == 1
+        assert dev_rows["bob"].reviews_given == 1
+        assert snapshot.team.pr_count == 3
+        assert snapshot.team.reviews_given == 1
+        for row in [*snapshot.devs, snapshot.team]:
+            assert isinstance(row.health, int)
+            assert row.band in ("good", "ok", "bad")


### PR DESCRIPTION
## Problem

No test proves that PullRequest dicts survive the full insert → seal → load → MetricsSnapshot cycle. If the cache serialization (datetimes to ISO, reviews to DB rows, commit_messages to JSON blob) silently drops or corrupts a field, the bug only surfaces in production during `gdm dashboard`.

## Solution

New integration test `test_cache_to_snapshot.py`:

1. Build real PullRequest dicts for 2 repos, 2 devs, across April 2026
2. `insert_prs()` + `seal_month()` into a temp SQLite cache
3. `load_all_repos_for_range()` reconstructs them
4. `MetricsSnapshot.from_repo_prs()` computes the snapshot
5. Assert Row values: pr_count, reviews_given, health, band

Confirmed: 247 tests pass, pyright 0 errors, ruff clean.