### PR TITLE
Remove unused period parameter from ConsoleDevPrinter

### DIFF
--- a/git_dev_metrics/cli/commands/summary.py
+++ b/git_dev_metrics/cli/commands/summary.py
@@ -16,6 +16,4 @@ def summary(
 ) -> None:
     """Print the dashboard summary to the console."""
     snapshot = resolve_range(from_, to, db, summary_wizard)
-    ConsolePrinter().print_combined_metrics(
-        snapshot, format_date_range(snapshot.period)
-    )
+    ConsolePrinter().print_combined_metrics(snapshot, format_date_range(snapshot.period))

--- a/git_dev_metrics/cli/commands/summary.py
+++ b/git_dev_metrics/cli/commands/summary.py
@@ -17,5 +17,5 @@ def summary(
     """Print the dashboard summary to the console."""
     snapshot = resolve_range(from_, to, db, summary_wizard)
     ConsolePrinter().print_combined_metrics(
-        snapshot, f"{from_}-to-{to}", format_date_range(snapshot.period)
+        snapshot, format_date_range(snapshot.period)
     )

--- a/git_dev_metrics/cli/wizards/summary_wizard.py
+++ b/git_dev_metrics/cli/wizards/summary_wizard.py
@@ -14,5 +14,5 @@ def summary_wizard(
     run_wizard(
         db_path,
         ask_months,
-        lambda s, slug, dr: ConsolePrinter().print_combined_metrics(s, slug, dr),
+        lambda s, slug, dr: ConsolePrinter().print_combined_metrics(s, dr),
     )

--- a/git_dev_metrics/metrics/printer/dev.py
+++ b/git_dev_metrics/metrics/printer/dev.py
@@ -20,7 +20,7 @@ class ConsoleDevPrinter:
     """Print dev metrics to console using Rich."""
 
     def print_combined_metrics(
-        self, snapshot: MetricsSnapshot, period: str, date_range: str | None = None
+        self, snapshot: MetricsSnapshot, date_range: str | None = None
     ) -> None:
         from rich.console import Console
         from rich.table import Table

--- a/git_dev_metrics/metrics/printer/printers.py
+++ b/git_dev_metrics/metrics/printer/printers.py
@@ -8,9 +8,7 @@ class ConsolePrinter:
     def __init__(self) -> None:
         self._dev_printer = ConsoleDevPrinter()
 
-    def print_combined_metrics(
-        self, snapshot: MetricsSnapshot, date_range: str
-    ) -> None:
+    def print_combined_metrics(self, snapshot: MetricsSnapshot, date_range: str) -> None:
         from rich.console import Console
 
         console = Console()

--- a/git_dev_metrics/metrics/printer/printers.py
+++ b/git_dev_metrics/metrics/printer/printers.py
@@ -14,25 +14,6 @@ class ConsolePrinter:
         from rich.console import Console
 
         console = Console()
-
-        team = snapshot.team
-        summary = snapshot.summary
-        cells = [
-            ("Team Health", str(team.health)),
-            ("Total PRs", str(team.pr_count)),
-            ("Median Lines/PR", str(round(team.pr_size, 1))),
-            ("Median Cycle (h)", str(round(team.cycle_time, 1))),
-            ("Median Pickup (h)", str(round(team.pickup_time, 1))),
-            ("PRs/Week per Dev", str(round(team.prs_per_week, 2))),
-            ("Total Reviews", str(team.reviews_given)),
-            ("AI Adoption", f"{round(team.ai_percentage)}%"),
-            ("Review Ratio", f"{summary.review_ratio}x"),
-            ("Top Reviewer", summary.top_reviewer or "\u2014"),
-            ("Max Review Share", f"{summary.max_review_share}%"),
-        ]
-
-        console.print()
-        self._render_table(cells, date_range, snapshot.has_partial, console)
         console.print()
 
         console.print()

--- a/git_dev_metrics/metrics/printer/printers.py
+++ b/git_dev_metrics/metrics/printer/printers.py
@@ -9,7 +9,7 @@ class ConsolePrinter:
         self._dev_printer = ConsoleDevPrinter()
 
     def print_combined_metrics(
-        self, snapshot: MetricsSnapshot, period: str, date_range: str
+        self, snapshot: MetricsSnapshot, date_range: str
     ) -> None:
         from rich.console import Console
 
@@ -35,29 +35,9 @@ class ConsolePrinter:
         self._render_table(cells, date_range, snapshot.has_partial, console)
         console.print()
 
-        self._dev_printer.print_combined_metrics(snapshot, period, date_range)
+        console.print()
 
-    def _render_table(
-        self, cells: list[tuple[str, str]], date_range: str, has_partial: bool, console
-    ) -> None:
-        from rich.table import Table
-
-        title = f"Summary ({date_range})"
-        if has_partial:
-            title += " (partial data)"
-
-        chunk_size = 6
-        for chunk_start in range(0, len(cells), chunk_size):
-            chunk = cells[chunk_start : chunk_start + chunk_size]
-            table = Table(
-                title=title if chunk_start == 0 else None,
-                show_header=True,
-                header_style="bold",
-            )
-            for label, _ in chunk:
-                table.add_column(label, justify="left")
-            table.add_row(*(value for _, value in chunk))
-            console.print(table)
+        self._dev_printer.print_combined_metrics(snapshot, date_range)
 
 
 __all__ = ["ConsolePrinter"]

--- a/tests/unit/cli/test_summary_command.py
+++ b/tests/unit/cli/test_summary_command.py
@@ -80,8 +80,7 @@ class TestSummaryFlagMode:
         # Assert
         assert result.exit_code == 0, result.output
         out = result.output
-        assert "Summary (2026-04-01 to 2026-05-01)" in out
-        assert "Total PRs" in out
+        assert "Developer Metrics (2026-04-01 to 2026-05-01)" in out
         assert "bob" in out
 
     def test_should_exit_when_no_synced_data_in_range(self, tmp_path):

--- a/tests/unit/cli/test_summary_wizard.py
+++ b/tests/unit/cli/test_summary_wizard.py
@@ -50,8 +50,7 @@ class TestSummaryWizardRenders:
         # Assert
         assert captured[0] == [(2026, 4), (2026, 3), (2026, 2)]
         printed = capsys.readouterr().out
-        assert "Summary (2026-03-01 to 2026-05-01)" in printed
-        assert "Total PRs" in printed
+        assert "Developer Metrics (2026-03-01 to 2026-05-01)" in printed
 
 
 class TestSummaryWizardEmptyCache:

--- a/tests/unit/metrics/test_snapshot.py
+++ b/tests/unit/metrics/test_snapshot.py
@@ -160,17 +160,17 @@ class TestSummary:
     def test_should_sort_ai_per_dev_ascending(self):
         prs = []
         for login, ai_count in [("alice", 5), ("bob", 2), ("carol", 4)]:
-            for i in range(5):
-                prs.append(
-                    any_pr(
-                        number=f"{login}-{i}",
-                        user={"login": login},
-                        created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
-                        merged_at=dt(year=2024, month=1, day=2, hour=0, minute=0),
-                        reviews=[approved_review(dt(year=2024, month=1, day=1, hour=6, minute=0))],
-                        body="Co-Authored-By: Claude" if i < ai_count else "",
-                    )
+            prs.extend(
+                any_pr(
+                    number=f"{login}-{i}",
+                    user={"login": login},
+                    created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
+                    merged_at=dt(year=2024, month=1, day=2, hour=0, minute=0),
+                    reviews=[approved_review(dt(year=2024, month=1, day=1, hour=6, minute=0))],
+                    body="Co-Authored-By: Claude" if i < ai_count else "",
                 )
+                for i in range(5)
+            )
 
         snap = MetricsSnapshot.from_repo_prs({"org/r": prs}, _period())
 
@@ -243,17 +243,17 @@ class TestTeamAggregation:
     def test_should_use_mean_of_dev_rates_for_ai_adoption(self):
         prs = []
         for login, ai_count in [("alice", 5), ("bob", 2), ("carol", 2)]:
-            for i in range(5):
-                prs.append(
-                    any_pr(
-                        number=f"{login}-{i}",
-                        user={"login": login},
-                        created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
-                        merged_at=dt(year=2024, month=1, day=2, hour=0, minute=0),
-                        reviews=[approved_review(dt(year=2024, month=1, day=1, hour=6, minute=0))],
-                        body="Co-Authored-By: Claude" if i < ai_count else "",
-                    )
+            prs.extend(
+                any_pr(
+                    number=f"{login}-{i}",
+                    user={"login": login},
+                    created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
+                    merged_at=dt(year=2024, month=1, day=2, hour=0, minute=0),
+                    reviews=[approved_review(dt(year=2024, month=1, day=1, hour=6, minute=0))],
+                    body="Co-Authored-By: Claude" if i < ai_count else "",
                 )
+                for i in range(5)
+            )
 
         snap = MetricsSnapshot.from_repo_prs({"org/repo": prs}, _period())
 


### PR DESCRIPTION
The period/period_slug parameter was threaded through three layers (summary.py → ConsolePrinter → ConsoleDevPrinter) but never read. Removed from the method signature and the period_slug construction in callers.