### PR TITLE
Deduplicate _STYLE and YearMonth across wizard modules

### DIFF
--- a/git_dev_metrics/cli/wizards/prompts.py
+++ b/git_dev_metrics/cli/wizards/prompts.py
@@ -1,7 +1,6 @@
 import questionary
-from questionary import Style
 
-_STYLE = Style([("highlighted", "fg:#00b4d8 bold"), ("selected", "fg:#90e0ef")])
+from ._wizard import _STYLE
 
 
 def prompt_org_name(default: str | None = None) -> str | None:

--- a/git_dev_metrics/cli/wizards/pull_wizard.py
+++ b/git_dev_metrics/cli/wizards/pull_wizard.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import questionary
 import typer
-from questionary import Style
 
 from ...cache import is_sealed
 from ...github import (
@@ -19,9 +18,9 @@ from ...models import PullRequest, Repository
 from ...utils.date_utils import TimePeriod, month_range
 from .._month_arg import parse_month_arg
 from ..runners.pull_runner import fetch_and_seal_month
+from ._wizard import _STYLE
 from .prompts import prompt_org_name, prompt_repo_selection
 
-_STYLE = Style([("highlighted", "fg:#00b4d8 bold"), ("selected", "fg:#90e0ef")])
 _MONTHS_LOOKBACK = 12
 
 MonthChoice = tuple[str, str]

--- a/git_dev_metrics/cli/wizards/trend_wizard.py
+++ b/git_dev_metrics/cli/wizards/trend_wizard.py
@@ -4,14 +4,10 @@ from pathlib import Path
 
 import questionary
 import typer
-from questionary import Style
 
 from ...cache import list_synced_months
 from ..runners.trend_runner import perform_trend
-
-YearMonth = tuple[int, int]
-
-_STYLE = Style([("highlighted", "fg:#00b4d8 bold"), ("selected", "fg:#90e0ef")])
+from ._wizard import _STYLE, YearMonth
 
 
 def _month_choices(months: list[YearMonth]) -> list[questionary.Choice]:


### PR DESCRIPTION
## Summary

- Centralize `_STYLE` (questionary `Style`) and `YearMonth` (`tuple[int, int]`) in `_wizard.py`
- Import them in `prompts.py`, `pull_wizard.py`, `trend_wizard.py` instead of redefining
- Removes 3 duplicate `_STYLE` definitions and 1 duplicate `YearMonth` alias
- No behaviour change — all imports resolve to the same object