### PR TITLE
Extract shared run_wizard helper from dashboard/summary wizards

### DIFF
--- a/git_dev_metrics/cli/wizards/_wizard.py
+++ b/git_dev_metrics/cli/wizards/_wizard.py
@@ -7,6 +7,9 @@ import typer
 from questionary import Style
 
 from ...cache import list_synced_months
+from ...metrics.loader import load_snapshot_for_months
+from ...metrics.snapshot import MetricsSnapshot
+from ..utils._date_formatter import format_date_range
 
 YearMonth = tuple[int, int]
 
@@ -36,3 +39,18 @@ def pick_months(
     if not picked:
         raise typer.Exit(code=1)
     return sorted(picked)
+
+
+def run_wizard(
+    db_path: Path | None,
+    ask_months: Callable[[list[YearMonth]], list[YearMonth]],
+    output_fn: Callable[[MetricsSnapshot, str, str], None],
+) -> None:
+    selected = pick_months(db_path, ask_months)
+    snapshot = load_snapshot_for_months(selected, db_path)
+    if snapshot is None:
+        typer.secho("No PRs in selected months.", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=1)
+    first, last = selected[0], selected[-1]
+    period_slug = f"{first[0]:04d}-{first[1]:02d}-to-{last[0]:04d}-{last[1]:02d}"
+    output_fn(snapshot, period_slug, format_date_range(snapshot.period))

--- a/git_dev_metrics/cli/wizards/dashboard_wizard.py
+++ b/git_dev_metrics/cli/wizards/dashboard_wizard.py
@@ -1,14 +1,8 @@
 from collections.abc import Callable
 from pathlib import Path
 
-import typer
-
-from ...metrics.loader import load_snapshot_for_months
 from ..runners.dashboard_runner import write_and_open_dashboard
-from ..utils._date_formatter import format_date_range
-from ._wizard import _prompt_months, pick_months
-
-YearMonth = tuple[int, int]
+from ._wizard import YearMonth, _prompt_months, run_wizard
 
 
 def dashboard_wizard(
@@ -17,11 +11,8 @@ def dashboard_wizard(
     ask_months: Callable[[list[YearMonth]], list[YearMonth]] = _prompt_months,
 ) -> None:
     """Pick months from cache, render HTML dashboard, open in browser."""
-    selected = pick_months(db_path, ask_months)
-    snapshot = load_snapshot_for_months(selected, db_path)
-    if snapshot is None:
-        typer.secho("No PRs in selected months.", fg=typer.colors.RED, err=True)
-        raise typer.Exit(code=1)
-    first, last = selected[0], selected[-1]
-    period_slug = f"{first[0]:04d}-{first[1]:02d}-to-{last[0]:04d}-{last[1]:02d}"
-    write_and_open_dashboard(snapshot, period_slug, format_date_range(snapshot.period), output=None)
+    run_wizard(
+        db_path,
+        ask_months,
+        lambda s, slug, dr: write_and_open_dashboard(s, slug, dr, output=None),
+    )

--- a/git_dev_metrics/cli/wizards/summary_wizard.py
+++ b/git_dev_metrics/cli/wizards/summary_wizard.py
@@ -1,14 +1,8 @@
 from collections.abc import Callable
 from pathlib import Path
 
-import typer
-
-from ...metrics.loader import load_snapshot_for_months
 from ...metrics.printer import ConsolePrinter
-from ..utils._date_formatter import format_date_range
-from ._wizard import _prompt_months, pick_months
-
-YearMonth = tuple[int, int]
+from ._wizard import YearMonth, _prompt_months, run_wizard
 
 
 def summary_wizard(
@@ -17,13 +11,8 @@ def summary_wizard(
     ask_months: Callable[[list[YearMonth]], list[YearMonth]] = _prompt_months,
 ) -> None:
     """Pick months from cache, print aggregated summary to console."""
-    selected = pick_months(db_path, ask_months)
-    snapshot = load_snapshot_for_months(selected, db_path)
-    if snapshot is None:
-        typer.secho("No PRs in selected months.", fg=typer.colors.RED, err=True)
-        raise typer.Exit(code=1)
-    first, last = selected[0], selected[-1]
-    period_slug = f"{first[0]:04d}-{first[1]:02d}-to-{last[0]:04d}-{last[1]:02d}"
-    ConsolePrinter().print_combined_metrics(
-        snapshot, period_slug, format_date_range(snapshot.period)
+    run_wizard(
+        db_path,
+        ask_months,
+        lambda s, slug, dr: ConsolePrinter().print_combined_metrics(s, slug, dr),
     )


### PR DESCRIPTION
Same pattern as the command-layer fix (#152): dashboard_wizard and
summary_wizard shared ~22 lines of identical month-picking + snapshot-loading
+ period-slug logic, differing only in how they output the result.

Extracted into `run_wizard()` in `_wizard.py`:

```
file                        before → after
dashboard_wizard.py            27 →  14   (-13)
summary_wizard.py              29 →  13   (-16)
_wizard.py                     38 →  64   (+26, shared helper)
```

238 pass, pyright 0 errors, lint/format clean.