### PR TITLE
Fix PR distribution pie chart and add stale command description

### DIFF
--- a/git_dev_metrics/cli/commands/stale.py
+++ b/git_dev_metrics/cli/commands/stale.py
@@ -19,6 +19,7 @@ def stale(
     output: Path | None = typer.Option(None, "--output", help="Output HTML path"),
     db: Path | None = typer.Option(None, "--db", help="Override cache database path"),
 ) -> None:
+    """Find stale open PRs across all cached repos."""
     repos = sorted({(org, repo) for org, repo, *_ in list_synced_months(db_path=db)})
     if not repos:
         typer.secho("No repos in cache — run pull first.", fg=typer.colors.RED, err=True)

--- a/git_dev_metrics/metrics/printer/templates/dashboard.html
+++ b/git_dev_metrics/metrics/printer/templates/dashboard.html
@@ -672,7 +672,8 @@ function pieChart(canvasId, legendId, data) {
 
 const pieData = [...devs]
   .filter(d => d.prs > 0)
-  .sort((a,b) => b.prs - a.prs);
+  .sort((a,b) => b.prs - a.prs)
+  .map(d => ({ label: d.name, value: d.prs }));
 pieChart("prPieChart", "prPieLegend", pieData);
 </script>
 


### PR DESCRIPTION
## Changes

- **PR distribution pie chart**: Data was passed as raw dev objects (name, prs) but pieChart() reads label and value. Added .map() to transform before rendering.
- **stale command description**: Missing docstring caused --help to show no description next to the stale command. Added one.

No dev identifiers included.