### PR TITLE
Enable ruff rules RUF022, RET501, PT, T20 and fix all violations

### DIFF
--- a/git_dev_metrics/github/__init__.py
+++ b/git_dev_metrics/github/__init__.py
@@ -17,16 +17,16 @@ from .queries import (
 )
 
 __all__ = [
-    "GitHubError",
-    "GitHubAuthError",
     "GitHubAPIError",
-    "GitHubRateLimitError",
+    "GitHubAuthError",
+    "GitHubError",
     "GitHubNotFoundError",
-    "get_github_token",
-    "fetch_repositories",
+    "GitHubRateLimitError",
+    "fetch_open_prs",
     "fetch_org_repositories",
     "fetch_repo_metrics",
-    "fetch_open_prs",
+    "fetch_repositories",
+    "get_github_token",
     "load_last_org",
     "save_last_org",
 ]

--- a/git_dev_metrics/github/auth.py
+++ b/git_dev_metrics/github/auth.py
@@ -1,18 +1,20 @@
 from getpass import getpass
 
+import typer
+
 from .auth_cache import is_token_valid, load_token, save_token
 from .exceptions import GitHubAuthError
 
 
 def _prompt_for_token() -> str:
     """Prompt user to input their GitHub PAT."""
-    print("Enter your GitHub Personal Access Token (PAT).")
-    print("Create a fine-grained token at: https://github.com/settings/tokens?type=beta")
-    print("- Repository access: All repositories (or select specific repos)")
-    print("- Permissions:")
-    print("  - Contents: Read")
-    print("  - Metadata: Read")
-    print("  - Pull requests: Read")
+    typer.echo("Enter your GitHub Personal Access Token (PAT).")
+    typer.echo("Create a fine-grained token at: https://github.com/settings/tokens?type=beta")
+    typer.echo("- Repository access: All repositories (or select specific repos)")
+    typer.echo("- Permissions:")
+    typer.echo("  - Contents: Read")
+    typer.echo("  - Metadata: Read")
+    typer.echo("  - Pull requests: Read")
     token = getpass("PAT: ")
     if not token:
         raise GitHubAuthError("No token provided")

--- a/git_dev_metrics/models/__init__.py
+++ b/git_dev_metrics/models/__init__.py
@@ -10,10 +10,10 @@ from .types import (
 )
 
 __all__ = [
-    "Repository",
     "GitHubUser",
-    "PullRequestInfo",
-    "PullRequest",
     "OpenPullRequest",
+    "PullRequest",
+    "PullRequestInfo",
+    "Repository",
     "Review",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,15 +62,22 @@ target-version = "py314"
 
 [tool.ruff.lint]
 select = [
-    "E",    # pycodestyle errors
-    "F",    # pyflakes
-    "I",    # isort (import sorting)
-    "B",    # flake8-bugbear (common bugs)
-    "UP",   # pyupgrade (modernize syntax)
-    "SIM",  # flake8-simplify
-    "C901", # max function complexity (nesting/branching)
+    "E",     # pycodestyle errors
+    "F",     # pyflakes
+    "I",     # isort (import sorting)
+    "B",     # flake8-bugbear (common bugs)
+    "UP",    # pyupgrade (modernize syntax)
+    "SIM",   # flake8-simplify
+    "C901",  # max function complexity (nesting/branching)
+    "RUF022",# sorted __all__
+    "RET501",# unnecessary return None
+    "PT",    # pytest-style
+    "T20",   # print/pprint detection
 ]
-ignore = ["B008"]  # typer.Option() in argument defaults is required
+ignore = [
+    "B008",  # typer.Option() in argument defaults is required
+    "PT019", # fixture value IS used in test body (false positive on autouse fixtures with mocker)
+]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10  # Rule 2: max nesting/branching depth

--- a/tests/unit/cli/test_pull_wizard.py
+++ b/tests/unit/cli/test_pull_wizard.py
@@ -145,7 +145,7 @@ class TestPullWizardMonthChoices:
 
         def ask_month(choices):
             captured.append(list(choices))
-            return None  # user cancels — exits before fetch
+            return  # user cancels — exits before fetch
 
         # Act
         with pytest.raises(typer.Exit):

--- a/tests/unit/github/test_github_fetch.py
+++ b/tests/unit/github/test_github_fetch.py
@@ -1,7 +1,7 @@
 import re
 
+import pytest
 import responses
-from pytest import raises
 
 from git_dev_metrics.github import GitHubAPIError, fetch_repositories
 from git_dev_metrics.github.queries import fetch_pull_requests, fetch_reviews
@@ -48,7 +48,7 @@ class TestFetchRepositories:
             status=200,
         )
 
-        with raises(GitHubAPIError, match="Unauthorized"):
+        with pytest.raises(GitHubAPIError, match="Unauthorized"):
             fetch_repositories("bad-token")
 
     @responses.activate

--- a/tests/unit/github/test_github_pagination.py
+++ b/tests/unit/github/test_github_pagination.py
@@ -1,7 +1,7 @@
 import re
 
+import pytest
 import responses
-from pytest import raises
 
 from git_dev_metrics.github import GitHubAPIError
 from git_dev_metrics.github.graphql_client import execute_paginated_query, get_client
@@ -297,7 +297,7 @@ class TestRetryOnTransientErrors:
             )
 
         client = get_client("fake-token")
-        with raises(GitHubAPIError):
+        with pytest.raises(GitHubAPIError):
             execute_paginated_query(
                 client,
                 REPO_METRICS_QUERY,


### PR DESCRIPTION
Adds four new ruff rule categories and fixes every violation in the existing codebase:

- **RUF022** — requires sorted `__all__` in `__init__.py` files (2 violations fixed)
- **RET501** — bans unnecessary `return None` (1 violation fixed)
- **PT** — pytest-style rules: PT013 catches `from pytest import raises` (2 violations fixed)
- **T20** — `print`/\`pprint\` detection; replaced `print()` with `typer.echo()` in `auth.py` (7 violations fixed)

PT019 (fixture injected as param without using its value) has been added to ignores — it fires falsely on `_stub_webbrowser` whose return value `is` used in every test body.