### PR TITLE
feat: add stacked area chart for per-dev PR contributions

### DIFF
--- a/git_dev_metrics/metrics/printer/team_velocity.py
+++ b/git_dev_metrics/metrics/printer/team_velocity.py
@@ -9,13 +9,24 @@ class FileTeamVelocityPrinter:
         self._output_path = output_path
 
     def render(self, dataset: TeamVelocityDataset, period_range: str) -> None:
+        month_labels = [m.month_label for m in dataset.months]
+
+        dev_data: list[dict[str, str | list[int]]] = []
+        if dataset.dev_month_counts:
+            logins = sorted(dataset.dev_month_counts[0].keys())
+            dev_data = [
+                {"label": login, "data": [m.get(login, 0) for m in dataset.dev_month_counts]}
+                for login in logins
+            ]
+
         html = render_template(
             "team_velocity.html",
             period_range=period_range,
-            month_labels=[m.month_label for m in dataset.months],
+            month_labels=month_labels,
             pr_counts=[m.pr_count for m in dataset.months],
             active_devs=[m.active_devs for m in dataset.months],
             prs_per_dev=[m.prs_per_dev for m in dataset.months],
+            dev_data=dev_data,
         )
         self._output_path.parent.mkdir(parents=True, exist_ok=True)
         self._output_path.write_text(html)

--- a/git_dev_metrics/metrics/printer/templates/team_velocity.html
+++ b/git_dev_metrics/metrics/printer/templates/team_velocity.html
@@ -46,6 +46,7 @@
 </div>
 <div class="grid">
   <div class="card"><h2>PR throughput, active devs, and PRs per developer</h2><div class="chart-wrap"><canvas id="velocity"></canvas></div></div>
+  <div class="card"><h2>PRs per developer (stacked)</h2><div class="chart-wrap"><canvas id="perdev"></canvas></div></div>
 </div>
 <script>
 const MONTHS = {{ month_labels | tojson }};
@@ -125,6 +126,51 @@ new Chart(document.getElementById('velocity'), {
       legend: {
         labels: { color: '#e1e4ed', usePointStyle: true, padding: 20 },
       },
+      tooltip: {
+        callbacks: {
+          label: function(ctx) {
+            return ctx.dataset.label + ': ' + ctx.parsed.y;
+          },
+        },
+      },
+    },
+  },
+});
+
+const DEV_DATA = {{ dev_data | tojson }};
+new Chart(document.getElementById('perdev'), {
+  type: 'line',
+  data: {
+    labels: MONTHS,
+    datasets: DEV_DATA.map(function(s, i) {
+      const hue = (i * 137) % 360;
+      return {
+        label: s.label,
+        data: s.data,
+        borderColor: 'hsl(' + hue + ', 70%, 55%)',
+        backgroundColor: 'hsla(' + hue + ', 70%, 55%, 0.3)',
+        fill: true,
+        tension: 0.2,
+        pointRadius: 3,
+        pointHoverRadius: 5,
+      };
+    }),
+  },
+  options: {
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: { mode: 'index', intersect: false },
+    scales: {
+      x: { ticks: { color: '#8b8fa3' }, grid: { color: '#2a2d3a' } },
+      y: {
+        beginAtZero: true,
+        ticks: { color: '#8b8fa3' },
+        grid: { color: '#2a2d3a' },
+        title: { display: true, text: 'Merged PRs', color: '#8b8fa3' },
+      },
+    },
+    plugins: {
+      legend: { labels: { color: '#e1e4ed', usePointStyle: true, padding: 20 } },
       tooltip: {
         callbacks: {
           label: function(ctx) {

--- a/git_dev_metrics/metrics/team_velocity_calculator.py
+++ b/git_dev_metrics/metrics/team_velocity_calculator.py
@@ -18,10 +18,41 @@ class TeamVelocityMonth:
 @dataclass(frozen=True)
 class TeamVelocityDataset:
     months: list[TeamVelocityMonth]
+    dev_month_counts: list[dict[str, int]]
 
 
 def _count_active_devs(prs: Sequence[PullRequest]) -> int:
     return len({pr["user"]["login"] for pr in prs if not is_bot_login(pr["user"]["login"])})
+
+
+def _latest_active_devs(
+    months: list[tuple[int, int]], prs_per_month: dict[tuple[int, int], list[PullRequest]]
+) -> set[str]:
+    for y, m in reversed(months):
+        month_prs = prs_per_month.get((y, m), [])
+        if month_prs:
+            return {
+                pr["user"]["login"] for pr in month_prs if not is_bot_login(pr["user"]["login"])
+            }
+    return set()
+
+
+def _dev_month_counts(
+    months: list[tuple[int, int]], prs_per_month: dict[tuple[int, int], list[PullRequest]]
+) -> list[dict[str, int]]:
+    all_devs = sorted(_latest_active_devs(months, prs_per_month))
+    result: list[dict[str, int]] = []
+    for y, m in months:
+        month_prs = prs_per_month.get((y, m), [])
+        if not month_prs:
+            continue
+        counts: dict[str, int] = {dev: 0 for dev in all_devs}
+        for pr in month_prs:
+            login = pr["user"]["login"]
+            if login in counts:
+                counts[login] += 1
+        result.append(counts)
+    return result
 
 
 def build_team_velocity_dataset(
@@ -45,7 +76,14 @@ def build_team_velocity_dataset(
                 prs_per_dev=round(pr_count / active, 1) if active else 0.0,
             )
         )
-    return TeamVelocityDataset(months=rows)
+    dev_counts = _dev_month_counts(months, prs_per_month)
+    return TeamVelocityDataset(months=rows, dev_month_counts=dev_counts)
 
 
-__all__ = ["TeamVelocityDataset", "TeamVelocityMonth", "build_team_velocity_dataset"]
+__all__ = [
+    "TeamVelocityDataset",
+    "TeamVelocityMonth",
+    "_dev_month_counts",
+    "_latest_active_devs",
+    "build_team_velocity_dataset",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -671,11 +671,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1"
+version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/7e/d2b04004e1068ad4fdfa2f227b839b5d03e602e47cdbbf49de71137c9546/pip-26.1.tar.gz", hash = "sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3", size = 1840316, upload-time = "2026-04-26T21:00:05.406Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl", hash = "sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1", size = 1812804, upload-time = "2026-04-26T21:00:03.194Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add a stacked area chart to team-velocity report showing per-developer PR contributions over time. Uses existing 12-month default — no CLI or wizard changes.

## Changes

- **`metrics/team_velocity_calculator.py`**: Add `dev_month_counts` field to `TeamVelocityDataset`, helpers `_latest_active_devs` and `_dev_month_counts` to compute per-month per-dev PR counts
- **`metrics/printer/team_velocity.py`**: Build `dev_data` from `dataset.dev_month_counts` (raw logins, no nicknames) and pass to template
- **`metrics/printer/templates/team_velocity.html`**: Add stacked area chart card with auto-generated hue colours

## Review notes

- Data pruned to devs active in latest non-empty month — no churned dev zeros
- Colours via golden-angle hue (`i * 137 % 360`)
- No CLI/runner/wizard changes — default 12-month behaviour preserved
- No nickname resolution — logins displayed as-is