### PR TITLE
Fix AI-detection false positive, pattern drift, and review truncation

### DIFF
--- a/git_dev_metrics/github/graphql_queries.py
+++ b/git_dev_metrics/github/graphql_queries.py
@@ -83,8 +83,7 @@ REPO_METRICS_QUERY = gql.gql(
                             }
                         }
                     }
-                    # Note: max 10 reviews per PR - truncates if more
-                    reviews(first: 10) {
+                    reviews(first: 100) {
                         nodes {
                             author {
                                 login
@@ -208,7 +207,7 @@ SEARCH_MERGED_PRS_QUERY = gql.gql(
                             }
                         }
                     }
-                    reviews(first: 10) {
+                    reviews(first: 100) {
                         nodes {
                             author {
                                 login

--- a/git_dev_metrics/metrics/_ai_detection.py
+++ b/git_dev_metrics/metrics/_ai_detection.py
@@ -5,8 +5,7 @@ import re
 from ..models import PullRequest
 
 AI_TRAILER_PATTERNS = [
-    r"Co-Authored-By:",
-    r"co-authored-by:",
+    r"Co-Authored-By:.*\b(Claude|Copilot|Cursor|Devin|Aider)\b",
     r"Generated\s+(by|with|with\s+)?[\w\s]*AI",
     r"Claude\s+Code",
     r"Coding-Agent:",

--- a/git_dev_metrics/metrics/trend_calculator.py
+++ b/git_dev_metrics/metrics/trend_calculator.py
@@ -1,4 +1,3 @@
-import re
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
@@ -6,6 +5,7 @@ from typing import TypedDict
 
 from ..constants import is_bot_login
 from ..models import PullRequest
+from ._ai_detection import calculate_ai_percentage
 
 
 @dataclass(frozen=True)
@@ -88,38 +88,6 @@ def _median_cycle_hours(prs: list[PullRequest]) -> float:
     return round(_median(hours), 2) if hours else 0.0
 
 
-_AI_PATTERNS = [
-    r"Co-Authored-By:",
-    r"co-authored-by:",
-    r"Generated\s+(by|with|with\s+)?[\w\s]*AI",
-    r"Claude\s+Code",
-    r"Coding-Agent:",
-    r"AI-assistant:",
-    r"🤖\s*Generated",
-    r"Aider:",
-    r"Cursor:",
-    r"GitHub\s+Copilot:",
-    r"Devin:",
-]
-
-
-def _is_ai_coauthored(pr: PullRequest) -> bool:
-    texts = [pr.get("body") or "", *(pr.get("commit_messages") or [])]
-    return any(
-        re.search(pattern, text, re.IGNORECASE)
-        for text in texts
-        if text
-        for pattern in _AI_PATTERNS
-    )
-
-
-def _ai_percentage(prs: list[PullRequest]) -> float:
-    if not prs:
-        return 0.0
-    ai_count = sum(1 for pr in prs if _is_ai_coauthored(pr))
-    return round((ai_count / len(prs)) * 100, 1)
-
-
 def _row(dev: str, year: int, month: int, prs: list[PullRequest]) -> DevMonthRow:
     dev_prs = [pr for pr in prs if pr["user"]["login"] == dev]
     return DevMonthRow(
@@ -127,7 +95,7 @@ def _row(dev: str, year: int, month: int, prs: list[PullRequest]) -> DevMonthRow
         month_key=_month_key(year, month),
         pr_count=len(dev_prs),
         cycle_hours=_median_cycle_hours(dev_prs),
-        ai_pct=_ai_percentage(dev_prs),
+        ai_pct=calculate_ai_percentage(dev_prs),
     )
 
 

--- a/tests/unit/metrics/test__ai_detection.py
+++ b/tests/unit/metrics/test__ai_detection.py
@@ -22,16 +22,24 @@ class TestIsAiCoauthored:
         result = is_ai_coauthored(any_pr(body="This is a regular PR description"))
         assert result is False
 
-    def test_should_return_true_for_coauthored_by_in_body(self):
+    def test_should_return_false_for_human_coauthored_by(self):
         from git_dev_metrics.metrics._ai_detection import is_ai_coauthored
 
-        result = is_ai_coauthored(any_pr(body="Co-Authored-By: GitHub <noreply@github.com>"))
+        result = is_ai_coauthored(any_pr(body="Co-Authored-By: Jane Doe <jane@example.com>"))
+        assert result is False
+
+    def test_should_return_true_for_claude_coauthored_by(self):
+        from git_dev_metrics.metrics._ai_detection import is_ai_coauthored
+
+        result = is_ai_coauthored(
+            any_pr(body="Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>")
+        )
         assert result is True
 
     def test_should_be_case_insensitive(self):
         from git_dev_metrics.metrics._ai_detection import is_ai_coauthored
 
-        result = is_ai_coauthored(any_pr(body="co-authored-by: someone@example.com"))
+        result = is_ai_coauthored(any_pr(body="co-authored-by: cursor <cursor@example.com>"))
         assert result is True
 
     def test_should_return_true_when_trailer_only_in_commit_message(self):
@@ -91,9 +99,9 @@ class TestCalculateAiPercentage:
         from git_dev_metrics.metrics._ai_detection import calculate_ai_percentage
 
         prs = [
-            any_pr(body="Co-Authored-By: someone@example.com"),
+            any_pr(body="Co-Authored-By: Claude <noreply@anthropic.com>"),
             any_pr(body="Regular PR"),
-            any_pr(body="Co-Authored-By: another@example.com"),
+            any_pr(body="Co-Authored-By: Cursor <cursor@example.com>"),
             any_pr(body="Another regular PR"),
         ]
         result = calculate_ai_percentage(prs)
@@ -103,8 +111,8 @@ class TestCalculateAiPercentage:
         from git_dev_metrics.metrics._ai_detection import calculate_ai_percentage
 
         prs = [
-            any_pr(body="Co-Authored-By: someone@example.com"),
-            any_pr(body="Co-Authored-By: another@example.com"),
+            any_pr(body="Co-Authored-By: Claude <noreply@anthropic.com>"),
+            any_pr(body="Co-Authored-By: Cursor <cursor@example.com>"),
         ]
         result = calculate_ai_percentage(prs)
         assert result == 100.0
@@ -113,7 +121,7 @@ class TestCalculateAiPercentage:
         from git_dev_metrics.metrics._ai_detection import calculate_ai_percentage
 
         prs = [
-            any_pr(body="Co-Authored-By: someone@example.com"),
+            any_pr(body="Co-Authored-By: Claude <noreply@anthropic.com>"),
             any_pr(body="Regular PR"),
             any_pr(body="Regular PR"),
         ]


### PR DESCRIPTION
The AI co-author detector matched any bare `Co-Authored-By:` trailer, so ordinary human co-authored commits were counted as AI-assisted and inflated `ai_percentage`. The same AI-pattern list was duplicated in `_ai_detection.py` and `trend_calculator.py`, letting the dashboard and trend AI% drift apart, and review fetching was capped at 10 per PR, which undercounts reviews and can misidentify first approval on heavily-reviewed PRs.

Detection now keys on AI-specific authorship signals only — `Co-Authored-By:` lines naming Claude, Copilot, Cursor, Devin, or Aider plus the existing AI generation markers — so a Claude co-author still counts while a human one does not. `trend_calculator` now imports the detector from `_ai_detection` so there is a single source of truth, and the `reviews` page size is raised to 100 (matching the open-PR query).

🤖 Generated with [Claude Code](https://claude.com/claude-code)