### PR TITLE
Remove dead code: format_health and get_health_color

### DIFF
--- a/git_dev_metrics/metrics/health.py
+++ b/git_dev_metrics/metrics/health.py
@@ -100,15 +100,3 @@ def calculate_dev_health_score(
 
     score = sum(DEV_WEIGHTS[k] * v for k, v in components.items())
     return round(max(0.0, min(100.0, score)))
-
-
-def format_health(score: int) -> str:
-    return str(score)
-
-
-def get_health_color(score: int) -> str:
-    if score >= 80:
-        return "green"
-    if score >= 60:
-        return "yellow"
-    return "red"

--- a/tests/unit/metrics/test_health.py
+++ b/tests/unit/metrics/test_health.py
@@ -5,8 +5,6 @@ from git_dev_metrics.metrics.health import (
     _time_score,
     calculate_dev_health_score,
     calculate_health_score,
-    format_health,
-    get_health_color,
 )
 
 
@@ -202,22 +200,3 @@ class TestCalculateDevHealthScore:
             )
             == 55
         )
-
-
-class TestFormatHealth:
-    def test_should_return_string(self) -> None:
-        assert format_health(85) == "85"
-
-
-class TestGetHealthColor:
-    def test_should_return_green_at_80(self) -> None:
-        assert get_health_color(80) == "green"
-        assert get_health_color(100) == "green"
-
-    def test_should_return_yellow_between_60_and_79(self) -> None:
-        assert get_health_color(60) == "yellow"
-        assert get_health_color(79) == "yellow"
-
-    def test_should_return_red_below_60(self) -> None:
-        assert get_health_color(0) == "red"
-        assert get_health_color(59) == "red"


### PR DESCRIPTION
## Summary

- `format_health(score)` returned `str(score)` — a trivial identity wrapper
- `get_health_color(score)` returned green/yellow/red strings — unused in
  production (dashboard template uses inline CSS classes with different thresholds)
- Both were only reachable from `test_health.py`
- Removed both functions and their tests (4 test cases)