### PR TITLE
Add lang-report: PR distribution by language

### DIFF
--- a/git_dev_metrics/cli/commands/app.py
+++ b/git_dev_metrics/cli/commands/app.py
@@ -2,6 +2,7 @@ import typer
 
 from .clear import clear
 from .dashboard import dashboard
+from .lang_report import lang_report
 from .logout import logout
 from .pull import pull
 from .skill_report import skill_report
@@ -22,6 +23,7 @@ def main(ctx: typer.Context) -> None:
 app.command()(clear)
 app.command()(dashboard)
 app.command()(skill_report)
+app.command()(lang_report)
 app.command()(logout)
 app.command()(pull)
 app.command()(stale)

--- a/git_dev_metrics/cli/commands/lang_report.py
+++ b/git_dev_metrics/cli/commands/lang_report.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import typer
+
+from ...utils.date_utils import month_iter
+from .._month_arg import parse_month_arg
+from ..runners.lang_runner import perform_lang_report
+from ..wizards.lang_wizard import lang_wizard
+
+
+def lang_report(
+    from_: str | None = typer.Option(None, "--from", help="Start month, YYYY-MM"),
+    to: str | None = typer.Option(None, "--to", help="End month, YYYY-MM"),
+    output: Path | None = typer.Option(None, "--output", help="Output HTML path"),
+    db: Path | None = typer.Option(None, "--db", help="Override cache database path"),
+) -> None:
+    """Render a language breakdown report for selected months."""
+    if from_ is None and to is None:
+        lang_wizard(db_path=db)
+        return
+
+    if from_ is None or to is None:
+        typer.secho(
+            "Provide both --from and --to, or neither (for the wizard).",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    from_ym = parse_month_arg(from_, "--from")
+    to_ym = parse_month_arg(to, "--to")
+    if to_ym < from_ym:
+        typer.secho("--to must be >= --from.", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=1)
+
+    months = month_iter(from_ym, to_ym)
+    perform_lang_report(months, output=output, db_path=db)

--- a/git_dev_metrics/cli/runners/lang_runner.py
+++ b/git_dev_metrics/cli/runners/lang_runner.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+from pathlib import Path
+
+import typer
+
+from ...cache import list_synced_months
+from ...github.auth_cache import load_token
+from ...github.queries import fetch_lang_report_prs
+from ...metrics.lang_calculator import build_lang_dataset
+from ...metrics.printer.lang import FileLangPrinter
+from .._browser import open_in_browser
+
+YearMonth = tuple[int, int]
+
+
+def _default_output(months: list[YearMonth]) -> Path:
+    first, last = months[0], months[-1]
+    return Path(
+        f"./metrics_results/lang_{first[0]:04d}-{first[1]:02d}_to_{last[0]:04d}-{last[1]:02d}.html"
+    )
+
+
+def perform_lang_report(months: list[YearMonth], output: Path | None, db_path: Path | None) -> None:
+    token = load_token()
+    if not token:
+        typer.secho("No GitHub token found. Run login first.", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=1)
+
+    synced = list_synced_months(db_path=db_path)
+    wanted = set(months)
+    all_prs: list[dict] = []
+    seen_ids: set[int] = set()
+
+    for org, repo, year, month in synced:
+        if (year, month) not in wanted:
+            continue
+        for pr in fetch_lang_report_prs(token, org, repo, year, month):
+            n = pr["number"]
+            if n not in seen_ids:
+                seen_ids.add(n)
+                all_prs.append(pr)
+
+    if not all_prs:
+        typer.secho("No PRs found for selected months.", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=1)
+
+    dataset = build_lang_dataset(all_prs)
+    first, last = months[0], months[-1]
+    period_range = (
+        f"{datetime(first[0], first[1], 1).strftime('%b %Y')}"
+        f" – {datetime(last[0], last[1], 1).strftime('%b %Y')}"
+    )
+    out_path = output or _default_output(months)
+    FileLangPrinter(out_path).render(dataset, period_range)
+    typer.echo(f"Language report written to {out_path}.")
+    open_in_browser(out_path)

--- a/git_dev_metrics/cli/wizards/lang_wizard.py
+++ b/git_dev_metrics/cli/wizards/lang_wizard.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+from ..runners.lang_runner import perform_lang_report
+from ._wizard import pick_months
+
+
+def lang_wizard(db_path: Path | None = None) -> None:
+    selected = pick_months(db_path)
+    perform_lang_report(selected, output=None, db_path=db_path)

--- a/git_dev_metrics/github/graphql_queries.py
+++ b/git_dev_metrics/github/graphql_queries.py
@@ -161,6 +161,7 @@ SKILL_REPORT_QUERY = gql.gql(
             pageInfo { hasNextPage endCursor }
         }
     }
