### PR TITLE
Remove 5 type: ignore comments from production code

### DIFF
--- a/git_dev_metrics/cache/query.py
+++ b/git_dev_metrics/cache/query.py
@@ -2,6 +2,7 @@ import json
 import sqlite3
 from collections import defaultdict
 from pathlib import Path
+from typing import cast
 
 from ..models import PullRequest, Review
 from ..utils.date_utils import parse_iso_datetime
@@ -17,23 +18,26 @@ def _review(row: sqlite3.Row) -> Review:
 
 
 def _pr(row: sqlite3.Row, reviews: list[Review]) -> PullRequest:
-    return {  # type: ignore[return-value]
-        "number": row["number"],
-        "state": row["state"] or "",
-        "title": row["title"] or "",
-        "user": {"login": row["author_login"] or ""},
-        "created_at": parse_iso_datetime(row["created_at"]),
-        "merged_at": parse_iso_datetime(row["merged_at"]),
-        "closed_at": parse_iso_datetime(row["closed_at"]),
-        "additions": row["additions"] or 0,
-        "deletions": row["deletions"] or 0,
-        "changed_files": row["changed_files"] or 0,
-        "first_commit_at": parse_iso_datetime(row["first_commit_at"]),
-        "ready_for_review_at": parse_iso_datetime(row["ready_for_review_at"]),
-        "body": row["body"],
-        "commit_messages": json.loads(row["commit_messages_json"] or "[]"),
-        "reviews": reviews,
-    }
+    return cast(
+        PullRequest,
+        {
+            "number": row["number"],
+            "state": row["state"] or "",
+            "title": row["title"] or "",
+            "user": {"login": row["author_login"] or ""},
+            "created_at": parse_iso_datetime(row["created_at"]),
+            "merged_at": parse_iso_datetime(row["merged_at"]),
+            "closed_at": parse_iso_datetime(row["closed_at"]),
+            "additions": row["additions"] or 0,
+            "deletions": row["deletions"] or 0,
+            "changed_files": row["changed_files"] or 0,
+            "first_commit_at": parse_iso_datetime(row["first_commit_at"]),
+            "ready_for_review_at": parse_iso_datetime(row["ready_for_review_at"]),
+            "body": row["body"],
+            "commit_messages": json.loads(row["commit_messages_json"] or "[]"),
+            "reviews": reviews,
+        },
+    )
 
 
 def load_prs(

--- a/git_dev_metrics/cli/wizards/pull_wizard.py
+++ b/git_dev_metrics/cli/wizards/pull_wizard.py
@@ -54,7 +54,7 @@ def _default_fetch_repos(token: str, org: str | None) -> list[Repository]:
 
 
 def _filter_active(repos: list[Repository], since: datetime) -> list[Repository]:
-    return [r for r in repos if r.get("last_pushed") and r["last_pushed"] >= since]  # type: ignore[reportOperatorIssue]
+    return [r for r in repos if (pushed := r.get("last_pushed")) is not None and pushed >= since]
 
 
 def pull_wizard(

--- a/git_dev_metrics/github/_response_mapper.py
+++ b/git_dev_metrics/github/_response_mapper.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from ..models import PullRequest, Repository, Review
 from ..utils.date_utils import parse_iso_datetime
 
@@ -9,11 +11,14 @@ def map_author_login(author: dict | None) -> str:
 
 def map_repository(repo: dict) -> Repository:
     """Map GraphQL repository response to internal model."""
-    return {
-        "full_name": repo.get("nameWithOwner"),  # type: ignore[return-value]
-        "private": repo.get("isPrivate", False),
-        "last_pushed": parse_iso_datetime(repo.get("pushedAt")),
-    }
+    return cast(
+        Repository,
+        {
+            "full_name": repo.get("nameWithOwner") or "",
+            "private": repo.get("isPrivate", False),
+            "last_pushed": parse_iso_datetime(repo.get("pushedAt")),
+        },
+    )
 
 
 def map_pull_request(pr: dict) -> PullRequest:
@@ -33,27 +38,33 @@ def map_pull_request(pr: dict) -> PullRequest:
         None,
     )
 
-    return {  # type: ignore[return-value]
-        "number": pr.get("number"),
-        "title": pr.get("title"),
-        "created_at": parse_iso_datetime(pr.get("createdAt")),
-        "merged_at": parse_iso_datetime(pr.get("mergedAt")),
-        "additions": pr.get("additions", 0),
-        "deletions": pr.get("deletions", 0),
-        "changed_files": pr.get("changedFiles", 0),
-        "user": {"login": map_author_login(pr.get("author"))},
-        "first_commit_at": first_commit_date,
-        "ready_for_review_at": ready_for_review,
-        "body": pr.get("body"),
-        "commit_messages": commit_messages,
-        "reviews": [],
-    }
+    return cast(
+        PullRequest,
+        {
+            "number": pr.get("number"),
+            "title": pr.get("title"),
+            "created_at": parse_iso_datetime(pr.get("createdAt")),
+            "merged_at": parse_iso_datetime(pr.get("mergedAt")),
+            "additions": pr.get("additions", 0),
+            "deletions": pr.get("deletions", 0),
+            "changed_files": pr.get("changedFiles", 0),
+            "user": {"login": map_author_login(pr.get("author"))},
+            "first_commit_at": first_commit_date,
+            "ready_for_review_at": ready_for_review,
+            "body": pr.get("body"),
+            "commit_messages": commit_messages,
+            "reviews": [],
+        },
+    )
 
 
 def map_review(review: dict) -> Review:
     """Map GraphQL review response to internal model."""
-    return {
-        "user": {"login": map_author_login(review.get("author"))},
-        "state": review.get("state"),  # type: ignore[return-value]
-        "submitted_at": parse_iso_datetime(review.get("submittedAt")),
-    }
+    return cast(
+        Review,
+        {
+            "user": {"login": map_author_login(review.get("author"))},
+            "state": review.get("state") or "",
+            "submitted_at": parse_iso_datetime(review.get("submittedAt")),
+        },
+    )


### PR DESCRIPTION
All 5 `type: ignore` comments in production code are now gone (0 errors, 0 remaining).

| File | Before | After | Reason |
|---|---|---|---|
| `_response_mapper.py:13` | `# type: ignore[return-value]` | `cast(Repository, {...})` | `dict.get()` returns `Any`, pyright can't match TypedDict |
| `_response_mapper.py:36` | `# type: ignore[return-value]` | `cast(PullRequest, {...})` | same pattern |
| `_response_mapper.py:57` | `# type: ignore[return-value]` | `cast(Review, {...})` + `or ""` fallback | same pattern |
| `cache/query.py:20` | `# type: ignore[return-value]` | `cast(PullRequest, {...})` | `sqlite3.Row` index returns `Any` |
| `pull_wizard.py:57` | `# type: ignore[reportOperatorIssue]` | walrus `pushed := r.get(...)` + `is not None` guard | pyright couldn't narrow `TypedDict.get()` into `__getitem__` |

238 tests pass, pyright 0 errors, lint/format clean.