### PR TITLE
Harden CI: lint and format-check tests, audit all deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,8 @@ jobs:
 
       - name: Lint and format check
         run: |
-          uv run ruff check git_dev_metrics
-          uv run ruff format --check git_dev_metrics
+          uv run ruff check git_dev_metrics tests/
+          uv run ruff format --check git_dev_metrics tests/
 
       - name: Dead code check
         run: uv run vulture

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -3,7 +3,7 @@
 set -e
 
 echo "Running ruff check --fix..."
-uv run ruff check git_dev_metrics --fix
+uv run ruff check git_dev_metrics tests --fix
 
 echo "Running ruff format..."
 uv run ruff format git_dev_metrics tests


### PR DESCRIPTION
## Summary

- `ruff check` and `ruff format --check` now also cover `tests/` (not just `git_dev_metrics/`)
- `pip-audit` now runs with `--all-extras` to include dev dependency vulnerabilities
- `format.sh` simplified: lint + format `git_dev_metrics tests` in one pass each instead of split commands