### PR TITLE
feat: add --from/--to flags + wizard + current shortcut to team-velocity

### DIFF
--- a/git_dev_metrics/cli/commands/team_velocity.py
+++ b/git_dev_metrics/cli/commands/team_velocity.py
@@ -3,14 +3,37 @@ from pathlib import Path
 import typer
 
 from ...utils.date_utils import last_n_months
+from .._month_arg import parse_month_arg
 from .._options import DB_OPTION
 from ..runners.team_velocity_runner import perform_team_velocity
+from ..wizards.team_velocity_wizard import team_velocity_wizard
 
 
 def team_velocity(
+    mode: str | None = typer.Argument(None, help="'current' for last 12 months"),
+    from_: str | None = typer.Option(None, "--from", help="Start month, YYYY-MM"),
+    to: str | None = typer.Option(None, "--to", help="End month, YYYY-MM"),
     output: Path | None = typer.Option(None, "--output", help="Output HTML path"),
     db: Path | None = DB_OPTION,
 ) -> None:
-    """Render a team velocity chart: merged PRs vs active developers over time."""
-    from_ym, to_ym = last_n_months(12, include_current=True)
+    """Render a team velocity chart: merged PRs per developer over time."""
+    if mode == "current":
+        from_ym, to_ym = last_n_months(12, include_current=True)
+        perform_team_velocity(from_ym, to_ym, output=output, db_path=db)
+        return
+
+    if from_ is None and to is None:
+        team_velocity_wizard(db_path=db)
+        return
+
+    if from_ is None or to is None:
+        typer.secho(
+            "Provide both --from and --to, or neither (for the wizard).",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    from_ym = parse_month_arg(from_, "--from")
+    to_ym = parse_month_arg(to, "--to")
     perform_team_velocity(from_ym, to_ym, output=output, db_path=db)

--- a/git_dev_metrics/cli/wizards/team_velocity_wizard.py
+++ b/git_dev_metrics/cli/wizards/team_velocity_wizard.py
@@ -1,0 +1,53 @@
+from collections.abc import Callable
+from datetime import datetime
+from pathlib import Path
+
+import questionary
+import typer
+
+from ...cache import list_synced_months
+from ..runners.team_velocity_runner import perform_team_velocity
+from ._wizard import _STYLE, YearMonth
+
+
+def _month_choices(months: list[YearMonth]) -> list[questionary.Choice]:
+    return [
+        questionary.Choice(title=datetime(y, m, 1).strftime("%B %Y"), value=(y, m))
+        for y, m in months
+    ]
+
+
+def _prompt_from(months: list[YearMonth]) -> YearMonth | None:
+    return questionary.select(
+        "From month:", choices=_month_choices(list(reversed(months))), style=_STYLE
+    ).ask()
+
+
+def _prompt_to(months: list[YearMonth]) -> YearMonth | None:
+    return questionary.select(
+        "To month:", choices=_month_choices(list(reversed(months))), style=_STYLE
+    ).ask()
+
+
+def team_velocity_wizard(
+    db_path: Path | None = None,
+    *,
+    ask_from: Callable[[list[YearMonth]], YearMonth | None] = _prompt_from,
+    ask_to: Callable[[list[YearMonth]], YearMonth | None] = _prompt_to,
+) -> None:
+    """Pick from/to months across the union of synced months; render team velocity HTML."""
+    synced = list_synced_months(db_path=db_path)
+    if not synced:
+        typer.secho("No synced months — run pull first.", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=1)
+
+    months = sorted({(y, m) for _, _, y, m in synced})
+    from_ym = ask_from(months)
+    if from_ym is None:
+        raise typer.Exit(code=1)
+    to_candidates = [ym for ym in months if ym >= from_ym]
+    to_ym = ask_to(to_candidates)
+    if to_ym is None:
+        raise typer.Exit(code=1)
+
+    perform_team_velocity(from_ym, to_ym, output=None, db_path=db_path)


### PR DESCRIPTION
## Summary

Replace hardcoded 12-month default with flexible range selection for the `team-velocity` command.

## Changes

- **`cli/commands/team_velocity.py`**: Add `--from`/-`-to` flags (`YYYY-MM`), `current` positional shortcut (last 12 months), and dispatch to interactive wizard when neither flag is given
- **`cli/wizards/team_velocity_wizard.py`** (new): Interactive month-picker wizard following existing wizard patterns (`trend_wizard.py`, `pull_wizard.py`)

## Review notes

- `parse_month_arg` imported from `cli/_month_arg.py` (shared across commands)
- Wizard uses `questionary.select` with `_STYLE` from `wizards/_wizard.py`
- Nickname resolution intentionally excluded — handled in PR C