### PR TITLE
Remove redundant cli/app.py, consolidate imports to cli

### DIFF
--- a/git_dev_metrics/cli/app.py
+++ b/git_dev_metrics/cli/app.py
@@ -1,3 +1,0 @@
-from .commands.app import app
-
-__all__ = ["app"]

--- a/tests/integration/test_pull_e2e.py
+++ b/tests/integration/test_pull_e2e.py
@@ -7,7 +7,7 @@ cache) breaks a test, not the next live `gdm pull`.
 from typer.testing import CliRunner
 
 from git_dev_metrics.cache import count_prs, is_sealed, query_prs
-from git_dev_metrics.cli.app import app
+from git_dev_metrics.cli import app
 from git_dev_metrics.github._response_mapper import map_pull_request
 
 runner = CliRunner()

--- a/tests/unit/cli/test_clear_command.py
+++ b/tests/unit/cli/test_clear_command.py
@@ -1,7 +1,7 @@
 from typer.testing import CliRunner
 
 from git_dev_metrics.cache import insert_prs, seal_month
-from git_dev_metrics.cli.app import app
+from git_dev_metrics.cli import app
 
 from ..conftest import any_pr
 

--- a/tests/unit/cli/test_cli_no_subcommand.py
+++ b/tests/unit/cli/test_cli_no_subcommand.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
-from git_dev_metrics.cli.app import app
+from git_dev_metrics.cli import app
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 

--- a/tests/unit/cli/test_dashboard_command.py
+++ b/tests/unit/cli/test_dashboard_command.py
@@ -1,7 +1,7 @@
 from typer.testing import CliRunner
 
 from git_dev_metrics.cache import insert_prs, seal_month
-from git_dev_metrics.cli.app import app
+from git_dev_metrics.cli import app
 
 from ..conftest import any_pr, approved_review, dt
 

--- a/tests/unit/cli/test_pull_command.py
+++ b/tests/unit/cli/test_pull_command.py
@@ -2,7 +2,7 @@ from freezegun import freeze_time
 from typer.testing import CliRunner
 
 from git_dev_metrics.cache import count_prs, seal_month
-from git_dev_metrics.cli.app import app
+from git_dev_metrics.cli import app
 
 from ..conftest import any_pr, approved_review, dt
 

--- a/tests/unit/cli/test_stale_command.py
+++ b/tests/unit/cli/test_stale_command.py
@@ -4,7 +4,7 @@ from freezegun import freeze_time
 from typer.testing import CliRunner
 
 from git_dev_metrics.cache import seal_month
-from git_dev_metrics.cli.app import app
+from git_dev_metrics.cli import app
 
 from ..conftest import dt
 

--- a/tests/unit/cli/test_summary_command.py
+++ b/tests/unit/cli/test_summary_command.py
@@ -1,7 +1,7 @@
 from typer.testing import CliRunner
 
 from git_dev_metrics.cache import insert_prs, seal_month
-from git_dev_metrics.cli.app import app
+from git_dev_metrics.cli import app
 
 from ..conftest import any_pr, approved_review, dt
 

--- a/tests/unit/cli/test_trend_command.py
+++ b/tests/unit/cli/test_trend_command.py
@@ -5,7 +5,7 @@ from freezegun import freeze_time
 from typer.testing import CliRunner
 
 from git_dev_metrics.cache import insert_prs, seal_month
-from git_dev_metrics.cli.app import app
+from git_dev_metrics.cli import app
 from git_dev_metrics.cli.wizards.trend_wizard import trend_wizard
 from git_dev_metrics.models import PullRequest
 


### PR DESCRIPTION
## Summary

- `cli/app.py` was identical to `cli/__init__.py` — both re-export `app` from
  `.commands.app`
- Production code (`main.py`) already imports via `from .cli import app`
- Only 8 test files imported via `cli.app` — updated them to `from git_dev_metrics.cli import app`
- -1 file, -3 lines