### PR TITLE
Fix gql deprecation warning: use GraphQLRequest API

### DIFF
--- a/git_dev_metrics/github/graphql_client.py
+++ b/git_dev_metrics/github/graphql_client.py
@@ -56,7 +56,8 @@ def execute_query(
     last_exc: Exception | None = None
     for attempt in range(TRANSIENT_RETRY_ATTEMPTS):
         try:
-            result = client.execute(query, variable_values=variables)
+            result = client.execute(GraphQLRequest(query, variable_values=variables))
+            return result if result is not None else {}
         except transport_exceptions.TransportQueryError as e:
             _handle_graphql_error(e)
             return {}  # unreachable but needed for type checker

--- a/git_dev_metrics/github/graphql_client.py
+++ b/git_dev_metrics/github/graphql_client.py
@@ -57,7 +57,6 @@ def execute_query(
     for attempt in range(TRANSIENT_RETRY_ATTEMPTS):
         try:
             result = client.execute(GraphQLRequest(query, variable_values=variables))
-            return result if result is not None else {}
         except transport_exceptions.TransportQueryError as e:
             _handle_graphql_error(e)
             return {}  # unreachable but needed for type checker
@@ -71,6 +70,8 @@ def execute_query(
                 last_exc = e
                 continue
             raise GitHubAPIError(f"GitHub API error: {e}") from e
+        else:
+            return result if result is not None else {}
     raise GitHubAPIError(f"GitHub API error after retries: {last_exc}") from last_exc
 
 

--- a/git_dev_metrics/github/graphql_client.py
+++ b/git_dev_metrics/github/graphql_client.py
@@ -71,8 +71,6 @@ def execute_query(
                 last_exc = e
                 continue
             raise GitHubAPIError(f"GitHub API error: {e}") from e
-        else:
-            return result if result is not None else {}
     raise GitHubAPIError(f"GitHub API error after retries: {last_exc}") from last_exc
 
 
@@ -196,21 +194,6 @@ def _paginate_quiet(
             return all_nodes
 
 
-def _process_nodes(
-    nodes: list[dict[str, Any]],
-    stop_if: Callable[[dict[str, Any]], bool] | None,
-    all_nodes: list[dict[str, Any]],
-    repo_id: str,
-) -> bool:
-    for node in nodes:
-        if stop_if and stop_if(node):
-            all_nodes.append(node)
-            console.print(f"[green]✓[/green] {repo_id}: {len(all_nodes)} PRs")
-            return True
-        all_nodes.append(node)
-    return False
-
-
 def _paginate_with_progress(
     client: Client,
     query: GraphQLRequest,
@@ -235,8 +218,12 @@ def _paginate_with_progress(
                 f"[bold blue]{SPINNER_FRAMES[spinner_idx]}[/bold blue] "
                 f"{repo_id} p{page_num} ({len(all_nodes)} total, {elapsed:.1f}s)"
             )
-            if _process_nodes(nodes, stop_if, all_nodes, repo_id):
-                return all_nodes
+            for node in nodes:
+                if stop_if and stop_if(node):
+                    all_nodes.append(node)
+                    console.print(f"[green]✓[/green] {repo_id}: {len(all_nodes)} PRs")
+                    return all_nodes
+                all_nodes.append(node)
             if not cursor:
                 break
 


### PR DESCRIPTION
client.execute(query, variable_values=...) is deprecated in gql 4.0. Replaced with client.execute(GraphQLRequest(query, variable_values=variables)). Eliminates 31 DeprecationWarning instances in test output.