### PR TITLE
Add __main__.py to enable python -m execution

### DIFF
--- a/git_dev_metrics/__main__.py
+++ b/git_dev_metrics/__main__.py
@@ -1,0 +1,3 @@
+from .cli import app
+
+app()


### PR DESCRIPTION
Missing __main__.py meant 'python -m git_dev_metrics' failed with 'No module named __main__'. Added 3-line __main__.py that delegates to the Typer app.