### PR TITLE
Add nickname management for developer display in reports

### DIFF
--- a/git_dev_metrics/cache/__init__.py
+++ b/git_dev_metrics/cache/__init__.py
@@ -4,6 +4,9 @@ from .db import (
     close_connection,
     count_prs,
     default_db_path,
+    delete_nickname,
+    get_all_dev_logins,
+    get_nicknames,
     insert_prs,
     is_partial,
     is_sealed,
@@ -12,6 +15,7 @@ from .db import (
     open_connection,
     query_prs,
     seal_month,
+    set_nickname,
 )
 from .query import (
     has_partial_for_range,
@@ -27,6 +31,9 @@ __all__ = [
     "close_connection",
     "count_prs",
     "default_db_path",
+    "delete_nickname",
+    "get_all_dev_logins",
+    "get_nicknames",
     "has_partial_for_range",
     "insert_prs",
     "is_partial",
@@ -42,4 +49,5 @@ __all__ = [
     "open_connection",
     "query_prs",
     "seal_month",
+    "set_nickname",
 ]

--- a/git_dev_metrics/cache/db.py
+++ b/git_dev_metrics/cache/db.py
@@ -53,6 +53,11 @@ CREATE TABLE IF NOT EXISTS synced_months (
     partial INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (year, month, repo_org, repo_name)
 );
+
+CREATE TABLE IF NOT EXISTS nicknames (
+    login TEXT PRIMARY KEY,
+    nickname TEXT NOT NULL
+);
 """
 
 
@@ -307,3 +312,43 @@ def count_prs(
         (org, repo, year, month),
     ).fetchone()
     return row["n"] if row else 0
+
+
+def get_all_dev_logins(db_path: Path | None = None) -> set[str]:
+    """All unique developer logins across cached PRs and reviews."""
+    conn = open_connection(db_path)
+    authors = conn.execute(
+        "SELECT DISTINCT author_login FROM prs "
+        "WHERE author_login IS NOT NULL AND author_login != ''"
+    ).fetchall()
+    reviewers = conn.execute(
+        "SELECT DISTINCT user_login FROM reviews WHERE user_login IS NOT NULL AND user_login != ''"
+    ).fetchall()
+    result: set[str] = set()
+    for row in authors:
+        result.add(row[0])
+    for row in reviewers:
+        result.add(row[0])
+    return result
+
+
+def get_nicknames(db_path: Path | None = None) -> dict[str, str]:
+    """All login → nickname mappings."""
+    conn = open_connection(db_path)
+    rows = conn.execute("SELECT login, nickname FROM nicknames").fetchall()
+    return {row["login"]: row["nickname"] for row in rows}
+
+
+def set_nickname(login: str, nickname: str, db_path: Path | None = None) -> None:
+    conn = open_connection(db_path)
+    with conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO nicknames (login, nickname) VALUES (?, ?)",
+            (login, nickname),
+        )
+
+
+def delete_nickname(login: str, db_path: Path | None = None) -> None:
+    conn = open_connection(db_path)
+    with conn:
+        conn.execute("DELETE FROM nicknames WHERE login = ?", (login,))

--- a/git_dev_metrics/cli/commands/app.py
+++ b/git_dev_metrics/cli/commands/app.py
@@ -4,6 +4,7 @@ from .clear import clear
 from .dashboard import dashboard
 from .lang_report import lang_report
 from .logout import logout
+from .nickname import nickname
 from .pull import pull
 from .skill_report import skill_report
 from .stale import stale
@@ -25,6 +26,7 @@ app.command()(dashboard)
 app.command()(skill_report)
 app.command()(lang_report)
 app.command()(logout)
+app.command()(nickname)
 app.command()(pull)
 app.command()(stale)
 app.command()(summary)

--- a/git_dev_metrics/cli/commands/dashboard.py
+++ b/git_dev_metrics/cli/commands/dashboard.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import typer
 
+from ...cache import get_nicknames
 from .._options import DB_OPTION
 from ..runners.dashboard_runner import write_and_open_dashboard
 from ..utils._date_formatter import format_date_range
@@ -17,6 +18,11 @@ def dashboard(
 ) -> None:
     """Render the in-depth HTML dashboard and open it in the browser."""
     snapshot = resolve_range(from_, to, db, dashboard_wizard)
+    nicknames = get_nicknames(db_path=db)
     write_and_open_dashboard(
-        snapshot, f"{from_}-to-{to}", format_date_range(snapshot.period), output
+        snapshot,
+        f"{from_}-to-{to}",
+        format_date_range(snapshot.period),
+        output,
+        nicknames=nicknames,
     )

--- a/git_dev_metrics/cli/commands/nickname.py
+++ b/git_dev_metrics/cli/commands/nickname.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+import typer
+
+from ...cache import delete_nickname, get_all_dev_logins, get_nicknames, set_nickname
+
+
+def _print_nicknames(logins: list[str], current: dict[str, str]) -> None:
+    typer.echo("")
+    typer.echo("Current nicknames:")
+    for login in logins:
+        nick = current.get(login, login)
+        marker = "" if nick == login else f" → {nick}"
+        typer.echo(f"  {login}{marker}")
+
+
+def nickname(
+    db: Path | None = typer.Option(None, "--db", help="Override cache database path"),
+) -> None:
+    """Set display nicknames for developers in reports."""
+    logins = sorted(get_all_dev_logins(db_path=db))
+    if not logins:
+        typer.secho(
+            "No cached data found. Pull some months first.",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    current = get_nicknames(db_path=db)
+    typer.echo(f"Found {len(logins)} developers.")
+    typer.echo("Enter a display name for each developer (blank keeps current, 'x' clears):")
+
+    for login in logins:
+        existing = current.get(login, "")
+        hint = f" [{existing}]" if existing else ""
+        val = typer.prompt(f"  {login}{hint}", default="", show_default=False, prompt_suffix="> ")
+
+        if val == "x":
+            if existing:
+                delete_nickname(login, db_path=db)
+                del current[login]
+        elif val and val != existing:
+            set_nickname(login, val, db_path=db)
+            current[login] = val
+
+    _print_nicknames(logins, current)

--- a/git_dev_metrics/cli/commands/summary.py
+++ b/git_dev_metrics/cli/commands/summary.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import typer
 
+from ...cache import get_nicknames
 from ...metrics.printer import ConsolePrinter
 from .._options import DB_OPTION
 from ..utils._date_formatter import format_date_range
@@ -16,4 +17,7 @@ def summary(
 ) -> None:
     """Print the dashboard summary to the console."""
     snapshot = resolve_range(from_, to, db, summary_wizard)
-    ConsolePrinter().print_combined_metrics(snapshot, format_date_range(snapshot.period))
+    nicknames = get_nicknames(db_path=db)
+    ConsolePrinter().print_combined_metrics(
+        snapshot, format_date_range(snapshot.period), nicknames=nicknames
+    )

--- a/git_dev_metrics/cli/runners/dashboard_runner.py
+++ b/git_dev_metrics/cli/runners/dashboard_runner.py
@@ -14,9 +14,15 @@ def _default_output(period_slug: str) -> Path:
 
 
 def write_and_open_dashboard(
-    snapshot: MetricsSnapshot, period_slug: str, date_range: str, output: Path | None
+    snapshot: MetricsSnapshot,
+    period_slug: str,
+    date_range: str,
+    output: Path | None,
+    nicknames: dict[str, str] | None = None,
 ) -> None:
     out = (output or _default_output(period_slug)).with_suffix(".html")
-    FileHtmlPrinter(out).print_combined_metrics(snapshot, period_slug, date_range)
+    FileHtmlPrinter(out).print_combined_metrics(
+        snapshot, period_slug, date_range, nicknames=nicknames
+    )
     typer.echo(f"Dashboard written to {out}.")
     open_in_browser(out)

--- a/git_dev_metrics/cli/wizards/dashboard_wizard.py
+++ b/git_dev_metrics/cli/wizards/dashboard_wizard.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from pathlib import Path
 
+from ...cache import get_nicknames
 from ..runners.dashboard_runner import write_and_open_dashboard
 from ._wizard import YearMonth, _prompt_months, run_wizard
 
@@ -11,8 +12,9 @@ def dashboard_wizard(
     ask_months: Callable[[list[YearMonth]], list[YearMonth]] = _prompt_months,
 ) -> None:
     """Pick months from cache, render HTML dashboard, open in browser."""
+    nicknames = get_nicknames(db_path=db_path)
     run_wizard(
         db_path,
         ask_months,
-        lambda s, slug, dr: write_and_open_dashboard(s, slug, dr, output=None),
+        lambda s, slug, dr: write_and_open_dashboard(s, slug, dr, output=None, nicknames=nicknames),
     )

--- a/git_dev_metrics/cli/wizards/summary_wizard.py
+++ b/git_dev_metrics/cli/wizards/summary_wizard.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from pathlib import Path
 
+from ...cache import get_nicknames
 from ...metrics.printer import ConsolePrinter
 from ._wizard import YearMonth, _prompt_months, run_wizard
 
@@ -11,8 +12,9 @@ def summary_wizard(
     ask_months: Callable[[list[YearMonth]], list[YearMonth]] = _prompt_months,
 ) -> None:
     """Pick months from cache, print aggregated summary to console."""
+    nicknames = get_nicknames(db_path=db_path)
     run_wizard(
         db_path,
         ask_months,
-        lambda s, slug, dr: ConsolePrinter().print_combined_metrics(s, dr),
+        lambda s, slug, dr: ConsolePrinter().print_combined_metrics(s, dr, nicknames=nicknames),
     )

--- a/git_dev_metrics/metrics/printer/dev.py
+++ b/git_dev_metrics/metrics/printer/dev.py
@@ -20,7 +20,10 @@ class ConsoleDevPrinter:
     """Print dev metrics to console using Rich."""
 
     def print_combined_metrics(
-        self, snapshot: MetricsSnapshot, date_range: str | None = None
+        self,
+        snapshot: MetricsSnapshot,
+        date_range: str | None = None,
+        nicknames: dict[str, str] | None = None,
     ) -> None:
         from rich.console import Console
         from rich.table import Table
@@ -37,8 +40,9 @@ class ConsoleDevPrinter:
 
         for row in snapshot.devs:
             color = band_color(row.band)
+            display_name = nicknames.get(row.name, row.name) if nicknames else row.name
             table.add_row(
-                row.name,
+                display_name,
                 f"[{color}]{row.health}[/{color}]",
                 f"{row.pickup_time:.2f}",
                 f"{row.review_time:.2f}",

--- a/git_dev_metrics/metrics/printer/html.py
+++ b/git_dev_metrics/metrics/printer/html.py
@@ -33,10 +33,13 @@ class _SummaryData(TypedDict):
     max_review_share: int
 
 
-def _devs_for_template(snapshot: MetricsSnapshot) -> list[_DevRow]:
+def _devs_for_template(
+    snapshot: MetricsSnapshot,
+    nicknames: dict[str, str] | None = None,
+) -> list[_DevRow]:
     return [
         _DevRow(
-            name=row.name,
+            name=nicknames.get(row.name, row.name) if nicknames else row.name,
             health=row.health,
             pickup=row.pickup_time,
             review=row.review_time,
@@ -51,9 +54,17 @@ def _devs_for_template(snapshot: MetricsSnapshot) -> list[_DevRow]:
     ]
 
 
-def _summary_for_template(snapshot: MetricsSnapshot) -> _SummaryData:
+def _summary_for_template(
+    snapshot: MetricsSnapshot,
+    nicknames: dict[str, str] | None = None,
+) -> _SummaryData:
     team = snapshot.team
     summary = snapshot.summary
+    top_reviewer = summary.top_reviewer
+    if nicknames and top_reviewer:
+        top_reviewer = nicknames.get(top_reviewer, top_reviewer)
+    elif not top_reviewer:
+        top_reviewer = "\u2014"
     return _SummaryData(
         team_health=team.health,
         total_prs=team.pr_count,
@@ -65,7 +76,7 @@ def _summary_for_template(snapshot: MetricsSnapshot) -> _SummaryData:
         ai_adoption=round(team.ai_percentage),
         ai_per_dev=list(summary.ai_per_dev),
         review_ratio=summary.review_ratio,
-        top_reviewer=summary.top_reviewer,
+        top_reviewer=top_reviewer,
         max_review_share=summary.max_review_share,
     )
 
@@ -77,12 +88,16 @@ class FileHtmlPrinter:
         self._output_path = output_path
 
     def print_combined_metrics(
-        self, snapshot: MetricsSnapshot, period: str, date_range: str
+        self,
+        snapshot: MetricsSnapshot,
+        period: str,
+        date_range: str,
+        nicknames: dict[str, str] | None = None,
     ) -> None:
         html = render_template(
             "dashboard.html",
-            devs=_devs_for_template(snapshot),
-            summary=_summary_for_template(snapshot),
+            devs=_devs_for_template(snapshot, nicknames),
+            summary=_summary_for_template(snapshot, nicknames),
             period=period,
             date_range=date_range,
             has_partial=snapshot.has_partial,

--- a/git_dev_metrics/metrics/printer/printers.py
+++ b/git_dev_metrics/metrics/printer/printers.py
@@ -8,15 +8,19 @@ class ConsolePrinter:
     def __init__(self) -> None:
         self._dev_printer = ConsoleDevPrinter()
 
-    def print_combined_metrics(self, snapshot: MetricsSnapshot, date_range: str) -> None:
+    def print_combined_metrics(
+        self,
+        snapshot: MetricsSnapshot,
+        date_range: str,
+        nicknames: dict[str, str] | None = None,
+    ) -> None:
         from rich.console import Console
 
         console = Console()
         console.print()
-
         console.print()
 
-        self._dev_printer.print_combined_metrics(snapshot, date_range)
+        self._dev_printer.print_combined_metrics(snapshot, date_range, nicknames=nicknames)
 
 
 __all__ = ["ConsolePrinter"]

--- a/tests/unit/cache/test_cache.py
+++ b/tests/unit/cache/test_cache.py
@@ -2,11 +2,15 @@ import json
 
 from git_dev_metrics.cache import (
     count_prs,
+    delete_nickname,
+    get_all_dev_logins,
+    get_nicknames,
     insert_prs,
     is_sealed,
     open_connection,
     query_prs,
     seal_month,
+    set_nickname,
 )
 
 from ..conftest import any_pr, approved_review, dt
@@ -129,3 +133,103 @@ class TestSealing:
         result = count_prs("myorg", "myrepo", 2026, 4, db_path=db_path)
 
         assert result == 2
+
+
+class TestNicknameDb:
+    def test_should_return_empty_dict_when_no_nicknames(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+
+        result = get_nicknames(db_path=db_path)
+
+        assert result == {}
+
+    def test_should_set_and_retrieve_nickname(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+
+        set_nickname("alice", "Alpha", db_path=db_path)
+
+        assert get_nicknames(db_path=db_path) == {"alice": "Alpha"}
+
+    def test_should_replace_existing_nickname(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+        set_nickname("alice", "Alpha", db_path=db_path)
+
+        set_nickname("alice", "A-Plus", db_path=db_path)
+
+        assert get_nicknames(db_path=db_path) == {"alice": "A-Plus"}
+
+    def test_should_delete_nickname(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+        set_nickname("alice", "Alpha", db_path=db_path)
+
+        delete_nickname("alice", db_path=db_path)
+
+        assert get_nicknames(db_path=db_path) == {}
+
+    def test_should_return_all_nicknames(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+        set_nickname("alice", "Alpha", db_path=db_path)
+        set_nickname("bob", "Beta", db_path=db_path)
+
+        result = get_nicknames(db_path=db_path)
+
+        assert result == {"alice": "Alpha", "bob": "Beta"}
+
+    def test_should_handle_special_characters(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+
+        set_nickname("bob", "Bøb 🌟", db_path=db_path)
+
+        assert get_nicknames(db_path=db_path) == {"bob": "Bøb 🌟"}
+
+    def test_should_get_all_dev_logins_from_authors(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+        insert_prs(
+            [any_pr(number=1, user={"login": "alice"}), any_pr(number=2, user={"login": "bob"})],
+            "myorg",
+            "myrepo",
+            2026,
+            4,
+            db_path=db_path,
+        )
+
+        logins = get_all_dev_logins(db_path=db_path)
+
+        assert logins == {"alice", "bob"}
+
+    def test_should_get_all_dev_logins_from_reviewers(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+        insert_prs(
+            [any_pr(number=1, user={"login": "alice"}, reviews=[approved_review(login="carol")])],
+            "myorg",
+            "myrepo",
+            2026,
+            4,
+            db_path=db_path,
+        )
+
+        logins = get_all_dev_logins(db_path=db_path)
+
+        assert logins == {"alice", "carol"}
+
+    def test_should_deduplicate_logins_in_get_all_dev_logins(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+        insert_prs(
+            [any_pr(number=1, user={"login": "alice"}, reviews=[approved_review(login="alice")])],
+            "myorg",
+            "myrepo",
+            2026,
+            4,
+            db_path=db_path,
+        )
+
+        logins = get_all_dev_logins(db_path=db_path)
+
+        assert logins == {"alice"}
+
+    def test_should_return_empty_set_when_no_data(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+
+        logins = get_all_dev_logins(db_path=db_path)
+
+        assert logins == set()

--- a/tests/unit/cli/test_dashboard_command.py
+++ b/tests/unit/cli/test_dashboard_command.py
@@ -1,6 +1,6 @@
 from typer.testing import CliRunner
 
-from git_dev_metrics.cache import insert_prs, seal_month
+from git_dev_metrics.cache import insert_prs, seal_month, set_nickname
 from git_dev_metrics.cli import app
 
 from ..conftest import any_pr, approved_review, dt
@@ -157,6 +157,33 @@ class TestDashboardFlagMode:
         # Assert
         assert result.exit_code == 1
         assert "No synced data" in result.stderr
+
+    def test_should_render_nickname_in_html(self, tmp_path, _stub_webbrowser):
+        db_path = tmp_path / "cache.db"
+        _seed_two_repos_apr(db_path)
+        set_nickname("alice", "Alpha", db_path=db_path)
+        set_nickname("bob", "Beta", db_path=db_path)
+        out = tmp_path / "r.html"
+
+        result = runner.invoke(
+            app,
+            [
+                "dashboard",
+                "--from",
+                "2026-04",
+                "--to",
+                "2026-04",
+                "--output",
+                str(out),
+                "--db",
+                str(db_path),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        html = out.read_text()
+        assert "Alpha" in html
+        assert "Beta" in html
 
 
 class TestDashboardWizardDispatch:

--- a/tests/unit/cli/test_nickname_command.py
+++ b/tests/unit/cli/test_nickname_command.py
@@ -1,0 +1,120 @@
+from typer.testing import CliRunner
+
+from git_dev_metrics.cache import (
+    get_nicknames,
+    insert_prs,
+    set_nickname,
+)
+from git_dev_metrics.cli import app
+
+from ..conftest import any_pr, approved_review, dt
+
+runner = CliRunner()
+
+
+def _seed_four_devs(db_path) -> None:
+    """April 2026 PRs with 4 unique devs across authors + reviewers."""
+    prs = [
+        any_pr(
+            number=1,
+            user={"login": "alice"},
+            reviews=[approved_review(login="bob")],
+            created_at=dt(year=2026, month=4, day=1, hour=9, minute=0),
+            merged_at=dt(year=2026, month=4, day=2, hour=10, minute=0),
+        ),
+        any_pr(
+            number=2,
+            user={"login": "carol"},
+            reviews=[approved_review(login="dave")],
+            created_at=dt(year=2026, month=4, day=3, hour=9, minute=0),
+            merged_at=dt(year=2026, month=4, day=4, hour=10, minute=0),
+        ),
+    ]
+    insert_prs(prs, "myorg", "myrepo", 2026, 4, db_path=db_path)
+
+
+class TestNicknameCommand:
+    def test_should_exit_when_no_cached_data(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+
+        result = runner.invoke(app, ["nickname", "--db", str(db_path)], input="")
+
+        assert result.exit_code == 1
+        assert "No cached data found" in result.stderr
+
+    def test_should_set_nicknames_via_prompt(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+        _seed_four_devs(db_path)
+
+        result = runner.invoke(
+            app,
+            ["nickname", "--db", str(db_path)],
+            input="Alpha\nBeta\nCharlie\nDave\n",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert get_nicknames(db_path=db_path) == {
+            "alice": "Alpha",
+            "bob": "Beta",
+            "carol": "Charlie",
+            "dave": "Dave",
+        }
+
+    def test_should_replace_existing_nickname(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+        _seed_four_devs(db_path)
+        set_nickname("alice", "OldName", db_path=db_path)
+
+        result = runner.invoke(
+            app,
+            ["nickname", "--db", str(db_path)],
+            input="NewName\n\n\n\n",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert get_nicknames(db_path=db_path)["alice"] == "NewName"
+
+    def test_should_clear_nickname_with_x(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+        _seed_four_devs(db_path)
+        set_nickname("alice", "Alpha", db_path=db_path)
+        set_nickname("bob", "Beta", db_path=db_path)
+
+        result = runner.invoke(
+            app,
+            ["nickname", "--db", str(db_path)],
+            input="x\n\n\n\n",
+        )
+
+        assert result.exit_code == 0, result.output
+        nicknames = get_nicknames(db_path=db_path)
+        assert "alice" not in nicknames
+        assert nicknames["bob"] == "Beta"
+
+    def test_should_skip_on_blank_input(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+        _seed_four_devs(db_path)
+        set_nickname("alice", "Alpha", db_path=db_path)
+
+        result = runner.invoke(
+            app,
+            ["nickname", "--db", str(db_path)],
+            input="\n\n\n\n",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert get_nicknames(db_path=db_path)["alice"] == "Alpha"
+
+    def test_should_print_current_nicknames(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+        _seed_four_devs(db_path)
+        set_nickname("alice", "Alpha", db_path=db_path)
+
+        result = runner.invoke(
+            app,
+            ["nickname", "--db", str(db_path)],
+            input="\n\n\n\n",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "alice → Alpha" in result.output

--- a/tests/unit/cli/test_summary_command.py
+++ b/tests/unit/cli/test_summary_command.py
@@ -1,6 +1,6 @@
 from typer.testing import CliRunner
 
-from git_dev_metrics.cache import insert_prs, seal_month
+from git_dev_metrics.cache import insert_prs, seal_month, set_nickname
 from git_dev_metrics.cli import app
 
 from ..conftest import any_pr, approved_review, dt
@@ -126,6 +126,22 @@ class TestSummaryFlagMode:
         # Assert
         assert result.exit_code == 0, result.output
         _stub_webbrowser.assert_not_called()
+
+    def test_should_display_nickname_instead_of_login(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+        _seed_two_repos_apr(db_path)
+        set_nickname("alice", "Ali", db_path=db_path)
+        set_nickname("bob", "Bob", db_path=db_path)
+
+        result = runner.invoke(
+            app,
+            ["summary", "--from", "2026-04", "--to", "2026-04", "--db", str(db_path)],
+        )
+
+        assert result.exit_code == 0, result.output
+        out = result.output
+        assert "Ali" in out
+        assert "Bob" in out
 
 
 class TestSummaryWizardDispatch:


### PR DESCRIPTION
- New nicknames table in cache DB with get/set/delete functions
- Interactive CLI command: `app nickname` to set per-dev display names
- Console & HTML printers resolve names via nickname map, fall back to login
- Wizards (summary, dashboard) also load and pass nicknames
- 18 new tests across DB layer, CLI command, and rendering
