### PR TITLE
Fix browser tabs opening during test runs

### DIFF
--- a/tests/unit/cli/test_stale_command.py
+++ b/tests/unit/cli/test_stale_command.py
@@ -60,7 +60,7 @@ class TestStale:
         _stub_webbrowser.assert_called_once_with(out.resolve().as_uri())
 
     @freeze_time("2026-05-12")
-    def test_should_sort_oldest_first(self, tmp_path, mocker):
+    def test_should_sort_oldest_first(self, tmp_path, mocker, _stub_webbrowser):
         # Arrange
         db_path = tmp_path / "cache.db"
         seal_month("myorg", "repoA", 2026, 4, db_path=db_path)
@@ -88,7 +88,7 @@ class TestStale:
         assert 0 < old_idx < young_idx
 
     @freeze_time("2026-05-12")
-    def test_should_render_empty_state_when_no_stale_prs(self, tmp_path, mocker):
+    def test_should_render_empty_state_when_no_stale_prs(self, tmp_path, mocker, _stub_webbrowser):
         # Arrange
         db_path = tmp_path / "cache.db"
         seal_month("myorg", "repoA", 2026, 4, db_path=db_path)
@@ -123,7 +123,9 @@ class TestStale:
         assert "No repos in cache" in result.stderr
 
     @freeze_time("2026-05-12")
-    def test_should_write_default_path_when_no_output(self, tmp_path, monkeypatch, mocker):
+    def test_should_write_default_path_when_no_output(
+        self, tmp_path, monkeypatch, mocker, _stub_webbrowser
+    ):
         # Arrange
         db_path = tmp_path / "cache.db"
         seal_month("myorg", "repoA", 2026, 4, db_path=db_path)

--- a/tests/unit/cli/test_trend_command.py
+++ b/tests/unit/cli/test_trend_command.py
@@ -64,7 +64,7 @@ def _data_block(html: str) -> dict:
 
 class TestTrendFiltersLeavers:
     @freeze_time("2026-05-12")
-    def test_should_render_active_devs_only_and_omit_leavers(self, tmp_path):
+    def test_should_render_active_devs_only_and_omit_leavers(self, tmp_path, _stub_webbrowser):
         # Arrange
         db_path = tmp_path / "cache.db"
         _seed_three_months_one_repo(db_path)
@@ -97,7 +97,7 @@ class TestTrendFiltersLeavers:
 
 class TestTrendCanvases:
     @freeze_time("2026-05-12")
-    def test_should_render_three_chart_canvases_with_cdn(self, tmp_path):
+    def test_should_render_three_chart_canvases_with_cdn(self, tmp_path, _stub_webbrowser):
         # Arrange
         db_path = tmp_path / "cache.db"
         _seed_three_months_one_repo(db_path)
@@ -132,7 +132,7 @@ class TestTrendCanvases:
 
 class TestTrendAggregatesAllRepos:
     @freeze_time("2026-05-12")
-    def test_should_sum_pr_counts_across_every_synced_repo(self, tmp_path):
+    def test_should_sum_pr_counts_across_every_synced_repo(self, tmp_path, _stub_webbrowser):
         # Arrange
         db_path = tmp_path / "cache.db"
         insert_prs(


### PR DESCRIPTION
Six tests in `test_trend_command.py` and `test_stale_command.py` invoked CLI commands that call `open_in_browser()` without patching `webbrowser.open`, causing real browser tabs to spawn during `uv run pytest`.

Added `_stub_webbrowser` fixture to each affected test:

- `test_trend_command.py`: TestTrendFiltersLeavers, TestTrendCanvases, TestTrendAggregatesAllRepos
- `test_stale_command.py`: test_should_sort_oldest_first, test_should_render_empty_state_when_no_stale_prs, test_should_write_default_path_when_no_output