### PR TITLE
feat: per-dev stacked area chart for team-velocity report

### DIFF
--- a/git_dev_metrics/cli/commands/team_velocity.py
+++ b/git_dev_metrics/cli/commands/team_velocity.py
@@ -2,15 +2,41 @@ from pathlib import Path
 
 import typer
 
+from ...cache import get_nicknames
 from ...utils.date_utils import last_n_months
+from .._month_arg import parse_month_arg
 from .._options import DB_OPTION
 from ..runners.team_velocity_runner import perform_team_velocity
+from ..wizards.team_velocity_wizard import team_velocity_wizard
 
 
 def team_velocity(
+    mode: str | None = typer.Argument(None, help="'current' for last 12 months"),
+    from_: str | None = typer.Option(None, "--from", help="Start month, YYYY-MM"),
+    to: str | None = typer.Option(None, "--to", help="End month, YYYY-MM"),
     output: Path | None = typer.Option(None, "--output", help="Output HTML path"),
     db: Path | None = DB_OPTION,
 ) -> None:
-    """Render a team velocity chart: merged PRs vs active developers over time."""
-    from_ym, to_ym = last_n_months(12, include_current=True)
-    perform_team_velocity(from_ym, to_ym, output=output, db_path=db)
+    """Render a team velocity chart: merged PRs per developer over time."""
+    nicknames = get_nicknames(db_path=db)
+
+    if mode == "current":
+        from_ym, to_ym = last_n_months(12, include_current=True)
+        perform_team_velocity(from_ym, to_ym, output=output, db_path=db, nicknames=nicknames)
+        return
+
+    if from_ is None and to is None:
+        team_velocity_wizard(db_path=db)
+        return
+
+    if from_ is None or to is None:
+        typer.secho(
+            "Provide both --from and --to, or neither (for the wizard).",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    from_ym = parse_month_arg(from_, "--from")
+    to_ym = parse_month_arg(to, "--to")
+    perform_team_velocity(from_ym, to_ym, output=output, db_path=db, nicknames=nicknames)

--- a/git_dev_metrics/cli/runners/team_velocity_runner.py
+++ b/git_dev_metrics/cli/runners/team_velocity_runner.py
@@ -24,6 +24,7 @@ def perform_team_velocity(
     to_ym: YearMonth,
     output: Path | None,
     db_path: Path | None,
+    nicknames: dict[str, str] | None = None,
 ) -> None:
     if to_ym < from_ym:
         typer.secho("--to must be >= --from.", fg=typer.colors.RED, err=True)
@@ -46,6 +47,6 @@ def perform_team_velocity(
         f" – {datetime(last[0], last[1], 1).strftime('%b %Y')}"
     )
     out_path = output or _default_output(from_ym, to_ym)
-    FileTeamVelocityPrinter(out_path).render(dataset, period_range)
+    FileTeamVelocityPrinter(out_path).render(dataset, period_range, nicknames=nicknames)
     typer.echo(f"Team velocity written to {out_path}.")
     open_in_browser(out_path)

--- a/git_dev_metrics/cli/wizards/team_velocity_wizard.py
+++ b/git_dev_metrics/cli/wizards/team_velocity_wizard.py
@@ -1,0 +1,54 @@
+from collections.abc import Callable
+from datetime import datetime
+from pathlib import Path
+
+import questionary
+import typer
+
+from ...cache import get_nicknames, list_synced_months
+from ..runners.team_velocity_runner import perform_team_velocity
+from ._wizard import _STYLE, YearMonth
+
+
+def _month_choices(months: list[YearMonth]) -> list[questionary.Choice]:
+    return [
+        questionary.Choice(title=datetime(y, m, 1).strftime("%B %Y"), value=(y, m))
+        for y, m in months
+    ]
+
+
+def _prompt_from(months: list[YearMonth]) -> YearMonth | None:
+    return questionary.select(
+        "From month:", choices=_month_choices(list(reversed(months))), style=_STYLE
+    ).ask()
+
+
+def _prompt_to(months: list[YearMonth]) -> YearMonth | None:
+    return questionary.select(
+        "To month:", choices=_month_choices(list(reversed(months))), style=_STYLE
+    ).ask()
+
+
+def team_velocity_wizard(
+    db_path: Path | None = None,
+    *,
+    ask_from: Callable[[list[YearMonth]], YearMonth | None] = _prompt_from,
+    ask_to: Callable[[list[YearMonth]], YearMonth | None] = _prompt_to,
+) -> None:
+    """Pick from/to months across the union of synced months; render team velocity HTML."""
+    synced = list_synced_months(db_path=db_path)
+    if not synced:
+        typer.secho("No synced months — run pull first.", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=1)
+
+    months = sorted({(y, m) for _, _, y, m in synced})
+    from_ym = ask_from(months)
+    if from_ym is None:
+        raise typer.Exit(code=1)
+    to_candidates = [ym for ym in months if ym >= from_ym]
+    to_ym = ask_to(to_candidates)
+    if to_ym is None:
+        raise typer.Exit(code=1)
+
+    nicknames = get_nicknames(db_path=db_path)
+    perform_team_velocity(from_ym, to_ym, output=None, db_path=db_path, nicknames=nicknames)

--- a/git_dev_metrics/metrics/printer/team_velocity.py
+++ b/git_dev_metrics/metrics/printer/team_velocity.py
@@ -8,7 +8,18 @@ class FileTeamVelocityPrinter:
     def __init__(self, output_path: Path) -> None:
         self._output_path = output_path
 
-    def render(self, dataset: TeamVelocityDataset, period_range: str) -> None:
+    def render(
+        self,
+        dataset: TeamVelocityDataset,
+        period_range: str,
+        nicknames: dict[str, str] | None = None,
+    ) -> None:
+        raw_names = sorted(dataset.dev_month_counts[0].keys()) if dataset.dev_month_counts else []
+        resolve = (nicknames or {}).get
+        dev_names = [resolve(n, n) for n in raw_names]
+        dev_data = [
+            [month_counts[dev] for month_counts in dataset.dev_month_counts] for dev in dev_names
+        ]
         html = render_template(
             "team_velocity.html",
             period_range=period_range,
@@ -16,6 +27,8 @@ class FileTeamVelocityPrinter:
             pr_counts=[m.pr_count for m in dataset.months],
             active_devs=[m.active_devs for m in dataset.months],
             prs_per_dev=[m.prs_per_dev for m in dataset.months],
+            dev_names=dev_names,
+            dev_data=dev_data,
         )
         self._output_path.parent.mkdir(parents=True, exist_ok=True)
         self._output_path.write_text(html)

--- a/git_dev_metrics/metrics/printer/templates/team_velocity.html
+++ b/git_dev_metrics/metrics/printer/templates/team_velocity.html
@@ -46,12 +46,38 @@
 </div>
 <div class="grid">
   <div class="card"><h2>PR throughput, active devs, and PRs per developer</h2><div class="chart-wrap"><canvas id="velocity"></canvas></div></div>
+  <div class="card"><h2>PR throughput by developer (stacked)</h2><div class="chart-wrap"><canvas id="per-dev"></canvas></div></div>
 </div>
 <script>
 const MONTHS = {{ month_labels | tojson }};
 const PR_COUNTS = {{ pr_counts | tojson }};
 const ACTIVE_DEVS = {{ active_devs | tojson }};
 const PRS_PER_DEV = {{ prs_per_dev | tojson }};
+const DEV_NAMES = {{ dev_names | tojson }};
+const DEV_DATA = {{ dev_data | tojson }};
+
+const palette = [
+  { b: '#4e79a7', f: 'rgba(78,121,167,0.45)' },
+  { b: '#f28e2b', f: 'rgba(242,142,43,0.45)' },
+  { b: '#e15759', f: 'rgba(225,87,89,0.45)' },
+  { b: '#76b7b2', f: 'rgba(118,183,178,0.45)' },
+  { b: '#59a14f', f: 'rgba(89,161,79,0.45)' },
+  { b: '#edc948', f: 'rgba(237,201,72,0.45)' },
+  { b: '#b07aa1', f: 'rgba(176,122,161,0.45)' },
+  { b: '#ff9da7', f: 'rgba(255,157,167,0.45)' },
+  { b: '#9c755f', f: 'rgba(156,117,95,0.45)' },
+  { b: '#4c6b8a', f: 'rgba(76,107,138,0.45)' },
+  { b: '#e06c5e', f: 'rgba(224,108,94,0.45)' },
+  { b: '#6ba3a0', f: 'rgba(107,163,160,0.45)' },
+  { b: '#b88b4a', f: 'rgba(184,139,74,0.45)' },
+  { b: '#a55e79', f: 'rgba(165,94,121,0.45)' },
+  { b: '#5f8f5a', f: 'rgba(95,143,90,0.45)' },
+  { b: '#c5a84d', f: 'rgba(197,168,77,0.45)' },
+  { b: '#8d6e8b', f: 'rgba(141,110,139,0.45)' },
+  { b: '#d48a8a', f: 'rgba(212,138,138,0.45)' },
+  { b: '#7a6b60', f: 'rgba(122,107,96,0.45)' },
+  { b: '#5b7f95', f: 'rgba(91,127,149,0.45)' },
+];
 
 new Chart(document.getElementById('velocity'), {
   type: 'line',
@@ -119,6 +145,54 @@ new Chart(document.getElementById('velocity'), {
         ticks: { color: '#8b8fa3' },
         grid: { drawOnChartArea: false },
         beginAtZero: true,
+      },
+    },
+    plugins: {
+      legend: {
+        labels: { color: '#e1e4ed', usePointStyle: true, padding: 20 },
+      },
+      tooltip: {
+        callbacks: {
+          label: function(ctx) {
+            return ctx.dataset.label + ': ' + ctx.parsed.y;
+          },
+        },
+      },
+    },
+  },
+});
+
+new Chart(document.getElementById('per-dev'), {
+  type: 'line',
+  data: {
+    labels: MONTHS,
+    datasets: DEV_NAMES.map((name, i) => ({
+      label: name,
+      data: DEV_DATA[i],
+      borderColor: palette[i % palette.length].b,
+      backgroundColor: palette[i % palette.length].f,
+      borderWidth: 2,
+      fill: true,
+      tension: 0.2,
+      pointRadius: 2,
+      pointHoverRadius: 4,
+    })),
+  },
+  options: {
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: { mode: 'index', intersect: false },
+    scales: {
+      x: {
+        ticks: { color: '#8b8fa3' },
+        grid: { color: '#2a2d3a' },
+      },
+      y: {
+        stacked: true,
+        beginAtZero: true,
+        title: { display: true, text: 'Merged PRs', color: '#8b8fa3' },
+        ticks: { color: '#8b8fa3' },
+        grid: { color: '#2a2d3a' },
       },
     },
     plugins: {

--- a/git_dev_metrics/metrics/team_velocity_calculator.py
+++ b/git_dev_metrics/metrics/team_velocity_calculator.py
@@ -18,10 +18,41 @@ class TeamVelocityMonth:
 @dataclass(frozen=True)
 class TeamVelocityDataset:
     months: list[TeamVelocityMonth]
+    dev_month_counts: list[dict[str, int]]
 
 
 def _count_active_devs(prs: Sequence[PullRequest]) -> int:
     return len({pr["user"]["login"] for pr in prs if not is_bot_login(pr["user"]["login"])})
+
+
+def _latest_active_devs(
+    months: list[tuple[int, int]], prs_per_month: dict[tuple[int, int], list[PullRequest]]
+) -> set[str]:
+    for y, m in reversed(months):
+        month_prs = prs_per_month.get((y, m), [])
+        if month_prs:
+            return {
+                pr["user"]["login"] for pr in month_prs if not is_bot_login(pr["user"]["login"])
+            }
+    return set()
+
+
+def _dev_month_counts(
+    months: list[tuple[int, int]], prs_per_month: dict[tuple[int, int], list[PullRequest]]
+) -> list[dict[str, int]]:
+    all_devs = sorted(_latest_active_devs(months, prs_per_month))
+    result: list[dict[str, int]] = []
+    for y, m in months:
+        month_prs = prs_per_month.get((y, m), [])
+        if not month_prs:
+            continue
+        counts: dict[str, int] = {dev: 0 for dev in all_devs}
+        for pr in month_prs:
+            login = pr["user"]["login"]
+            if login in counts:
+                counts[login] += 1
+        result.append(counts)
+    return result
 
 
 def build_team_velocity_dataset(
@@ -45,7 +76,8 @@ def build_team_velocity_dataset(
                 prs_per_dev=round(pr_count / active, 1) if active else 0.0,
             )
         )
-    return TeamVelocityDataset(months=rows)
+    dev_counts = _dev_month_counts(months, prs_per_month)
+    return TeamVelocityDataset(months=rows, dev_month_counts=dev_counts)
 
 
 __all__ = ["TeamVelocityDataset", "TeamVelocityMonth", "build_team_velocity_dataset"]


### PR DESCRIPTION
## Summary

Replaces the hardcoded 12-month default with a proper `--from`/`--to` + wizard flow (matching `trend`/dashboard patterns) and adds a per-developer stacked area chart to the team-velocity report.

## Changes

- **CLI**: `team-velocity` now accepts `--from`/`--to` flags or a `current` positional arg for quick 12-month view. No args → interactive wizard.
- **Calculator**: `TeamVelocityDataset` gains `dev_month_counts` — per-dev PR counts per month. Devs filtered to latest-month active only (leavers excluded, matching `trend` behavior).
- **Template**: New "PR throughput by developer (stacked)" Chart.js stacked area chart with 20-color Tableau-derived palette.
- **Nicknames**: Dev names resolved through nickname DB in legend labels.
- **Color fix**: Switched from hex+alpha suffix (broken in some browsers) to `rgba()` for reliable stacked area fills.