### PR TITLE
Add targets command and embed target indicators in reports

### DIFF
--- a/git_dev_metrics/cache/__init__.py
+++ b/git_dev_metrics/cache/__init__.py
@@ -5,8 +5,10 @@ from .db import (
     count_prs,
     default_db_path,
     delete_nickname,
+    delete_target,
     get_all_dev_logins,
     get_nicknames,
+    get_targets,
     insert_prs,
     is_partial,
     is_sealed,
@@ -16,6 +18,7 @@ from .db import (
     query_prs,
     seal_month,
     set_nickname,
+    set_target,
 )
 from .query import (
     has_partial_for_range,
@@ -32,8 +35,10 @@ __all__ = [
     "count_prs",
     "default_db_path",
     "delete_nickname",
+    "delete_target",
     "get_all_dev_logins",
     "get_nicknames",
+    "get_targets",
     "has_partial_for_range",
     "insert_prs",
     "is_partial",
@@ -50,4 +55,5 @@ __all__ = [
     "query_prs",
     "seal_month",
     "set_nickname",
+    "set_target",
 ]

--- a/git_dev_metrics/cache/db.py
+++ b/git_dev_metrics/cache/db.py
@@ -58,6 +58,11 @@ CREATE TABLE IF NOT EXISTS nicknames (
     login TEXT PRIMARY KEY,
     nickname TEXT NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS targets (
+    key TEXT PRIMARY KEY,
+    value REAL NOT NULL
+);
 """
 
 
@@ -352,3 +357,25 @@ def delete_nickname(login: str, db_path: Path | None = None) -> None:
     conn = open_connection(db_path)
     with conn:
         conn.execute("DELETE FROM nicknames WHERE login = ?", (login,))
+
+
+def get_targets(db_path: Path | None = None) -> dict[str, float]:
+    """All target key → value mappings."""
+    conn = open_connection(db_path)
+    rows = conn.execute("SELECT key, value FROM targets").fetchall()
+    return {row["key"]: row["value"] for row in rows}
+
+
+def set_target(key: str, value: float, db_path: Path | None = None) -> None:
+    conn = open_connection(db_path)
+    with conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO targets (key, value) VALUES (?, ?)",
+            (key, value),
+        )
+
+
+def delete_target(key: str, db_path: Path | None = None) -> None:
+    conn = open_connection(db_path)
+    with conn:
+        conn.execute("DELETE FROM targets WHERE key = ?", (key,))

--- a/git_dev_metrics/cli/commands/app.py
+++ b/git_dev_metrics/cli/commands/app.py
@@ -9,6 +9,7 @@ from .pull import pull
 from .skill_report import skill_report
 from .stale import stale
 from .summary import summary
+from .targets import targets
 from .trend import trend
 
 app = typer.Typer(help="Git development metrics CLI.")
@@ -30,4 +31,5 @@ app.command()(nickname)
 app.command()(pull)
 app.command()(stale)
 app.command()(summary)
+app.command()(targets)
 app.command()(trend)

--- a/git_dev_metrics/cli/commands/dashboard.py
+++ b/git_dev_metrics/cli/commands/dashboard.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import typer
 
-from ...cache import get_nicknames
+from ...cache import get_nicknames, get_targets
 from .._options import DB_OPTION
 from ..runners.dashboard_runner import write_and_open_dashboard
 from ..utils._date_formatter import format_date_range
@@ -19,10 +19,12 @@ def dashboard(
     """Render the in-depth HTML dashboard and open it in the browser."""
     snapshot = resolve_range(from_, to, db, dashboard_wizard)
     nicknames = get_nicknames(db_path=db)
+    targets = get_targets(db_path=db)
     write_and_open_dashboard(
         snapshot,
         f"{from_}-to-{to}",
         format_date_range(snapshot.period),
         output,
         nicknames=nicknames,
+        targets=targets,
     )

--- a/git_dev_metrics/cli/commands/stale.py
+++ b/git_dev_metrics/cli/commands/stale.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import typer
 
-from ...cache import list_synced_months
+from ...cache import get_targets, list_synced_months
 from ...github import GitHubNotFoundError, fetch_open_prs, get_github_token
 from ...metrics._stale_pr import StalePr, get_stale_prs
 from ...metrics.printer.stale import FileStaleHtmlPrinter
@@ -26,6 +26,10 @@ def stale(
         typer.secho("No repos in cache — run pull first.", fg=typer.colors.RED, err=True)
         raise typer.Exit(code=1)
 
+    targets = get_targets(db_path=db)
+    threshold_days = targets.get("stale_threshold_days", 7)
+    threshold_hours = threshold_days * 24
+
     token = get_github_token()
     all_stale: list[StalePr] = []
     for org, repo in repos:
@@ -38,10 +42,10 @@ def stale(
                 err=True,
             )
             continue
-        all_stale.extend(get_stale_prs(opens, f"{org}/{repo}"))
+        all_stale.extend(get_stale_prs(opens, f"{org}/{repo}", threshold_hours=threshold_hours))
     all_stale.sort(key=lambda x: x.age_hours, reverse=True)
 
     out = (output or _default_output()).with_suffix(".html")
-    FileStaleHtmlPrinter(out).render(all_stale)
+    FileStaleHtmlPrinter(out).render(all_stale, targets=targets)
     typer.echo(f"Stale written to {out}.")
     open_in_browser(out)

--- a/git_dev_metrics/cli/commands/summary.py
+++ b/git_dev_metrics/cli/commands/summary.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import typer
 
-from ...cache import get_nicknames
+from ...cache import get_nicknames, get_targets
 from ...metrics.printer import ConsolePrinter
 from .._options import DB_OPTION
 from ..utils._date_formatter import format_date_range
@@ -18,6 +18,7 @@ def summary(
     """Print the dashboard summary to the console."""
     snapshot = resolve_range(from_, to, db, summary_wizard)
     nicknames = get_nicknames(db_path=db)
+    targets = get_targets(db_path=db)
     ConsolePrinter().print_combined_metrics(
-        snapshot, format_date_range(snapshot.period), nicknames=nicknames
+        snapshot, format_date_range(snapshot.period), nicknames=nicknames, targets=targets
     )

--- a/git_dev_metrics/cli/commands/targets.py
+++ b/git_dev_metrics/cli/commands/targets.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import typer
+
+from ...cache import delete_target, get_targets, set_target
+
+TARGET_KEYS: dict[str, str] = {
+    "cycle_time_max": "Max cycle time (hours)",
+    "pickup_time_max": "Max pickup time (hours)",
+    "review_time_max": "Max review time (hours)",
+    "health_min": "Min health score",
+    "prs_per_week_min": "Min PRs/week",
+    "stale_threshold_days": "Stale threshold (days)",
+    "stale_max_count": "Max stale PR count",
+    "stale_max_avg_age_days": "Max average stale age (days)",
+    "stale_max_pr_age_days": "Max PR age (days)",
+}
+
+
+def targets(
+    db: Path | None = typer.Option(None, "--db", help="Override cache database path"),
+) -> None:
+    """Set performance targets for team metrics."""
+    current = get_targets(db_path=db)
+    typer.echo("Enter a target value for each metric (blank keeps current, 'x' clears):")
+
+    for key, label in TARGET_KEYS.items():
+        existing = current.get(key)
+        hint = f" [{existing}]" if existing is not None else ""
+        val = typer.prompt(f"  {label}{hint}", default="", show_default=False, prompt_suffix="> ")
+
+        if val == "x":
+            if existing is not None:
+                delete_target(key, db_path=db)
+        elif val:
+            try:
+                parsed = float(val)
+            except ValueError:
+                typer.secho(f"  Invalid number: {val}", fg=typer.colors.RED, err=True)
+                continue
+            set_target(key, parsed, db_path=db)
+            current[key] = parsed

--- a/git_dev_metrics/cli/runners/dashboard_runner.py
+++ b/git_dev_metrics/cli/runners/dashboard_runner.py
@@ -19,10 +19,11 @@ def write_and_open_dashboard(
     date_range: str,
     output: Path | None,
     nicknames: dict[str, str] | None = None,
+    targets: dict[str, float] | None = None,
 ) -> None:
     out = (output or _default_output(period_slug)).with_suffix(".html")
     FileHtmlPrinter(out).print_combined_metrics(
-        snapshot, period_slug, date_range, nicknames=nicknames
+        snapshot, period_slug, date_range, nicknames=nicknames, targets=targets
     )
     typer.echo(f"Dashboard written to {out}.")
     open_in_browser(out)

--- a/git_dev_metrics/cli/wizards/summary_wizard.py
+++ b/git_dev_metrics/cli/wizards/summary_wizard.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 from pathlib import Path
 
-from ...cache import get_nicknames
+from ...cache import get_nicknames, get_targets
 from ...metrics.printer import ConsolePrinter
 from ._wizard import YearMonth, _prompt_months, run_wizard
 
@@ -13,8 +13,11 @@ def summary_wizard(
 ) -> None:
     """Pick months from cache, print aggregated summary to console."""
     nicknames = get_nicknames(db_path=db_path)
+    targets = get_targets(db_path=db_path)
     run_wizard(
         db_path,
         ask_months,
-        lambda s, slug, dr: ConsolePrinter().print_combined_metrics(s, dr, nicknames=nicknames),
+        lambda s, slug, dr: ConsolePrinter().print_combined_metrics(
+            s, dr, nicknames=nicknames, targets=targets
+        ),
     )

--- a/git_dev_metrics/metrics/_rows.py
+++ b/git_dev_metrics/metrics/_rows.py
@@ -44,6 +44,42 @@ class Row:
     band: Band
 
 
+_TEAM_TARGETS: dict[str, tuple[str, str]] = {
+    "cycle_time_max": ("Cycle Time", "h"),
+    "pickup_time_max": ("Pickup Time", "h"),
+    "review_time_max": ("Review Time", "h"),
+    "health_min": ("Health", ""),
+    "prs_per_week_min": ("PRs/Week", ""),
+}
+
+
+def team_target_status(team: Row, targets: dict[str, float]) -> dict:
+    """Compare team row against targets, return {items, met, total}."""
+    items: list[dict] = []
+    met = 0
+    for key, (label, unit) in _TEAM_TARGETS.items():
+        if key not in targets:
+            continue
+        target = targets[key]
+        actual = getattr(team, key.removesuffix("_max").removesuffix("_min"), None)
+        if actual is None:
+            continue
+        is_max = key.endswith("_max")
+        ok = actual <= target if is_max else actual >= target
+        if ok:
+            met += 1
+        items.append(
+            {
+                "label": label,
+                "actual": round(actual, 1),
+                "target": int(target) if target == int(target) else target,
+                "unit": unit,
+                "ok": ok,
+            }
+        )
+    return {"items": items, "met": met, "total": len(items)}
+
+
 @dataclass(frozen=True)
 class Summary:
     ai_per_dev: tuple[int, ...]

--- a/git_dev_metrics/metrics/_stale_pr.py
+++ b/git_dev_metrics/metrics/_stale_pr.py
@@ -36,14 +36,17 @@ def _calculate_age_hours(
 
 
 def _is_stale_pr(
-    pr: OpenPullRequest, repo: str, clock: Callable[[], datetime] | None = None
+    pr: OpenPullRequest,
+    repo: str,
+    clock: Callable[[], datetime] | None = None,
+    threshold_hours: float = STALE_PR_THRESHOLD_HOURS,
 ) -> StalePr | None:
     created = pr.get("created_at")
     if created is None:
         return None
 
     age_hours = _calculate_age_hours(created, clock)
-    if age_hours > STALE_PR_THRESHOLD_HOURS:
+    if age_hours > threshold_hours:
         number = pr.get("number")
         return StalePr(
             number=number if number is not None else 0,
@@ -60,9 +63,12 @@ def _is_stale_pr(
 
 
 def get_stale_prs(
-    prs: list[OpenPullRequest], repo: str = "", clock: Callable[[], datetime] | None = None
+    prs: list[OpenPullRequest],
+    repo: str = "",
+    clock: Callable[[], datetime] | None = None,
+    threshold_hours: float = STALE_PR_THRESHOLD_HOURS,
 ) -> list[StalePr]:
-    stale = [p for p in (_is_stale_pr(pr, repo, clock) for pr in prs) if p]
+    stale = [p for p in (_is_stale_pr(pr, repo, clock, threshold_hours) for pr in prs) if p]
     stale.sort(key=lambda x: x.age_hours, reverse=True)
     return stale
 

--- a/git_dev_metrics/metrics/printer/html.py
+++ b/git_dev_metrics/metrics/printer/html.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import TypedDict
 
+from .._rows import team_target_status
 from ..snapshot import MetricsSnapshot
 from ._html_templates import render_template
 
@@ -93,7 +94,9 @@ class FileHtmlPrinter:
         period: str,
         date_range: str,
         nicknames: dict[str, str] | None = None,
+        targets: dict[str, float] | None = None,
     ) -> None:
+        target_status = team_target_status(snapshot.team, targets) if targets else None
         html = render_template(
             "dashboard.html",
             devs=_devs_for_template(snapshot, nicknames),
@@ -101,6 +104,7 @@ class FileHtmlPrinter:
             period=period,
             date_range=date_range,
             has_partial=snapshot.has_partial,
+            target_status=target_status,
         )
 
         html_path = self._output_path.with_suffix(".html")

--- a/git_dev_metrics/metrics/printer/printers.py
+++ b/git_dev_metrics/metrics/printer/printers.py
@@ -1,3 +1,4 @@
+from .._rows import team_target_status
 from ..snapshot import MetricsSnapshot
 from .dev import ConsoleDevPrinter
 
@@ -13,14 +14,30 @@ class ConsolePrinter:
         snapshot: MetricsSnapshot,
         date_range: str,
         nicknames: dict[str, str] | None = None,
+        targets: dict[str, float] | None = None,
     ) -> None:
         from rich.console import Console
+        from rich.text import Text
 
         console = Console()
         console.print()
         console.print()
 
         self._dev_printer.print_combined_metrics(snapshot, date_range, nicknames=nicknames)
+
+        if targets:
+            status = team_target_status(snapshot.team, targets)
+            if status["total"] > 0:
+                parts = [f"[bold]Targets:[/bold] {status['met']}/{status['total']} met"]
+                for item in status["items"]:
+                    icon = "✓" if item["ok"] else "✗"
+                    color = "green" if item["ok"] else "red"
+                    parts.append(
+                        f"[{color}]{icon}[/{color}] {item['label']} "
+                        f"{item['actual']}{item['unit']} / {item['target']}{item['unit']}"
+                    )
+                console.print(Text.from_markup(" · ".join(parts)))
+                console.print()
 
 
 __all__ = ["ConsolePrinter"]

--- a/git_dev_metrics/metrics/printer/stale.py
+++ b/git_dev_metrics/metrics/printer/stale.py
@@ -4,12 +4,46 @@ from .._stale_pr import StalePr, summarize_stale_prs
 from ._html_templates import render_template
 
 
+def _target_status(
+    targets: dict[str, float], total: int, avg_age: float, stale_prs: list[StalePr]
+) -> dict:
+    items: list[dict] = []
+    met = 0
+
+    if "stale_max_count" in targets:
+        t = targets["stale_max_count"]
+        ok = total <= t
+        if ok:
+            met += 1
+        items.append(dict(label="Count", actual=total, target=t, ok=ok, unit=""))
+
+    if "stale_max_avg_age_days" in targets:
+        t = targets["stale_max_avg_age_days"]
+        ok = avg_age <= t
+        if ok:
+            met += 1
+        items.append(dict(label="Avg age", actual=round(avg_age, 1), target=t, ok=ok, unit="d"))
+
+    max_age = max((pr.age_days for pr in stale_prs), default=0.0)
+    if "stale_max_pr_age_days" in targets:
+        t = targets["stale_max_pr_age_days"]
+        ok = max_age <= t
+        if ok:
+            met += 1
+        items.append(dict(label="Max age", actual=round(max_age, 1), target=t, ok=ok, unit="d"))
+
+    return {"items": items, "met": met, "total": len(items)}
+
+
 class FileStaleHtmlPrinter:
     def __init__(self, output_path: Path) -> None:
         self._output_path = output_path
 
-    def render(self, stale_prs: list[StalePr]) -> None:
+    def render(self, stale_prs: list[StalePr], targets: dict[str, float] | None = None) -> None:
         total, avg_age = summarize_stale_prs(stale_prs)
-        html = render_template("stale.html", total=total, avg_age=avg_age, prs=stale_prs)
+        ctx = {"total": total, "avg_age": avg_age, "prs": stale_prs, "targets": None}
+        if targets:
+            ctx["targets"] = _target_status(targets, total, avg_age, stale_prs)
+        html = render_template("stale.html", **ctx)
         self._output_path.parent.mkdir(parents=True, exist_ok=True)
         self._output_path.write_text(html)

--- a/git_dev_metrics/metrics/printer/templates/dashboard.html
+++ b/git_dev_metrics/metrics/printer/templates/dashboard.html
@@ -348,6 +348,11 @@
     flex-shrink: 0;
   }
 
+  .target-ok { color: var(--green); }
+  .target-fail { color: var(--red); font-weight: 600; }
+  .target-items { display: flex; flex-direction: column; gap: 4px; font-size: 0.75rem; }
+  .target-items .item { display: flex; gap: 4px; }
+
   .scatter-container {
     position: relative;
     height: 260px;
@@ -481,6 +486,23 @@
     <div class="value">{{ summary.max_review_share }}%</div>
     <div class="sub">Reviews by top reviewer</div>
   </div>
+  {% if target_status and target_status.total > 0 %}
+  <div class="summary-card">
+    <div class="label">Targets</div>
+    <div class="value">{{ target_status.met }}/{{ target_status.total }}</div>
+    <div class="sub">Met</div>
+    <div class="target-items">
+      {% for t in target_status.items %}
+      <div class="item">
+        <span class="{% if t.ok %}target-ok{% else %}target-fail{% endif %}">
+          {% if t.ok %}✓{% else %}✗{% endif %}
+        </span>
+        {{ t.label }} {{ t.actual }}{{ t.unit }} / {{ t.target }}{{ t.unit }}
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+  {% endif %}
 </div>
 
 <div class="table-wrapper">

--- a/git_dev_metrics/metrics/printer/templates/stale.html
+++ b/git_dev_metrics/metrics/printer/templates/stale.html
@@ -36,6 +36,10 @@
   .badge { font-size: 0.7rem; padding: 0.1rem 0.4rem; border-radius: 4px; background: var(--border); color: var(--muted); }
   .badge-approved { background: rgba(34,197,94,0.15); color: var(--ok); }
   .empty { text-align: center; color: var(--muted); padding: 3rem; }
+  .targets { display: flex; gap: 1.5rem; justify-content: center; margin-bottom: 1.5rem; }
+  .target-item { font-size: 0.85rem; }
+  .target-item .ok { color: var(--ok); }
+  .target-item .fail { color: var(--crit); font-weight: 600; }
 </style>
 </head>
 <body>
@@ -44,6 +48,19 @@
     <h1>Stale PRs</h1>
     <p>{{ total }} open &gt; 7 days · avg age {{ "%.1f"|format(avg_age) }} days</p>
   </div>
+  {% if targets %}
+  <div class="targets">
+    {% for t in targets.items %}
+    <div class="target-item">
+      <span class="{% if t.ok %}ok{% else %}fail{% endif %}">
+        {% if t.ok %}✓{% else %}✗{% endif %}
+      </span>
+      {{ t.label }}: {{ t.actual }}{{ t.unit }} / {{ t.target }}{{ t.unit }}
+    </div>
+    {% endfor %}
+    <div class="target-item">Targets met: {{ targets.met }}/{{ targets.total }}</div>
+  </div>
+  {% endif %}
   <div class="card">
     {% if prs %}
     <table>

--- a/tests/unit/cache/test_cache.py
+++ b/tests/unit/cache/test_cache.py
@@ -3,14 +3,17 @@ import json
 from git_dev_metrics.cache import (
     count_prs,
     delete_nickname,
+    delete_target,
     get_all_dev_logins,
     get_nicknames,
+    get_targets,
     insert_prs,
     is_sealed,
     open_connection,
     query_prs,
     seal_month,
     set_nickname,
+    set_target,
 )
 
 from ..conftest import any_pr, approved_review, dt
@@ -233,3 +236,44 @@ class TestNicknameDb:
         logins = get_all_dev_logins(db_path=db_path)
 
         assert logins == set()
+
+
+class TestTargetDb:
+    def test_should_return_empty_dict_when_no_targets(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+
+        result = get_targets(db_path=db_path)
+
+        assert result == {}
+
+    def test_should_set_and_retrieve_target(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+
+        set_target("cycle_time_max", 24.0, db_path=db_path)
+
+        assert get_targets(db_path=db_path) == {"cycle_time_max": 24.0}
+
+    def test_should_replace_existing_target(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+        set_target("cycle_time_max", 24.0, db_path=db_path)
+
+        set_target("cycle_time_max", 48.0, db_path=db_path)
+
+        assert get_targets(db_path=db_path) == {"cycle_time_max": 48.0}
+
+    def test_should_delete_target(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+        set_target("cycle_time_max", 24.0, db_path=db_path)
+
+        delete_target("cycle_time_max", db_path=db_path)
+
+        assert get_targets(db_path=db_path) == {}
+
+    def test_should_return_all_targets(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+        set_target("cycle_time_max", 24.0, db_path=db_path)
+        set_target("health_min", 80.0, db_path=db_path)
+
+        result = get_targets(db_path=db_path)
+
+        assert result == {"cycle_time_max": 24.0, "health_min": 80.0}

--- a/tests/unit/cli/test_targets_command.py
+++ b/tests/unit/cli/test_targets_command.py
@@ -1,0 +1,90 @@
+from typer.testing import CliRunner
+
+from git_dev_metrics.cache import get_targets, set_target
+from git_dev_metrics.cli import app
+
+runner = CliRunner()
+
+
+class TestTargetsCommand:
+    def test_should_set_target_via_prompt(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+
+        result = runner.invoke(
+            app,
+            ["targets", "--db", str(db_path)],
+            input="24\n4\n12\n80\n2\n7\n5\n14\n21\n",
+        )
+
+        assert result.exit_code == 0, result.output
+        targets = get_targets(db_path=db_path)
+        assert targets["cycle_time_max"] == 24.0
+        assert targets["health_min"] == 80.0
+        assert targets["stale_threshold_days"] == 7.0
+
+    def test_should_replace_existing_target(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+        set_target("cycle_time_max", 48.0, db_path=db_path)
+
+        result = runner.invoke(
+            app,
+            ["targets", "--db", str(db_path)],
+            input="24\n\n\n\n\n\n\n\n\n",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert get_targets(db_path=db_path)["cycle_time_max"] == 24.0
+
+    def test_should_clear_target_with_x(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+        set_target("cycle_time_max", 24.0, db_path=db_path)
+
+        result = runner.invoke(
+            app,
+            ["targets", "--db", str(db_path)],
+            input="x\n\n\n\n\n\n\n\n\n",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "cycle_time_max" not in get_targets(db_path=db_path)
+
+    def test_should_skip_on_blank_input(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+        set_target("cycle_time_max", 24.0, db_path=db_path)
+
+        result = runner.invoke(
+            app,
+            ["targets", "--db", str(db_path)],
+            input="\n\n\n\n\n\n\n\n\n",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert get_targets(db_path=db_path)["cycle_time_max"] == 24.0
+
+    def test_should_show_current_values_as_hint(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+        set_target("cycle_time_max", 24.0, db_path=db_path)
+
+        result = runner.invoke(
+            app,
+            ["targets", "--db", str(db_path)],
+            input="\n\n\n\n\n\n\n\n\n",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "24.0" in result.output
+
+    def test_should_reject_invalid_number(self, tmp_path):
+        db_path = tmp_path / "cache.db"
+
+        result = runner.invoke(
+            app,
+            ["targets", "--db", str(db_path)],
+            input="abc\n24\n\n\n\n\n\n\n\n",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Invalid number" in result.stderr
+        # cycle_time_max should NOT have been set, so get_targets should not contain it
+        targets = get_targets(db_path=db_path)
+        assert "cycle_time_max" not in targets

--- a/tests/unit/metrics/test__stale_pr.py
+++ b/tests/unit/metrics/test__stale_pr.py
@@ -13,6 +13,29 @@ class TestGetStalePrs:
         result = get_stale_prs([], "myrepo")
         assert result == []
 
+    def test_should_use_custom_threshold(self):
+        from git_dev_metrics.metrics._stale_pr import get_stale_prs
+
+        now = datetime.now(UTC)
+        prs = cast(
+            list[OpenPullRequest],
+            [
+                {
+                    "number": 1,
+                    "title": "5 day old PR",
+                    "created_at": now - timedelta(days=5),
+                    "merged_at": None,
+                    "user": {"login": "alice"},
+                },
+            ],
+        )
+        # 5 days = 120 hours, threshold 96h should flag it
+        result = get_stale_prs(prs, "myrepo", lambda: now, threshold_hours=96)
+        assert len(result) == 1
+        # threshold 144h should not flag it
+        result = get_stale_prs(prs, "myrepo", lambda: now, threshold_hours=144)
+        assert result == []
+
     def test_should_return_fresh_prs(self):
         from git_dev_metrics.metrics._stale_pr import get_stale_prs
 

--- a/tests/unit/metrics/test_snapshot.py
+++ b/tests/unit/metrics/test_snapshot.py
@@ -276,3 +276,51 @@ class TestBuildSummary:
         assert summary.top_reviewer == "bob"
         assert summary.max_review_share == round(5 / 7 * 100)
         assert summary.review_ratio == round(7 / 5, 2)
+
+
+class TestTeamTargetStatus:
+    def test_should_return_total_zero_with_no_matching_targets(self):
+        from git_dev_metrics.metrics._rows import team_target_status
+
+        team = Row("team", 5, 10, 2, 4, 100, 20, 2.5, 7, 50, 80, "good")
+        result = team_target_status(team, {"unrelated": 42})
+        assert result["total"] == 0
+        assert result["met"] == 0
+
+    def test_should_report_cycle_time_target_as_met(self):
+        from git_dev_metrics.metrics._rows import team_target_status
+
+        team = Row("team", 5, 10, 2, 4, 100, 20, 2.5, 7, 50, 80, "good")
+        result = team_target_status(team, {"cycle_time_max": 24})
+        assert result["total"] == 1
+        assert result["met"] == 1
+        assert result["items"][0]["ok"] is True
+
+    def test_should_report_cycle_time_target_as_unmet(self):
+        from git_dev_metrics.metrics._rows import team_target_status
+
+        team = Row("team", 5, 30, 2, 4, 100, 20, 2.5, 7, 50, 80, "good")
+        result = team_target_status(team, {"cycle_time_max": 24})
+        assert result["total"] == 1
+        assert result["met"] == 0
+        assert result["items"][0]["ok"] is False
+
+    def test_should_report_health_min_target(self):
+        from git_dev_metrics.metrics._rows import team_target_status
+
+        team = Row("team", 5, 10, 2, 4, 100, 20, 2.5, 7, 50, 80, "good")
+        result = team_target_status(team, {"health_min": 90})
+        assert result["met"] == 0
+        result = team_target_status(team, {"health_min": 70})
+        assert result["met"] == 1
+
+    def test_should_handle_multiple_targets(self):
+        from git_dev_metrics.metrics._rows import team_target_status
+
+        team = Row("team", 5, 18, 3, 6, 100, 20, 3.0, 7, 50, 85, "good")
+        result = team_target_status(
+            team, {"cycle_time_max": 24, "pickup_time_max": 4, "health_min": 80}
+        )
+        assert result["total"] == 3
+        assert result["met"] == 3  # 18/24 ✓, 3/4 ✓, 85/80 ✓
+        assert all(item["ok"] for item in result["items"])


### PR DESCRIPTION
New 'targets' interactive wizard (like nickname) for setting
performance targets stored in SQLite. Targets are consumed by:
- dashboard/summary (cycle time, pickup time, health, etc.)
- stale report (threshold days, max count, max age)

The stale threshold is no longer hardcoded at 7 days — it reads
from the stale_threshold_days target (default 7).
