### PR TITLE
Remove dead exports from github/__init__.py

### DIFF
--- a/git_dev_metrics/github/__init__.py
+++ b/git_dev_metrics/github/__init__.py
@@ -1,11 +1,5 @@
 """Github auth and data fetching."""
 
-from ._response_mapper import (
-    map_author_login,
-    map_pull_request,
-    map_repository,
-    map_review,
-)
 from .auth import get_github_token
 from .exceptions import (
     GitHubAPIError,
@@ -18,10 +12,8 @@ from .org_cache import load_last_org, save_last_org
 from .queries import (
     fetch_open_prs,
     fetch_org_repositories,
-    fetch_pull_requests,
     fetch_repo_metrics,
     fetch_repositories,
-    fetch_reviews,
 )
 
 __all__ = [
@@ -30,17 +22,11 @@ __all__ = [
     "GitHubAPIError",
     "GitHubRateLimitError",
     "GitHubNotFoundError",
-    "map_author_login",
     "get_github_token",
     "fetch_repositories",
     "fetch_org_repositories",
-    "fetch_pull_requests",
-    "fetch_reviews",
     "fetch_repo_metrics",
     "fetch_open_prs",
     "load_last_org",
-    "map_pull_request",
-    "map_repository",
-    "map_review",
     "save_last_org",
 ]

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -1,9 +1,7 @@
 from datetime import UTC, datetime
 
-from git_dev_metrics.github import (
-    fetch_pull_requests,
-    fetch_repositories,
-)
+from git_dev_metrics.github import fetch_repositories
+from git_dev_metrics.github.queries import fetch_pull_requests
 from git_dev_metrics.utils import TimePeriod
 
 

--- a/tests/unit/github/test_github_fetch.py
+++ b/tests/unit/github/test_github_fetch.py
@@ -3,12 +3,8 @@ import re
 import responses
 from pytest import raises
 
-from git_dev_metrics.github import (
-    GitHubAPIError,
-    fetch_pull_requests,
-    fetch_repositories,
-    fetch_reviews,
-)
+from git_dev_metrics.github import GitHubAPIError, fetch_repositories
+from git_dev_metrics.github.queries import fetch_pull_requests, fetch_reviews
 from git_dev_metrics.utils import TimePeriod
 
 from ..conftest import dt


### PR DESCRIPTION
Removed 6 symbols re-exported from `github/__init__.py` but never imported
by production code:

- `map_author_login`, `map_pull_request`, `map_repository`, `map_review`
  (only imported within the `github` package directly from `_response_mapper`)
- `fetch_pull_requests`, `fetch_reviews`
  (superseded by `fetch_repo_metrics`, only used in tests)

`__all__`: 17 → 11 entries. Test imports updated.
238 pass, pyright 0 errors, lint/format clean.