### PR TITLE
Fix setuptools package discovery when metrics_results/ directory exists

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ venv = ".venv"
 typeCheckingMode = "standard"
 
 
+[tool.setuptools.packages.find]
+include = ["git_dev_metrics", "git_dev_metrics.*"]
+
 [tool.uv]
 package = true
 override-dependencies = ["idna>=3.15"]


### PR DESCRIPTION
## Problem\n\n`uv run app pull` fails with:\n\n```\nerror: Multiple top-level packages discovered in a flat-layout: ['metrics_results', 'git_dev_metrics']\n```\n\nThe `metrics_results/` directory (output data) is picked up by setuptools' automatic flat-layout discovery alongside `git_dev_metrics/`.\n\n## Solution\n\nRestrict setuptools to discover only `git_dev_metrics` via `[tool.setuptools.packages.find]` in `pyproject.toml`.\n\n## Verification\n\n`uv run app pull --help` now builds and runs successfully.