### PR TITLE
Move compute_raw from _dev_repo_metrics.py to _raw_metrics.py

### DIFF
--- a/git_dev_metrics/metrics/_dev_repo_metrics.py
+++ b/git_dev_metrics/metrics/_dev_repo_metrics.py
@@ -1,31 +1,6 @@
 from ..models import PullRequest
-from ._raw_metrics import RawMetrics
-from .calculator import (
-    calculate_ai_percentage,
-    calculate_avg_lines_per_pr,
-    calculate_cycle_time,
-    calculate_pickup_time,
-    calculate_pr_size,
-    calculate_prs_per_week,
-    calculate_review_time,
-    calculate_reviews_given,
-    calculate_throughput,
-    group_prs_by_devs,
-)
-
-
-def compute_raw(prs: list[PullRequest], days: int, reviews_given: int) -> RawMetrics:
-    return RawMetrics(
-        cycle_time=calculate_cycle_time(prs),
-        pr_size=calculate_pr_size(prs),
-        avg_lines_per_pr=calculate_avg_lines_per_pr(prs),
-        pr_count=calculate_throughput(prs),
-        pickup_time=calculate_pickup_time(prs),
-        review_time=calculate_review_time(prs),
-        prs_per_week=calculate_prs_per_week(prs, days),
-        reviews_given=reviews_given,
-        ai_percentage=calculate_ai_percentage(prs),
-    )
+from ._raw_metrics import RawMetrics, compute_raw
+from .calculator import calculate_reviews_given, group_prs_by_devs
 
 
 def compute_dev_metrics(

--- a/git_dev_metrics/metrics/_health_ranking.py
+++ b/git_dev_metrics/metrics/_health_ranking.py
@@ -1,19 +1,7 @@
 from collections.abc import Callable
 
-from ..models import PullRequest
-from ._dev_repo_metrics import compute_raw
 from ._raw_metrics import RawMetrics
 from ._rows import Band, Row
-from .calculator import median
-
-_PER_DEV_AGGREGATED_KEYS = (
-    "cycle_time",
-    "pickup_time",
-    "review_time",
-    "pr_size",
-    "avg_lines_per_pr",
-    "prs_per_week",
-)
 
 
 def band_from_health(health: int) -> Band:
@@ -49,29 +37,3 @@ def rank_rows(
     rows = [raw_to_row(name, m, health_fn(m, cohort)) for name, m in raws.items()]
     rows.sort(key=lambda r: r.health, reverse=True)
     return tuple(rows)
-
-
-def compute_team_row(
-    all_prs: list[PullRequest],
-    days: int,
-    dev_raws: dict[str, RawMetrics],
-    devs: tuple[Row, ...],
-    reviewer_counts: dict[str, int],
-) -> Row:
-    team_raw = compute_raw(all_prs, days, sum(reviewer_counts.values()))
-    aggregated = {
-        key: round(median([getattr(m, key) for m in dev_raws.values() if getattr(m, key, None)]), 2)
-        for key in _PER_DEV_AGGREGATED_KEYS
-    }
-    ai_values = [m.ai_percentage for m in dev_raws.values()]
-    aggregated["ai_percentage"] = round(sum(ai_values) / len(ai_values), 1) if ai_values else 0.0
-    team_health = round(sum(r.health for r in devs) / len(devs)) if devs else 0
-    return raw_to_row(
-        "team",
-        RawMetrics(
-            **aggregated,
-            pr_count=team_raw.pr_count,
-            reviews_given=team_raw.reviews_given,
-        ),
-        team_health,
-    )

--- a/git_dev_metrics/metrics/_raw_metrics.py
+++ b/git_dev_metrics/metrics/_raw_metrics.py
@@ -2,6 +2,18 @@
 
 from dataclasses import dataclass
 
+from ..models import PullRequest
+from .calculator import (
+    calculate_ai_percentage,
+    calculate_avg_lines_per_pr,
+    calculate_cycle_time,
+    calculate_pickup_time,
+    calculate_pr_size,
+    calculate_prs_per_week,
+    calculate_review_time,
+    calculate_throughput,
+)
+
 
 @dataclass(frozen=True)
 class RawMetrics:
@@ -14,3 +26,17 @@ class RawMetrics:
     prs_per_week: float
     reviews_given: int
     ai_percentage: float
+
+
+def compute_raw(prs: list[PullRequest], days: int, reviews_given: int) -> RawMetrics:
+    return RawMetrics(
+        cycle_time=calculate_cycle_time(prs),
+        pr_size=calculate_pr_size(prs),
+        avg_lines_per_pr=calculate_avg_lines_per_pr(prs),
+        pr_count=calculate_throughput(prs),
+        pickup_time=calculate_pickup_time(prs),
+        review_time=calculate_review_time(prs),
+        prs_per_week=calculate_prs_per_week(prs, days),
+        reviews_given=reviews_given,
+        ai_percentage=calculate_ai_percentage(prs),
+    )

--- a/git_dev_metrics/metrics/snapshot.py
+++ b/git_dev_metrics/metrics/snapshot.py
@@ -8,11 +8,47 @@ from dataclasses import dataclass
 
 from ..models import PullRequest
 from ..utils import TimePeriod, period_days
-from ._dev_repo_metrics import compute_dev_metrics, compute_repo_metrics
-from ._health_ranking import band_from_health, compute_team_row, rank_rows
+from ._dev_repo_metrics import compute_dev_metrics, compute_raw, compute_repo_metrics
+from ._health_ranking import band_from_health, rank_rows, raw_to_row
+from ._raw_metrics import RawMetrics
 from ._rows import Row, Summary
-from .calculator import calculate_reviews_given
+from .calculator import calculate_reviews_given, median
 from .health import calculate_dev_health_score, calculate_health_score
+
+_PER_DEV_AGGREGATED_KEYS = (
+    "cycle_time",
+    "pickup_time",
+    "review_time",
+    "pr_size",
+    "avg_lines_per_pr",
+    "prs_per_week",
+)
+
+
+def compute_team_row(
+    all_prs: list[PullRequest],
+    days: int,
+    dev_raws: dict[str, RawMetrics],
+    devs: tuple[Row, ...],
+    reviewer_counts: dict[str, int],
+) -> Row:
+    team_raw = compute_raw(all_prs, days, sum(reviewer_counts.values()))
+    aggregated = {
+        key: round(median([getattr(m, key) for m in dev_raws.values() if getattr(m, key, None)]), 2)
+        for key in _PER_DEV_AGGREGATED_KEYS
+    }
+    ai_values = [m.ai_percentage for m in dev_raws.values()]
+    aggregated["ai_percentage"] = round(sum(ai_values) / len(ai_values), 1) if ai_values else 0.0
+    team_health = round(sum(r.health for r in devs) / len(devs)) if devs else 0
+    return raw_to_row(
+        "team",
+        RawMetrics(
+            **aggregated,
+            pr_count=team_raw.pr_count,
+            reviews_given=team_raw.reviews_given,
+        ),
+        team_health,
+    )
 
 
 @dataclass(frozen=True)
@@ -80,4 +116,5 @@ __all__ = [
     "MetricsSnapshot",
     "band_from_health",
     "build_summary",
+    "compute_team_row",
 ]


### PR DESCRIPTION
## Problem

`compute_raw` (the `RawMetrics` factory) lived in `_dev_repo_metrics.py`, separated from the dataclass it constructs. Meanwhile `_dev_repo_metrics` bundled three responsibilities: the raw metrics factory, per-dev grouping, and per-repo grouping.

## Solution

Move `compute_raw` to `_raw_metrics.py` — co-locate the dataclass and its factory. `_dev_repo_metrics.py` drops from 49→24 lines and becomes only grouping wrappers that call `compute_raw` internally.

Import path changes:
- `_dev_repo_metrics.py`: imports `compute_raw` from `._raw_metrics` instead of defining it

## Dependencies

Stacked on #140 — rebased onto `move-compute-team-row`. Merge #140 first.

## Impact

246 tests pass, pyright 0 errors, ruff clean. Zero behavioral change.