+    """
 )
 
 LANG_REPORT_QUERY = gql.gql(
@@ -179,8 +180,8 @@ LANG_REPORT_QUERY = gql.gql(
             pageInfo { hasNextPage endCursor }
         }
     }
+    """
 )
-
 
 SEARCH_MERGED_PRS_QUERY = gql.gql(
     """

--- a/git_dev_metrics/github/graphql_queries.py
+++ b/git_dev_metrics/github/graphql_queries.py
@@ -161,7 +161,24 @@ SKILL_REPORT_QUERY = gql.gql(
             pageInfo { hasNextPage endCursor }
         }
     }
+)
+
+LANG_REPORT_QUERY = gql.gql(
     """
+    query LangReportQuery($query: String!, $first: Int!, $after: String) {
+        search(query: $query, type: ISSUE, first: $first, after: $after) {
+            nodes {
+                ... on PullRequest {
+                    number
+                    author { login }
+                    files(first: 100) {
+                        nodes { path additions deletions }
+                    }
+                }
+            }
+            pageInfo { hasNextPage endCursor }
+        }
+    }
 )
 
 

--- a/git_dev_metrics/github/queries.py
+++ b/git_dev_metrics/github/queries.py
@@ -9,6 +9,7 @@ from ._response_mapper import (
 )
 from .graphql_client import execute_paginated_query, get_client
 from .graphql_queries import (
+    LANG_REPORT_QUERY,
     OPEN_PRS_QUERY,
     ORG_REPOSITORIES_QUERY,
     REPO_METRICS_QUERY,
@@ -127,6 +128,7 @@ def fetch_repo_metrics(token: str, org: str, repo: str, period: TimePeriod) -> l
 
 
 def _map_open_prs(prs: list[dict]) -> list[OpenPullRequest]:
+    """Map raw GraphQL PR nodes to OpenPullRequest model."""
     result: list[OpenPullRequest] = []
     for pr in prs:
         number = pr.get("number")
@@ -161,6 +163,45 @@ def fetch_skill_report_prs(token: str, org: str, repo: str, year: int, month: in
     nodes = execute_paginated_query(
         client,
         SKILL_REPORT_QUERY,
+        {"query": query_str, "first": 25},
+        "search",
+        repo_id=f"{org}/{repo}",
+    )
+
+    result: list[dict] = []
+    for node in nodes:
+        files_raw = (node.get("files") or {}).get("nodes") or []
+        result.append(
+            {
+                "number": node.get("number"),
+                "user": {"login": map_author_login(node.get("author"))},
+                "files": [
+                    {
+                        "path": f["path"],
+                        "additions": f.get("additions", 0),
+                        "deletions": f.get("deletions", 0),
+                    }
+                    for f in files_raw
+                ],
+            }
+        )
+    return result
+
+
+def fetch_lang_report_prs(
+    token: str, org: str, repo: str, year: int, month: int
+) -> list[dict]:
+    """Fetch merged PRs with file paths for a given month. Returns lightweight dicts."""
+    from ..utils.date_utils import month_range
+
+    client = get_client(token)
+    period = month_range(year, month)
+    since_s = period.since.strftime("%Y-%m-%d")
+    until_s = period.until.strftime("%Y-%m-%d")
+    query_str = f"repo:{org}/{repo} is:pr merged:{since_s}..{until_s}"
+    nodes = execute_paginated_query(
+        client,
+        LANG_REPORT_QUERY,
         {"query": query_str, "first": 25},
         "search",
         repo_id=f"{org}/{repo}",

--- a/git_dev_metrics/github/queries.py
+++ b/git_dev_metrics/github/queries.py
@@ -188,9 +188,7 @@ def fetch_skill_report_prs(token: str, org: str, repo: str, year: int, month: in
     return result
 
 
-def fetch_lang_report_prs(
-    token: str, org: str, repo: str, year: int, month: int
-) -> list[dict]:
+def fetch_lang_report_prs(token: str, org: str, repo: str, year: int, month: int) -> list[dict]:
     """Fetch merged PRs with file paths for a given month. Returns lightweight dicts."""
     from ..utils.date_utils import month_range
 

--- a/git_dev_metrics/metrics/lang_calculator.py
+++ b/git_dev_metrics/metrics/lang_calculator.py
@@ -1,0 +1,99 @@
+from collections import defaultdict
+from dataclasses import dataclass, field
+
+from ..constants import is_bot_login
+
+LANG_MAP: dict[str, str] = {
+    ".py": "Python",
+    ".ts": "TypeScript",
+    ".tsx": "TypeScript",
+    ".js": "JavaScript",
+    ".jsx": "JavaScript",
+    ".go": "Go",
+    ".rs": "Rust",
+    ".java": "Java",
+    ".kt": "Kotlin",
+    ".swift": "Swift",
+    ".rb": "Ruby",
+    ".php": "PHP",
+    ".c": "C",
+    ".cpp": "C++",
+    ".h": "C",
+    ".cs": "C#",
+    ".scala": "Scala",
+    ".tf": "Terraform",
+    ".tfvars": "Terraform",
+    ".yml": "YAML",
+    ".yaml": "YAML",
+    ".json": "JSON",
+    ".md": "Documentation",
+    ".rst": "Documentation",
+    ".sql": "SQL",
+    ".sh": "Shell",
+    ".bash": "Shell",
+    ".zsh": "Shell",
+    ".dockerfile": "Docker",
+    ".html": "HTML",
+    ".css": "CSS",
+    ".scss": "CSS",
+    ".less": "CSS",
+    ".xml": "XML",
+    ".gradle": "Groovy",
+    ".proto": "Protobuf",
+}
+
+_BASENAME_MAP: dict[str, str] = {
+    "Dockerfile": "Docker",
+    "Makefile": "Make",
+    "CMakeLists.txt": "Make",
+    "compose.yml": "YAML",
+    "compose.yaml": "YAML",
+}
+
+
+def _classify(path: str) -> str:
+    for basename, lang in _BASENAME_MAP.items():
+        if path.endswith(basename):
+            return lang
+    _, _, ext = path.rpartition(".")
+    return LANG_MAP.get(f".{ext}", "Other")
+
+
+@dataclass
+class LangDataset:
+    dev_langs: dict[str, dict[str, int]] = field(
+        default_factory=lambda: defaultdict(lambda: defaultdict(int))
+    )
+    devs: list[str] = field(default_factory=list)
+    langs: list[str] = field(default_factory=list)
+
+    @property
+    def team_langs(self) -> dict[str, int]:
+        out: dict[str, int] = defaultdict(int)
+        for dev_data in self.dev_langs.values():
+            for lang, count in dev_data.items():
+                out[lang] += count
+        return dict(out)
+
+    def _finalize(self) -> None:
+        self.devs = sorted(self.dev_langs)
+        all_langs: set[str] = set()
+        for data in self.dev_langs.values():
+            all_langs.update(data)
+        self.langs = sorted(all_langs)
+
+
+def build_lang_dataset(prs: list[dict]) -> LangDataset:
+    ds = LangDataset()
+    for pr in prs:
+        login = pr.get("user", {}).get("login", "")
+        if is_bot_login(login):
+            continue
+        seen: set[str] = set()
+        for f in pr.get("files", []):
+            lang = _classify(f.get("path", ""))
+            if lang not in seen:
+                seen.add(lang)
+                ds.dev_langs[login][lang] += 1
+    ds._finalize()
+    return ds

--- a/git_dev_metrics/metrics/printer/lang.py
+++ b/git_dev_metrics/metrics/printer/lang.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from ..lang_calculator import LangDataset
+from ._html_templates import render_template
+
+
+class FileLangPrinter:
+    def __init__(self, output_path: Path) -> None:
+        self._output_path = output_path
+
+    def render(self, dataset: LangDataset, period_range: str) -> None:
+        html = render_template(
+            "lang.html",
+            period_range=period_range,
+            devs=dataset.devs,
+            langs=dataset.langs,
+            dev_langs={k: dict(v) for k, v in dataset.dev_langs.items()},
+            team_langs=dataset.team_langs,
+        )
+        self._output_path.parent.mkdir(parents=True, exist_ok=True)
+        self._output_path.write_text(html)
+
+
+__all__ = ["FileLangPrinter"]

--- a/git_dev_metrics/metrics/printer/templates/lang.html
+++ b/git_dev_metrics/metrics/printer/templates/lang.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Language Report</title>
+<style>
+  :root {
+    --bg: #0f1117;
+    --card: #1a1d27;
+    --border: #2a2d3a;
+    --text: #e1e4ed;
+    --muted: #8b8fa3;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    padding: 2rem;
+  }
+  .header { text-align: center; margin-bottom: 2rem; }
+  .header h1 { font-size: 1.5rem; letter-spacing: -0.02em; }
+  .header p { color: var(--muted); font-size: 0.875rem; margin-top: 0.25rem; }
+  .grid {
+    display: grid;
+    gap: 1.5rem;
+    max-width: 1200px;
+    margin: 0 auto;
+  }
+  .card {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.25rem;
+  }
+  .card h2 { font-size: 1rem; margin-bottom: 0.75rem; }
+  .chart-wrap { position: relative; height: 360px; display: flex; justify-content: center; }
+  .pie-wrap { max-width: 400px; margin: 0 auto; }
+  table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; }
+  th { text-align: left; padding: 0.5rem; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted); font-weight: 500; border-bottom: 1px solid var(--border); }
+  td { padding: 0.5rem; font-size: 0.8rem; border-bottom: 1px solid var(--border); }
+  td:first-child { font-weight: 600; }
+  tr:last-child td { border-bottom: none; }
+  .total-row td { border-top: 2px solid var(--border); font-weight: 700; }
+</style>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+</head>
+<body>
+<div class="header">
+  <h1>Language Report</h1>
+  <p>{{ period_range }}</p>
+</div>
+<div class="grid">
+  <div class="card"><h2>PRs by Language (team)</h2><div class="chart-wrap pie-wrap"><canvas id="teamPie"></canvas></div></div>
+  <div class="card"><h2>Language Breakdown per Developer</h2><div class="chart-wrap"><canvas id="devBar"></canvas></div></div>
+  <div class="card">
+    <h2>PRs by Language per Developer</h2>
+    <table>
+      <thead><tr><th>Developer</th>{% for lang in langs %}<th>{{ lang }}</th>{% endfor %}</tr></thead>
+      <tbody>
+        {% for dev in devs %}
+        <tr><td>{{ dev }}</td>{% for lang in langs %}<td>{{ dev_langs.get(dev, {}).get(lang, 0) }}</td>{% endfor %}</tr>
+        {% endfor %}
+        <tr class="total-row"><td>Total</td>{% for lang in langs %}<td>{{ team_langs.get(lang, 0) }}</td>{% endfor %}</tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+<script>
+const palette = ['#6366f1','#22c55e','#eab308','#ef4444','#06b6d4','#f97316','#3b82f6','#a855f7','#14b8a6','#ec4899','#84cc16','#0ea5e9','#d946ef','#10b981','#f43f5e'];
+const TEAM = {{ team_langs | tojson }};
+const DEVS = {{ devs | tojson }};
+const LANGS = {{ langs | tojson }};
+const DEV_LANGS = {{ dev_langs | tojson }};
+
+new Chart(document.getElementById('teamPie'), {
+  type: 'doughnut',
+  data: {
+    labels: LANGS,
+    datasets: [{ data: LANGS.map(l => TEAM[l] || 0), backgroundColor: palette.slice(0, LANGS.length) }],
+  },
+  options: {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { position: 'right', labels: { color: '#e1e4ed' } },
+    },
+  },
+});
+
+new Chart(document.getElementById('devBar'), {
+  type: 'bar',
+  data: {
+    labels: DEVS,
+    datasets: LANGS.map((lang, i) => ({
+      label: lang,
+      backgroundColor: palette[i % palette.length],
+      data: DEVS.map(dev => (DEV_LANGS[dev] && DEV_LANGS[dev][lang]) || 0),
+    })),
+  },
+  options: {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      x: { stacked: true, ticks: { color: '#e1e4ed' }, grid: { color: '#2a2d3a' } },
+      y: { stacked: true, title: { display: true, text: 'PRs', color: '#8b8fa3' }, ticks: { color: '#8b8fa3' }, grid: { color: '#2a2d3a' } },
+    },
+    plugins: { legend: { position: 'bottom', labels: { color: '#e1e4ed' } } },
+  },
+});
+</script>
+</body>
+</html>

