### PR TITLE
Move vulture from main deps to dev deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
     "requests>=2.32.5",
     "rich>=14.3.1",
     "typer>=0.21.1",
-    "vulture>=2.16",
 ]
 
 [project.scripts]
@@ -36,6 +35,7 @@ dev = [
     "responses>=0.25.8",
     "ruff>=0.15.0",
     "vcrpy>=8.1.1",
+    "vulture>=2.16",
 ]
 
 [tool.basedpyright]

--- a/uv.lock
+++ b/uv.lock
@@ -298,7 +298,6 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
     { name = "typer" },
-    { name = "vulture" },
 ]
 
 [package.dev-dependencies]
@@ -312,6 +311,7 @@ dev = [
     { name = "responses" },
     { name = "ruff" },
     { name = "vcrpy" },
+    { name = "vulture" },
 ]
 
 [package.metadata]
@@ -325,7 +325,6 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.5" },
     { name = "rich", specifier = ">=14.3.1" },
     { name = "typer", specifier = ">=0.21.1" },
-    { name = "vulture", specifier = ">=2.16" },
 ]
 
 [package.metadata.requires-dev]
@@ -339,6 +338,7 @@ dev = [
     { name = "responses", specifier = ">=0.25.8" },
     { name = "ruff", specifier = ">=0.15.0" },
     { name = "vcrpy", specifier = ">=8.1.1" },
+    { name = "vulture", specifier = ">=2.16" },
 ]
 
 [[package]]


### PR DESCRIPTION
vulture is only used as a CLI tool in CI (uv run vulture), never imported in source code. It was misclassified as a runtime dependency.