### PR TITLE
Deduplicate --db option into shared DB_OPTION constant

### DIFF
--- a/git_dev_metrics/cli/_options.py
+++ b/git_dev_metrics/cli/_options.py
@@ -1,0 +1,3 @@
+import typer
+
+DB_OPTION = typer.Option(None, "--db", help="Override cache database path")

--- a/git_dev_metrics/cli/commands/clear.py
+++ b/git_dev_metrics/cli/commands/clear.py
@@ -3,11 +3,12 @@ from pathlib import Path
 import typer
 
 from ...cache import close_connection, default_db_path
+from .._options import DB_OPTION
 
 
 def clear(
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip the confirmation prompt"),
-    db: Path | None = typer.Option(None, "--db", help="Override cache database path"),
+    db: Path | None = DB_OPTION,
 ) -> None:
     """Delete the entire local cache database."""
     path = db or default_db_path()

--- a/git_dev_metrics/cli/commands/dashboard.py
+++ b/git_dev_metrics/cli/commands/dashboard.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import typer
 
+from .._options import DB_OPTION
 from ..runners.dashboard_runner import write_and_open_dashboard
 from ..utils._date_formatter import format_date_range
 from ..wizards.dashboard_wizard import dashboard_wizard
@@ -12,7 +13,7 @@ def dashboard(
     from_: str | None = typer.Option(None, "--from", help="Start month, YYYY-MM"),
     to: str | None = typer.Option(None, "--to", help="End month, YYYY-MM"),
     output: Path | None = typer.Option(None, "--output", help="Output HTML path"),
-    db: Path | None = typer.Option(None, "--db", help="Override cache database path"),
+    db: Path | None = DB_OPTION,
 ) -> None:
     """Render the in-depth HTML dashboard and open it in the browser."""
     snapshot = resolve_range(from_, to, db, dashboard_wizard)

--- a/git_dev_metrics/cli/commands/pull.py
+++ b/git_dev_metrics/cli/commands/pull.py
@@ -7,6 +7,7 @@ from ...cache import is_sealed
 from ...github import get_github_token
 from ...utils.date_utils import month_range
 from .._month_arg import parse_month_arg
+from .._options import DB_OPTION
 from ..runners.pull_runner import fetch_and_seal_month
 from ..wizards.pull_wizard import pull_wizard
 
@@ -43,7 +44,7 @@ def pull(
     re_pull: bool = typer.Option(
         False, "--re-pull", help="Re-fetch even if month is already sealed"
     ),
-    db: Path | None = typer.Option(None, "--db", help="Override cache database path"),
+    db: Path | None = DB_OPTION,
 ) -> None:
     """Pull a month of PRs for one repository into the cache."""
     if month is None and org is None and repo is None:

--- a/git_dev_metrics/cli/commands/stale.py
+++ b/git_dev_metrics/cli/commands/stale.py
@@ -8,6 +8,7 @@ from ...github import fetch_open_prs, get_github_token
 from ...metrics._stale_pr import StalePr, get_stale_prs
 from ...metrics.printer.stale import FileStaleHtmlPrinter
 from .._browser import open_in_browser
+from .._options import DB_OPTION
 
 
 def _default_output() -> Path:
@@ -17,7 +18,7 @@ def _default_output() -> Path:
 
 def stale(
     output: Path | None = typer.Option(None, "--output", help="Output HTML path"),
-    db: Path | None = typer.Option(None, "--db", help="Override cache database path"),
+    db: Path | None = DB_OPTION,
 ) -> None:
     """Find stale open PRs across all cached repos."""
     repos = sorted({(org, repo) for org, repo, *_ in list_synced_months(db_path=db)})

--- a/git_dev_metrics/cli/commands/summary.py
+++ b/git_dev_metrics/cli/commands/summary.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import typer
 
 from ...metrics.printer import ConsolePrinter
+from .._options import DB_OPTION
 from ..utils._date_formatter import format_date_range
 from ..wizards.summary_wizard import summary_wizard
 from ._resolve_range import resolve_range
@@ -11,7 +12,7 @@ from ._resolve_range import resolve_range
 def summary(
     from_: str | None = typer.Option(None, "--from", help="Start month, YYYY-MM"),
     to: str | None = typer.Option(None, "--to", help="End month, YYYY-MM"),
-    db: Path | None = typer.Option(None, "--db", help="Override cache database path"),
+    db: Path | None = DB_OPTION,
 ) -> None:
     """Print the dashboard summary to the console."""
     snapshot = resolve_range(from_, to, db, summary_wizard)

--- a/git_dev_metrics/cli/commands/trend.py
+++ b/git_dev_metrics/cli/commands/trend.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import typer
 
 from .._month_arg import parse_month_arg
+from .._options import DB_OPTION
 from ..runners.trend_runner import perform_trend
 from ..wizards.trend_wizard import trend_wizard
 
@@ -11,7 +12,7 @@ def trend(
     from_: str | None = typer.Option(None, "--from", help="Start month, YYYY-MM"),
     to: str | None = typer.Option(None, "--to", help="End month, YYYY-MM"),
     output: Path | None = typer.Option(None, "--output", help="Output HTML path"),
-    db: Path | None = typer.Option(None, "--db", help="Override cache database path"),
+    db: Path | None = DB_OPTION,
 ) -> None:
     """Render a multi-month trend HTML aggregated across all cached repos."""
     if from_ is None and to is None:


### PR DESCRIPTION
The --db option was declared identically in 6 command files. Extracted to cli/_options.py as DB_OPTION, cutting 5 redundant lines.