--- a/tests/unit/cli/test_cli_no_subcommand.py
+++ b/tests/unit/cli/test_cli_no_subcommand.py
@@ -26,6 +26,7 @@ class TestNoSubcommand:
         assert "clear" in result.output
         assert "logout" in result.output
         assert "skill-report" in result.output
+        assert "lang-report" in result.output
         assert "analyze" not in result.output
         forbidden = "anon" + "ymize"
         assert forbidden not in result.output

--- a/tests/unit/metrics/test_snapshot.py
+++ b/tests/unit/metrics/test_snapshot.py
@@ -158,19 +158,18 @@ class TestSummary:
         assert snap.summary.max_review_share == 0
 
     def test_should_sort_ai_per_dev_ascending(self):
-        prs = []
-        for login, ai_count in [("alice", 5), ("bob", 2), ("carol", 4)]:
-            prs.extend(
-                any_pr(
-                    number=f"{login}-{i}",
-                    user={"login": login},
-                    created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
-                    merged_at=dt(year=2024, month=1, day=2, hour=0, minute=0),
-                    reviews=[approved_review(dt(year=2024, month=1, day=1, hour=6, minute=0))],
-                    body="Co-Authored-By: Claude" if i < ai_count else "",
-                )
-                for i in range(5)
+        prs = [
+            any_pr(
+                number=f"{login}-{i}",
+                user={"login": login},
+                created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
+                merged_at=dt(year=2024, month=1, day=2, hour=0, minute=0),
+                reviews=[approved_review(dt(year=2024, month=1, day=1, hour=6, minute=0))],
+                body="Co-Authored-By: Claude" if i < ai_count else "",
             )
+            for login, ai_count in [("alice", 5), ("bob", 2), ("carol", 4)]
+            for i in range(5)
+        ]
 
         snap = MetricsSnapshot.from_repo_prs({"org/r": prs}, _period())
 
@@ -241,19 +240,18 @@ class TestTeamAggregation:
         assert snap.team.pickup_time <= snap.team.cycle_time
 
     def test_should_use_mean_of_dev_rates_for_ai_adoption(self):
-        prs = []
-        for login, ai_count in [("alice", 5), ("bob", 2), ("carol", 2)]:
-            prs.extend(
-                any_pr(
-                    number=f"{login}-{i}",
-                    user={"login": login},
-                    created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
-                    merged_at=dt(year=2024, month=1, day=2, hour=0, minute=0),
-                    reviews=[approved_review(dt(year=2024, month=1, day=1, hour=6, minute=0))],
-                    body="Co-Authored-By: Claude" if i < ai_count else "",
-                )
-                for i in range(5)
+        prs = [
+            any_pr(
+                number=f"{login}-{i}",
+                user={"login": login},
+                created_at=dt(year=2024, month=1, day=1, hour=0, minute=0),
+                merged_at=dt(year=2024, month=1, day=2, hour=0, minute=0),
+                reviews=[approved_review(dt(year=2024, month=1, day=1, hour=6, minute=0))],
+                body="Co-Authored-By: Claude" if i < ai_count else "",
             )
+            for login, ai_count in [("alice", 5), ("bob", 2), ("carol", 2)]
+            for i in range(5)
+        ]
 
         snap = MetricsSnapshot.from_repo_prs({"org/repo": prs}, _period())
 


### PR DESCRIPTION
New `lang-report` command that fetches PRs with file data from GitHub, maps file extensions to language categories, and renders a self-contained HTML report with team doughnut chart, per-dev stacked bar chart, and detail table. No cache storage — fresh fetch per run.