### PR TITLE
Remove redundant ruff format command in format.sh

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -6,9 +6,6 @@ echo "Running ruff check --fix..."
 uv run ruff check git_dev_metrics --fix
 
 echo "Running ruff format..."
-uv run ruff format git_dev_metrics
-
-echo "Running ruff format on tests..."
 uv run ruff format git_dev_metrics tests
 
 echo "Code formatting complete!"


### PR DESCRIPTION
format.sh ran 'ruff format git_dev_metrics' twice — once standalone and once in the combined 'ruff format git_dev_metrics tests' command. Removed the redundant middle command.