### PR TITLE
Enable PERF401, PTH123, TRY300 ruff rules and fix violations

### DIFF
--- a/git_dev_metrics/cache/db.py
+++ b/git_dev_metrics/cache/db.py
@@ -109,21 +109,19 @@ def _pr_row(pr: Mapping[str, Any], org: str, repo: str, year: int, month: int) -
 
 
 def _review_rows(pr: Mapping[str, Any], org: str, repo: str, year: int, month: int) -> list[tuple]:
-    rows = []
-    for review in pr.get("reviews") or []:
-        rows.append(
-            (
-                pr.get("number"),
-                org,
-                repo,
-                year,
-                month,
-                (review.get("user") or {}).get("login"),
-                review.get("state"),
-                _iso(review.get("submitted_at")),
-            )
+    return [
+        (
+            pr.get("number"),
+            org,
+            repo,
+            year,
+            month,
+            (review.get("user") or {}).get("login"),
+            review.get("state"),
+            _iso(review.get("submitted_at")),
         )
-    return rows
+        for review in pr.get("reviews") or []
+    ]
 
 
 def insert_prs(

--- a/git_dev_metrics/github/graphql_client.py
+++ b/git_dev_metrics/github/graphql_client.py
@@ -57,7 +57,6 @@ def execute_query(
     for attempt in range(TRANSIENT_RETRY_ATTEMPTS):
         try:
             result = client.execute(query, variable_values=variables)
-            return result if result is not None else {}
         except transport_exceptions.TransportQueryError as e:
             _handle_graphql_error(e)
             return {}  # unreachable but needed for type checker
@@ -71,6 +70,8 @@ def execute_query(
                 last_exc = e
                 continue
             raise GitHubAPIError(f"GitHub API error: {e}") from e
+        else:
+            return result if result is not None else {}
     raise GitHubAPIError(f"GitHub API error after retries: {last_exc}") from last_exc
 
 

--- a/git_dev_metrics/metrics/printer/html.py
+++ b/git_dev_metrics/metrics/printer/html.py
@@ -89,7 +89,7 @@ class FileHtmlPrinter:
 
         html_path = self._output_path.with_suffix(".html")
         html_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(html_path, "w") as f:
+        with html_path.open("w") as f:
             f.write(html)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ select = [
     "C901",  # max function complexity (nesting/branching)
     "RUF022",# sorted __all__
     "RET501",# unnecessary return None
+    "PERF401",# list comprehension
+    "PTH123", # Path.open()
+    "TRY300", # try/except/else
     "PT",    # pytest-style
     "T20",   # print/pprint detection
 ]


### PR DESCRIPTION
Three low-churn ruff rules, three corresponding fixes:

- **PERF401** — list comprehension instead of manual append loop in `cache/db.py:114` (`_review_rows`)
- **PTH123** — `Path.open()` instead of builtin `open()` in `metrics/printer/html.py:92`
- **TRY300** — move `return` to `else` block in `github/graphql_client.py:60`