### PR TITLE
Add bandit security scanner and fix missing requests timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Dead code check
         run: uv run vulture
 
+      - name: Security scan
+        run: uv run bandit -s B105 -r git_dev_metrics
+
       - name: Type check
         run: uv run pyright
 

--- a/git_dev_metrics/github/auth_cache.py
+++ b/git_dev_metrics/github/auth_cache.py
@@ -24,6 +24,7 @@ def is_token_valid(token: str) -> bool:
     response = requests.get(
         "https://api.github.com/user",
         headers={"Authorization": f"token {token}"},
+        timeout=10,
     )
     return response.status_code == 200
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ Repository = "https://github.com/kobbikobb/git-dev-metrics"
 
 [dependency-groups]
 dev = [
+    "bandit>=1.8.0",
     "freezegun>=1.5.5",
     "pip-audit>=2.10.0",
     "pyright>=1.1.408",
@@ -100,3 +101,4 @@ source = ["git_dev_metrics"]
 
 [tool.coverage.report]
 fail_under = 60
+

--- a/uv.lock
+++ b/uv.lock
@@ -36,6 +36,21 @@ wheels = [
 ]
 
 [[package]]
+name = "bandit"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "stevedore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677, upload-time = "2026-02-25T06:44:15.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741, upload-time = "2026-02-25T06:44:13.694Z" },
+]
+
+[[package]]
 name = "boolean-py"
 version = "5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -303,6 +318,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "bandit" },
     { name = "freezegun" },
     { name = "pip-audit" },
     { name = "pyright" },
@@ -330,6 +346,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "bandit", specifier = ">=1.8.0" },
     { name = "freezegun", specifier = ">=1.5.5" },
     { name = "pip-audit", specifier = ">=2.10.0" },
     { name = "pyright", specifier = ">=1.1.408" },
@@ -1030,6 +1047,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "stevedore"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/88/35e4d27d9177d7df76d060e0a18f69c6c5794c96960c94042e20a12c8ba2/stevedore-5.8.0.tar.gz", hash = "sha256:b49867b32ca3016e94100e68dbf26e72aa7b8708d0a3f73c08aeb220370ac715", size = 514710, upload-time = "2026-05-18T09:15:27.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl", hash = "sha256:88eede9e66ca80e34085b9174e2327da2c61ac91f24f70e41c3ad76e4bb4872b", size = 54553, upload-time = "2026-05-18T09:15:25.82Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds bandit to the dev toolchain and fixes the one real issue it found.

**Bug fix:** `requests.get()` at `auth_cache.py:24` had no `timeout` — if GitHub API hangs, the app hangs forever. Added `timeout=10`.

**New CI step:** `uv run bandit` in the lint job, skipping B105 (flags `TOKEN_KEY = "github_token"` as a hardcoded password, but it's a keyring key name, not a password).