### PR TITLE
feat: add per-dev PR counts to team velocity dataset

### DIFF
--- a/git_dev_metrics/metrics/team_velocity_calculator.py
+++ b/git_dev_metrics/metrics/team_velocity_calculator.py
@@ -18,10 +18,41 @@ class TeamVelocityMonth:
 @dataclass(frozen=True)
 class TeamVelocityDataset:
     months: list[TeamVelocityMonth]
+    dev_month_counts: list[dict[str, int]]
 
 
 def _count_active_devs(prs: Sequence[PullRequest]) -> int:
     return len({pr["user"]["login"] for pr in prs if not is_bot_login(pr["user"]["login"])})
+
+
+def _latest_active_devs(
+    months: list[tuple[int, int]], prs_per_month: dict[tuple[int, int], list[PullRequest]]
+) -> set[str]:
+    for y, m in reversed(months):
+        month_prs = prs_per_month.get((y, m), [])
+        if month_prs:
+            return {
+                pr["user"]["login"] for pr in month_prs if not is_bot_login(pr["user"]["login"])
+            }
+    return set()
+
+
+def _dev_month_counts(
+    months: list[tuple[int, int]], prs_per_month: dict[tuple[int, int], list[PullRequest]]
+) -> list[dict[str, int]]:
+    all_devs = sorted(_latest_active_devs(months, prs_per_month))
+    result: list[dict[str, int]] = []
+    for y, m in months:
+        month_prs = prs_per_month.get((y, m), [])
+        if not month_prs:
+            continue
+        counts: dict[str, int] = {dev: 0 for dev in all_devs}
+        for pr in month_prs:
+            login = pr["user"]["login"]
+            if login in counts:
+                counts[login] += 1
+        result.append(counts)
+    return result
 
 
 def build_team_velocity_dataset(
@@ -45,7 +76,14 @@ def build_team_velocity_dataset(
                 prs_per_dev=round(pr_count / active, 1) if active else 0.0,
             )
         )
-    return TeamVelocityDataset(months=rows)
+    dev_counts = _dev_month_counts(months, prs_per_month)
+    return TeamVelocityDataset(months=rows, dev_month_counts=dev_counts)
 
 
-__all__ = ["TeamVelocityDataset", "TeamVelocityMonth", "build_team_velocity_dataset"]
+__all__ = [
+    "TeamVelocityDataset",
+    "TeamVelocityMonth",
+    "build_team_velocity_dataset",
+    "_latest_active_devs",
+    "_dev_month_counts",
+]


### PR DESCRIPTION
## Summary

Extend `TeamVelocityDataset` with per-developer PR counts per month, enabling stacked area visualisations downstream.

## Changes

- **`metrics/team_velocity_calculator.py`**:
  - Add `dev_month_counts: list[dict[str, int]]` field to `TeamVelocityDataset`
  - Add `_latest_active_devs()` — finds the set of non-bot devs active in the most recent month with data
  - Add `_dev_month_counts()` — builds a per-month dict of login→PR count, filtered to the latest-active dev set
  - `build_team_velocity_dataset()` now returns both `months` and `dev_month_counts`

## Review notes

- Data is pruned to devs active in the latest non-empty month — avoids showing churned devs with all-zero tails
- Private helpers prefixed `_` per project convention
- Next PR (C) consumes this data in the stack chart