### PR TITLE
feat: add stacked area chart for per-dev PR contributions

### DIFF
--- a/git_dev_metrics/cli/runners/team_velocity_runner.py
+++ b/git_dev_metrics/cli/runners/team_velocity_runner.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import typer
 
-from ...cache import load_all_repos_by_month
+from ...cache import get_nicknames, load_all_repos_by_month
 from ...metrics.printer.team_velocity import FileTeamVelocityPrinter
 from ...metrics.team_velocity_calculator import build_team_velocity_dataset
 from ...utils.date_utils import month_iter
@@ -40,12 +40,13 @@ def perform_team_velocity(
         raise typer.Exit(code=1)
 
     dataset = build_team_velocity_dataset(months, prs_per_month)
+    nicknames = get_nicknames(db_path=db_path)
     first, last = months[0], months[-1]
     period_range = (
         f"{datetime(first[0], first[1], 1).strftime('%b %Y')}"
         f" – {datetime(last[0], last[1], 1).strftime('%b %Y')}"
     )
     out_path = output or _default_output(from_ym, to_ym)
-    FileTeamVelocityPrinter(out_path).render(dataset, period_range)
+    FileTeamVelocityPrinter(out_path).render(dataset, period_range, dev_names=nicknames)
     typer.echo(f"Team velocity written to {out_path}.")
     open_in_browser(out_path)

--- a/git_dev_metrics/metrics/printer/team_velocity.py
+++ b/git_dev_metrics/metrics/printer/team_velocity.py
@@ -8,14 +8,33 @@ class FileTeamVelocityPrinter:
     def __init__(self, output_path: Path) -> None:
         self._output_path = output_path
 
-    def render(self, dataset: TeamVelocityDataset, period_range: str) -> None:
+    def render(
+        self, dataset: TeamVelocityDataset, period_range: str, dev_names: dict[str, str] | None = None
+    ) -> None:
+        dev_data: list[dict[str, int]] = []
+        month_labels = [m.month_label for m in dataset.months]
+        if dataset.dev_month_counts and dev_names is not None:
+            devs_present: list[str] = []
+            for counts in dataset.dev_month_counts:
+                for login in counts:
+                    if login not in devs_present:
+                        devs_present.append(login)
+            dev_data = [
+                {
+                    "label": dev_names.get(login, login),
+                    "data": [m.get(login, 0) for m in dataset.dev_month_counts],
+                }
+                for login in devs_present
+            ]
+
         html = render_template(
             "team_velocity.html",
             period_range=period_range,
-            month_labels=[m.month_label for m in dataset.months],
+            month_labels=month_labels,
             pr_counts=[m.pr_count for m in dataset.months],
             active_devs=[m.active_devs for m in dataset.months],
             prs_per_dev=[m.prs_per_dev for m in dataset.months],
+            dev_data=dev_data,
         )
         self._output_path.parent.mkdir(parents=True, exist_ok=True)
         self._output_path.write_text(html)

--- a/git_dev_metrics/metrics/printer/templates/team_velocity.html
+++ b/git_dev_metrics/metrics/printer/templates/team_velocity.html
@@ -46,6 +46,9 @@
 </div>
 <div class="grid">
   <div class="card"><h2>PR throughput, active devs, and PRs per developer</h2><div class="chart-wrap"><canvas id="velocity"></canvas></div></div>
+  {% if dev_data %}
+  <div class="card"><h2>PRs per developer (stacked)</h2><div class="chart-wrap"><canvas id="perdev"></canvas></div></div>
+  {% endif %}
 </div>
 <script>
 const MONTHS = {{ month_labels | tojson }};
@@ -135,6 +138,52 @@ new Chart(document.getElementById('velocity'), {
     },
   },
 });
+{% if dev_data %}
+const DEV_DATA = {{ dev_data | tojson }};
+new Chart(document.getElementById('perdev'), {
+  type: 'line',
+  data: {
+    labels: MONTHS,
+    datasets: DEV_DATA.map(function(s, i) {
+      const hue = (i * 137) % 360;
+      return {
+        label: s.label,
+        data: s.data,
+        borderColor: 'hsl(' + hue + ', 70%, 55%)',
+        backgroundColor: 'hsla(' + hue + ', 70%, 55%, 0.3)',
+        fill: true,
+        tension: 0.2,
+        pointRadius: 3,
+        pointHoverRadius: 5,
+      };
+    }),
+  },
+  options: {
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: { mode: 'index', intersect: false },
+    scales: {
+      x: { ticks: { color: '#8b8fa3' }, grid: { color: '#2a2d3a' } },
+      y: {
+        beginAtZero: true,
+        ticks: { color: '#8b8fa3' },
+        grid: { color: '#2a2d3a' },
+        title: { display: true, text: 'Merged PRs', color: '#8b8fa3' },
+      },
+    },
+    plugins: {
+      legend: { labels: { color: '#e1e4ed', usePointStyle: true, padding: 20 } },
+      tooltip: {
+        callbacks: {
+          label: function(ctx) {
+            return ctx.dataset.label + ': ' + ctx.parsed.y;
+          },
+        },
+      },
+    },
+  },
+});
+{% endif %}
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Add a stacked area chart showing per-developer PR contributions over time, with optional GitHub login → display-name resolution via the existing nickname system.

## Changes

- **`cli/runners/team_velocity_runner.py`**: Load nicknames via `get_nicknames()` and pass `dev_names` to printer
- **`metrics/printer/team_velocity.py`**: Accept optional `dev_names` dict, build `dev_data` array for template (resolving logins to display names)
- **`metrics/printer/templates/team_velocity.html`**: Add stacked area chart card (hidden when no dev data), auto-generated hue-based colours

## Dependencies

- **Requires PR #215** — consumes `dev_month_counts` field added there
- Nickname data loaded in runner (not command) to avoid touching PR #214 files

## Review notes

- Chart renders only when `dev_data` is non-empty (i.e. `dev_month_counts` exists + nicknames loaded)
- Colours generated via golden-angle hue distribution (`i * 137 % 360`) — no hardcoded colour list needed