### PR TITLE
Config cleanup: remove dead setuptools, deduplicate pyright, misc fixes

### DIFF
--- a/git_dev_metrics/cli/commands/logout.py
+++ b/git_dev_metrics/cli/commands/logout.py
@@ -2,7 +2,7 @@ import logging
 
 import typer
 
-from git_dev_metrics.github.auth_cache import delete_token
+from ...github.auth_cache import delete_token
 
 logger = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,13 +49,6 @@ package = true
 override-dependencies = ["idna>=3.15"]
 
 
-[tool.setuptools.packages.find]
-exclude = ["metrics_results", "tests*"]
-
-[tool.setuptools]
-license-files = ["LICENSE"]
-
-
 [tool.ruff]
 line-length = 100
 target-version = "py314"

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,4 +1,0 @@
-{
-  "venvPath": ".",
-  "venv": ".venv"
-}

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -10,7 +10,7 @@ from git_dev_metrics.models import PullRequest
 freezegun.configure(default_ignore_list=[])
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def _stub_webbrowser(mocker):
     return mocker.patch("webbrowser.open", return_value=False)
 


### PR DESCRIPTION
Four cleanup changes:
- Remove dead [tool.setuptools] config (uv-project)
- Delete redundant pyrightconfig.json
- Fix logout.py to use relative import like sibling commands
- Remove autouse=True from _stub_webbrowser fixture (only 8/70+ tests need it)